### PR TITLE
Adding support for GPUArray.

### DIFF
--- a/pymc/PyMCObjects.py
+++ b/pymc/PyMCObjects.py
@@ -17,6 +17,18 @@ import calc_utils
 
 import datatypes
 
+try:
+    from pycuda.gpuarray import GPUArray as pycuda_array
+    import_pycuda = True
+except:
+    import_pycuda = False
+
+try:
+    from pyopencl.array import Array as pyopencl_array
+    import_pyopencl = True
+except:
+    import_pyopencl = False
+
 d_neg_inf = float(-1.7976931348623157e+308)
 
 # from PyrexLazyFunction import LazyFunction
@@ -667,7 +679,11 @@ class Stochastic(StochasticBase):
 
         # Initialize value, either from value provided or from random function.
         try:
-            if dtype.kind != 'O' and value is not None:
+            if (import_pycuda and type(value) is pycuda_array) or \
+               (import_pyopencl and type(value) is pyopencl_array):
+                # Special case for GPUArrays as they can't be passed to asanyarray.
+                self._value = value
+            elif dtype.kind != 'O' and value is not None:
                 self._value = asanyarray(value, dtype=dtype)
                 self._value.flags['W']=False
             else:


### PR DESCRIPTION
Added support for pycuda or pyopencl arrays to be passed as value to Stochastic nodes.

Background:
I experimented some more with carrying out some of the computations on the GPU and I think I found a way that is very efficient. In essence, the parts that can be sped up easily are multiple likelihood evaluations (e.g. pm.Normal(np.random.rand(5000),...)). My first approach was to create a likelihood function that would copy the data onto the device and then make the computations each time the likelihood gets evaluated, but because memory transfer is the bottleneck this does not result in increases in speed. However, if the data is uploaded to the gfx card during model creation (e.g. pm.GPUNormal(GPUArray(np.random.rand(5000)...)) no more transfers have to be made for each evaluation and you get huge speed improvements. GPUArray is provided by pycuda and pyopencl. I think this is really the way to go as all my other experiments were very cumbersome and slow while this one nicely fits in with the PyMC style of model creation.

Issue:
Passing of a GPUArray to a stochastic node doesn't work because of this line only:
if (dtype.kind != 'O' and value is not None):
    self._value = asanyarray(value, dtype=dtype)

as numpy.asanyarray breaks if you pass a GPUArray. My (ugly) solution is to check if the input argument is a gpuarray and then just assign the gpuarray to self._value. This works (also in cases where no pycuda or pyopencl is present) but is not very elegant. However, I can't think of another solution that wouldn't require a bigger rewrite.
