### PR TITLE
Include autocorrelation of trace in Matplotlib.plot

### DIFF
--- a/pymc/Matplot.py
+++ b/pymc/Matplot.py
@@ -385,11 +385,11 @@ def plot(data, name, format='png', suffix='', path='./', common_scale=True, data
             figure(figsize=(10, 6))
 
         # Call trace
-        trace(data, name, datarange=datarange, rows=rows*2, columns=2, num=num, last=last, fontmap=fontmap)
+        trace(data, name, datarange=datarange, rows=rows*2, columns=2, num=num+3*(num-1), last=last, fontmap=fontmap)
         # Call autocorrelation
-        autocorrelation(data, name, rows=rows*2, columns=2, num=num+2*rows, last=last, fontmap=fontmap)
+        autocorrelation(data, name, rows=rows*2, columns=2, num=num+3*(num-1)+2, last=last, fontmap=fontmap)
         # Call histogram
-        histogram(data, name, datarange=datarange, rows=rows, columns=2, num=num+1, last=last, fontmap=fontmap)
+        histogram(data, name, datarange=datarange, rows=rows, columns=2, num=num*2, last=last, fontmap=fontmap)
 
         if last:
             if not os.path.exists(path):
@@ -415,7 +415,7 @@ def plot(data, name, format='png', suffix='', path='./', common_scale=True, data
             # New plot or adding to existing?
             _new = not i % _rows
             # Current subplot number
-            _num = i % _rows * 2 + 1
+            _num = i % _rows + 1
             # Final subplot of current figure?
             _last = not (_num + 1) % (_rows * 2) or (i==len(tdata)-1)
 
@@ -497,10 +497,10 @@ def trace(data, name, format='png', datarange=(None, None), suffix='', path='./'
 
     # Smaller tick labels
     tlabels = gca().get_xticklabels()
-    setp(tlabels, 'fontsize', fontmap[rows])
+    setp(tlabels, 'fontsize', fontmap[rows/2])
 
     tlabels = gca().get_yticklabels()
-    setp(tlabels, 'fontsize', fontmap[rows])
+    setp(tlabels, 'fontsize', fontmap[rows/2])
 
     if standalone:
         if not os.path.exists(path):
@@ -688,10 +688,10 @@ def autocorrelation(data, name, maxlags=100, format='png', suffix='-acf', path='
 
         # Smaller tick labels
         tlabels = gca().get_xticklabels()
-        setp(tlabels, 'fontsize', fontmap[rows])
+        setp(tlabels, 'fontsize', fontmap[rows/2])
 
         tlabels = gca().get_yticklabels()
-        setp(tlabels, 'fontsize', fontmap[rows])
+        setp(tlabels, 'fontsize', fontmap[rows/2])
     elif ndim(data) == 2:
         # generate acorr plot for each dimension
         rows = data.shape[1]

--- a/pymc/examples/pump.py
+++ b/pymc/examples/pump.py
@@ -1,0 +1,36 @@
+# Hierarchical Poisson failure rates example from Clark and Gelfand (2006), pp.23
+# ma macneil; 13.03.09
+# Import relevant modules
+import pdb
+from numpy import ones
+from pymc import deterministic, stochastic, observed, Gamma, Exponential, poisson_like, MCMC, AdaptiveMetropolis, Matplot
+
+#------------------------------------------------------------------ DATA
+# Number of failures for pump system i
+Yi = [5,1,5,14,3,19,1,1,4,22]
+# Time over which failure measurements were made for pump system i
+ti = [94.320, 15.720, 62.880, 125.760, 5.240, 31.440, 1.048, 1.048, 2.096, 10.480]
+# Observed failure rate of pump system i
+ri = [Yi[n]/ti[n] for n in range(len(Yi))]
+# Number of observations
+k=len(Yi)
+
+#------------------------------------------------------------------ PRIORS
+# alpha is the estimated gamma shape parameter to describe the distribution of thetas
+alpha0=Exponential('alpha0', 1.0, value=1.)
+# beta is the estimated gamma scale parameter to describe the distribution of thetas
+beta0=Gamma('beta0', alpha=0.1, beta=1.0, value=1.)
+# Theta values (point esitimates of the failure rate) per pump
+theta = Gamma('theta', alpha=alpha0, beta=beta0, value=ones(k))
+# overall Lambda = alpha0/beta0*tot_lambda = alpha0/beta0
+# overall mtbf = beta0/alpha0*tot__mtbf = beta0/alpha0*
+
+#------------------------------------------------------------------ MODEL
+# Relate thetas to time
+@deterministic(trace=True)
+def L(theta=theta):
+    return theta*ti
+# Estimated value for shape of Poisson distribution given number of failures observed
+@observed(dtype=int)
+def y(value=Yi, lambduh=L):
+    return poisson_like(value, lambduh) 


### PR DESCRIPTION
This commit makes the Matplotlib.plot function include an autocorrelation plot as well as the trace of the MCMC draws

This is often a more informative indicator of MCMC convergence.

This is my first pull request, so please let me know if you would like me to use a different mechanism for this contribution.
