### PR TITLE
Fixed "Metropolis has no proposal_sd" bug

### DIFF
--- a/pymc/StepMethods.py
+++ b/pymc/StepMethods.py
@@ -351,6 +351,8 @@ class Metropolis(StepMethod):
         StepMethod.__init__(self, [stochastic], tally=tally)
 
         # Initialize hidden attributes
+	self.proposal_sd=proposal_sd
+
         self.adaptive_scale_factor = 1.
         self.accepted = 0.
         self.rejected = 0.
@@ -367,9 +369,7 @@ class Metropolis(StepMethod):
 
         if proposal_distribution != "Prior":
             # Avoid zeros when setting proposal variance
-            if proposal_sd is not None:
-                self.proposal_sd = proposal_sd
-            else:
+            if self.proposal_sd is None:
                 if all(self.stochastic.value != 0.):
                     self.proposal_sd = ones(shape(self.stochastic.value)) * abs(self.stochastic.value) * scale
                 else:
@@ -384,7 +384,8 @@ class Metropolis(StepMethod):
             else:
                 self._len = 1
 
-        # If no dist argument is provided, assign a proposal distribution automatically.
+        #else: self.proposal_sd = None # Probably unnecessary
+	# If no dist argument is provided, assign a proposal distribution automatically.
         if not proposal_distribution:
 
             # Pick Gaussian by default


### PR DESCRIPTION
In case when proposal_distribution is 'Prior', proposal_sd is never set, leading to the following error:

Warning, unable to save state.
Error message:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/pymc/Model.py", line 599, in save_state
    self.db.savestate(self.get_state())
  File "/usr/local/lib/python2.7/dist-packages/pymc/MCMC.py", line 344, in get_state
    state['step_methods'][sm._id] = sm.current_state().copy()
  File "/usr/local/lib/python2.7/dist-packages/pymc/StepMethods.py", line 293, in current_state
    state[s] = getattr(self, s)
AttributeError: 'Metropolis' object has no attribute 'proposal_sd'
