### PR TITLE
Making pymc3 pep8 compatible.

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,3 +1,6 @@
+import matplotlib
+matplotlib.use('Agg')
+
 import traceback, sys
 from os import path
 from glob import glob


### PR DESCRIPTION
This PR makes only syntax changes to the existing code. It is the result of running

```
autopep8 -i -r *
```

from the root dir. I did revert the changes to README.rst and setup.py as they messed with the syntax.

I reviewed the changes and maybe some of them don't really add to the readability (personally, I think n*_2 is more readable than n *_ 2, some line-breaks are also not perfect and maybe some hand-tuning would ) but I'm putting this forward to start a discussion on what people's preferences are. I'm happy to change those specific issues if desired.

I realize that opinions differ widely on whether a coding standard should be enforced and how strongly. My personal take is not a religious one but I feel that some general guideline is helpful to have some consistency across the code-base, especially with contributions from different authors. As such, pep8 seems to be what most people can agree upon.
