### PR TITLE
BIC and AIC should be calculated using the logp of the observed variables

### DIFF
--- a/pymc/NormalApproximation.py
+++ b/pymc/NormalApproximation.py
@@ -316,9 +316,10 @@ class MAP(Model):
         except:
             raise RuntimeError('Posterior probability optimization converged to value with zero probability.')
 
-        self.AIC = 2. * (self.len - self.logp_at_max) # 2k - 2 ln(L)
+        lnL = sum([x.logp for x in self.observed_stochastics]) # log-likelihood of observed stochastics
+        self.AIC = 2. * (self.len - lnL) # 2k - 2 ln(L)
         try:
-            self.BIC = self.len * log(self.data_len) - 2. * self.logp_at_max # k ln(n) - 2 ln(L)
+            self.BIC = self.len * log(self.data_len) - 2. * lnL # k ln(n) - 2 ln(L)
         except FloatingPointError:
             self.BIC = -Inf
 


### PR DESCRIPTION
according to the definitions of BIC and AIC, they should be calculated using the log-likelihood of the data.
As I understand the log-likelihood of the data does not equal to the logp of the whole model, but to the logp of the observed variables. I have applied this changes to MAP.fit

before the change:

```
L = self.lopg
```

now: 

```
L =  sum([x.logp for x in self.observed_stochastics])
```
