### PR TITLE
FIX: Transform pymc distributions to value before calling scipy.distribution.rv_continuous functions.

### DIFF
--- a/CREDITS.rst
+++ b/CREDITS.rst
@@ -8,7 +8,7 @@ Development team
 * Christopher Fonnesbeck
 * David Huard
 * Anand Patil
-
+* John Salvatier
 
 Contributors
 ============

--- a/pymc/MCMC.py
+++ b/pymc/MCMC.py
@@ -170,7 +170,7 @@ class MCMC(Sampler):
     
     def sample(self, iter, burn=0, thin=1, tune_interval=1000, tune_throughout=True, save_interval=None, verbose=0, progress_bar=True):
         """
-        sample(iter, burn, thin, tune_interval, tune_throughout, save_interval, verbose)
+        sample(iter, burn, thin, tune_interval, tune_throughout, save_interval, verbose, progress_bar)
         
         Initialize traces, run sampling loop, clean up afterward. Calls _loop.
         
@@ -189,6 +189,8 @@ class MCMC(Sampler):
           - save_interval : int or None
             If given, the model state will be saved at intervals of this many iterations
           - verbose : boolean
+          - progress_bar : boolean
+            Display progress bar while sampling.
         """
         
         self.assign_step_methods(verbose=verbose)

--- a/pymc/Model.py
+++ b/pymc/Model.py
@@ -203,6 +203,11 @@ class Sampler(Model):
         self._iter = None
 
         self._state = ['status', '_current_iter', '_iter']
+        
+        if hasattr(db, '_traces'):
+            # Put traces on objects
+            for v in self._variables_to_tally:
+                v.trace = self.db._traces[v.__name__]
 
     def _sum_deviance(self):
         # Sum deviance from all stochastics

--- a/pymc/ScipyDistributions.py
+++ b/pymc/ScipyDistributions.py
@@ -143,13 +143,29 @@ reporting the bug.
             new_class.__init__(self, *args, **kwds)
             self.args, self.kwds = separate_shape_args(self.parents, shape_args)
             self.frozen_rv = self.rv(self.args, self.kwds)
+            
+        def _pymc_dists_to_value(self, args):
+            """Replace arguments that are a pymc.Node with their value."""
+            # This is needed because the scipy rv function transforms
+            # every input argument which causes new pymc lambda
+            # functions to be generated. Thus, when calling this many
+            # many times, excessive amounts of RAM are used.
+            new_args = []
+            for arg in args:
+                if isinstance(arg, pm.Node):
+                    new_args.append(arg.value)
+                else:
+                    new_args.append(arg)
+
+            return new_args
+
 
         def _cdf(self):
             """
             The cumulative distribution function of self conditional on parents
             evaluated at self's current value
             """
-            return self.rv.cdf(self.value, *self.args, **self.kwds)
+            return self.rv.cdf(self.value, *self._pymc_dists_to_value(self.args), **self.kwds)
         cdf = property(_cdf, doc=_cdf.__doc__)
 
         def _sf(self):
@@ -157,7 +173,7 @@ reporting the bug.
             The survival function of self conditional on parents
             evaluated at self's current value
             """
-            return self.rv.sf(self.value, *self.args, **self.kwds)
+            return self.rv.sf(self.value, *self._pymc_dists_to_value(self.args), **self.kwds)
         sf = property(_sf, doc=_sf.__doc__)
 
         def ppf(self, q):
@@ -165,7 +181,7 @@ reporting the bug.
             The percentile point function (inverse cdf) of self conditional on parents.
             Self's value will be set to the return value.
             """
-            self.value = self.rv.ppf(q, *self.args, **self.kwds)
+            self.value = self.rv.ppf(q, *self._pymc_dists_to_value(self.args), **self.kwds)
             return self.value
 
         def isf(self, q):
@@ -173,16 +189,16 @@ reporting the bug.
             The inverse survival function of self conditional on parents.
             Self's value will be set to the return value.
             """
-            self.value = self.rv.isf(q, *self.args, **self.kwds)
+            self.value = self.rv.isf(q, *self._pymc_dists_to_value(self.args), **self.kwds)
             return self.value
 
         def stats(self, moments='mv'):
             """The first few moments of self's distribution conditional on parents"""
-            return self.rv.stats(moments=moments, *self.args, **self.kwds)
+            return self.rv.stats(moments=moments, *self._pymc_dists_to_value(self.args), **self.kwds)
 
         def _entropy(self):
             """The entropy of self's distribution conditional on its parents"""
-            return self.rv.entropy(*self.args, **self.kwds)
+            return self.rv.entropy(*self._pymc_dists_to_value(self.args), **self.kwds)
         entropy = property(_entropy, doc=_entropy.__doc__)
 
     newer_class.__name__ = new_class.__name__

--- a/pymc/distributions.py
+++ b/pymc/distributions.py
@@ -1343,7 +1343,7 @@ def half_cauchy_like(x, alpha, beta):
 
     x = np.atleast_1d(x)
     if sum(x<0): return -inf
-    return flib.cauchy(x,alpha,beta) + len(x)*log(2)
+    return flib.cauchy(x,alpha,beta) + len(x)*np.log(2)
 
 # Half-normal----------------------------------------------
 @randomwrap


### PR DESCRIPTION
Function calls made through scipy.distribution.rv_continuous wrappers sanitize the input arguments by transformation before calling the user-defined function. This causes PyMC lambda functions to be generated each time the function is called leading to excessive memory consumption (which doesn't get collected) when called repeatedly.

Not sure if this also has to be done for self.kwds.
