### PR TITLE
bug: flib returns wrong likelihood for exponential distribution

### DIFF
--- a/pymc/flib.f
+++ b/pymc/flib.f
@@ -2623,7 +2623,7 @@ cf2py threadsafe
         if (x(i).EQ.0.0) then
 
             if (alpha_tmp.EQ.1.0) then
-                like = like + beta_tmp
+                like = like + dlog(beta_tmp)
             else if (alpha_tmp.LT.1.0) then
                 like = infinity
                 RETURN


### PR DESCRIPTION
if i construct an exponential distribution, say with beta=5

<pre>
x = pymc.Exponential('x', 5)
</pre>


and then evaluate the log likelihood around x=0, a completely wrong answer is spat out at x=0:

<pre>
In [3]: x.set_value(0.01)

In [4]: x.logp
Out[4]: 1.5594379124341002

In [5]: x.set_value(0.0001)

In [6]: x.logp
Out[6]: 1.6089379124341003

In [7]: x.set_value(1e-15)

In [8]: x.logp
Out[8]: 1.6094379124340952

In [9]: x.set_value(0)

In [10]: x.logp
Out[10]: 5.0
</pre>


the wrong answer spat out is beta:

<pre>
In [11]: y = pymc.Exponential('y', 345)

In [12]: y.set_value(0.0)

In [13]: y.logp
Out[13]: 345.0
</pre>


this appears to be coming from flib

<pre>
In [22]: flib.gamma(0.0, 1, 345)
Out[22]: 345.0
</pre>


i think i've found the dodgy line in flib.f -- when alpha is 1 (i.e. for an exponential) and x is 0, the log-likelihood was being incremented by beta, not by log(beta).
