### PR TITLE
Fixed typo in MCMC docstring

### DIFF
--- a/pymc/MCMC.py
+++ b/pymc/MCMC.py
@@ -207,7 +207,7 @@ class MCMC(Sampler):
             procedure.
             If burn_till_tuned is True it also overrides the tune_thorughout argument, so no step method
             will be tuned when sample are being tallied.
-          - stop_tuning_adfter: int
+          - stop_tuning_after: int
             the number of untuned successive tuning interval needed to be reach in order for
             the burn-in phase to be done (If burn_till_tuned is True).
         """


### PR DESCRIPTION
My first Github pull request, let me know if I did anything wrong. Thanks!
