### PR TITLE
Changed Stochastic.get_logp to return -inf instead of raising exception if logp is NaN

### DIFF
--- a/pymc/PyMCObjects.py
+++ b/pymc/PyMCObjects.py
@@ -821,7 +821,7 @@ class Stochastic(StochasticBase):
             raise TypeError, self.__name__ + ': computed log-probability ' + str(logp) + ' cannot be cast to float'
 
         if logp != logp:
-            raise ValueError, self.__name__ + ': computed log-probability is NaN'
+            return -np.inf
 
         if self.verbose > 0:
             print '\t' + self.__name__ + ': Returning log-probability ', logp


### PR DESCRIPTION
I get this often and I think this is a result of float underflow in flib code.
