### PR TITLE
FloatingPointError raised upon defining a TruncatedNormal

### DIFF
--- a/pymc/distributions.py
+++ b/pymc/distributions.py
@@ -2483,7 +2483,11 @@ def truncated_normal_like(x, mu, tau, a=None, b=None):
         n = len(x)
         phi = normal_like(x, mu, tau)
         # It would be nice to replace these with log-error function calls.
-        lPhia = np.log(pymc.utils.normcdf((a-mu)/sigma))
+        Phia = pymc.utils.normcdf((a-mu)/sigma)
+        if Phia > 0:
+        	lPhia = np.log(Phia)
+        else:
+        	lPhia = -np.inf
         lPhib = np.log(pymc.utils.normcdf((b-mu)/sigma))
         try:
             d = utils.log_difference(lPhib, lPhia)


### PR DESCRIPTION
When a TruncatedNormal object is created with a lower limit which is far below the mean, a FloatingPointError exception is triggered. I believe this is unexpected behaviour:

``` Python
>>> pymc.TruncatedNormal("x", mu=10.0, tau=0.1**-2, a=0, b=10.0)
Traceback:
  File "/home/geert/phd/python/lib/python2.7/site-packages/pymc/distributions.py", line 2497, in truncated_normal_like
    lPhia = np.log(pymc.utils.normcdf((a-mu)/sigma))
FloatingPointError: divide by zero encountered in log
```

The attached commit is a hack which resolves the issue for me, though be aware that I am not familiar with the PyMC source yet. (PS: I love PyMC, thanks!)
