### PR TITLE
FIX: half_cauchy_like is now working

### DIFF
--- a/pymc/distributions.py
+++ b/pymc/distributions.py
@@ -1343,7 +1343,7 @@ def half_cauchy_like(x, alpha, beta):
 
     x = np.atleast_1d(x)
     if sum(x<0): return -inf
-    return flib.cauchy(x,alpha,beta) + len(x)*log(2)
+    return flib.cauchy(x,alpha,beta) + len(x)*np.log(2)
 
 # Half-normal----------------------------------------------
 @randomwrap


### PR DESCRIPTION
this was the error I got when using half_cauchy_like:

```
In [65]: pm.half_cauchy_like(1,1,1)
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
/Users/imrisofer/Documents/Projects/rapid/alz/<ipython-input-65-a3990327d407> in <module>()
----> 1 pm.half_cauchy_like(1,1,1)

/Users/imrisofer/Documents/third/pymc/pymc/distributions.pyc in half_cauchy_like(x, alpha, beta)
   1344     x = np.atleast_1d(x)
   1345     if sum(x<0): return -inf
-> 1346     return flib.cauchy(x,alpha,beta) + len(x)*log(2)
   1347 
   1348 # Half-normal----------------------------------------------


NameError: global name 'log' is not defined
```

I just replaced the log with np.log
