### PR TITLE
Tweak CREATE TABLE statement and allow SQLITE errors to propagate up.

### DIFF
--- a/pymc/database/sqlite.py
+++ b/pymc/database/sqlite.py
@@ -64,14 +64,10 @@ class Trace(base.Trace):
         
         # Create the variable name strings.
         vstr = ', '.join(v + ' FLOAT' for v in var_str(self._shape))
-        
-        try:
-            query = "create table [%s] (recid INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, trace  int(5), %s )" % (self.name, vstr)
-        
-            self.db.cur.execute(query)
-        except OperationalError:
-            "Table already exists"
-            return
+        query = """CREATE TABLE IF NOT EXISTS [%s]
+                     (recid INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                      trace  int(5), %s)""" % (self.name, vstr)
+        self.db.cur.execute(query)
 
 
     


### PR DESCRIPTION
An 'IF NOT EXISTS' clause was added to the CREATE TABLE query so that
exceptions would not be raised if the table already exists.  Then,
the try/except statements were removed so that other database errors
would be propagated.
