### PR TITLE
BUG: MCMC.sample with burn_till_tuned was broken

### DIFF
--- a/pymc/MCMC.py
+++ b/pymc/MCMC.py
@@ -219,6 +219,7 @@ class MCMC(Sampler):
 
         self._n_tally = int(iter) - int(burn)
         if burn_till_tuned:
+            self._stop_tuning_after = stop_tuning_after
             tune_throughout = False
             if verbose > 0:
                 print "burn_til_tuned is True. tune_throughout is set to False"
@@ -272,6 +273,8 @@ class MCMC(Sampler):
                         new_burn = self._current_iter + int(self._stop_tuning_after * self._tune_interval)
                         self._burn =  max(new_burn, self._burn);
                         self._iter = self._burn + self._n_tally
+                        self.pbar = ProgressBar(self._iter)
+                        self.pbar.animate(i+1)
 
                 # Manage burn-in
                 if i == self._burn:


### PR DESCRIPTION
the last changes broke the burn_till_tuned option in MCMC.sample

```
/Users/imrisofer/Documents/third/pymc/pymc/MCMC.pyc in sample(self, iter, burn, thin, tune_interval, tune_throughout, save_interval, burn_till_tuned, stop_tuning_after, verbose, progress_bar)
    247 
    248         # Run sampler

--> 249         Sampler.sample(self, iter, length, verbose)
    250 
    251     def _loop(self):

/Users/imrisofer/Documents/third/pymc/pymc/Model.pyc in sample(self, iter, length, verbose)
    241         # Loop

    242         self._current_iter = 0
--> 243         self._loop()
    244         self._finalize()
    245 

/Users/imrisofer/Documents/third/pymc/pymc/MCMC.pyc in _loop(self)
    266                 # Tune at interval

    267                 if i and not (i % self._tune_interval) and self._tuning:
--> 268                     self.tune()
    269 
    270                     #update _burn and _iter if needed


/Users/imrisofer/Documents/third/pymc/pymc/MCMC.pyc in tune(self)
    353             # n consecutive clean intervals removed tuning

    354             # n is equal to self._stop_tuning_after

--> 355             if self._tuned_count ==  self._stop_tuning_after:
    356                 if self.verbose > 0: print_('\nFinished tuning')
    357                 self._tuning = False

AttributeError: 'MCMC' object has no attribute '_stop_tuning_after'
```

It was an easy fix.
the new code also re-initialize pbar each time the total number of iteration increases.
