### PR TITLE
Adds arch option to FFLAGS for OS X

### DIFF
--- a/buildosx
+++ b/buildosx
@@ -1,7 +1,7 @@
 #!/bin/sh
 export MACOSX_DEPLOYMENT_TARGET=10.8
 export CFLAGS="-arch x86_64"
-export FFLAGS="-static -ff2c"
+export FFLAGS="-static -ff2c -arch x86_64"
 export LDFLAGS="-Wall -undefined dynamic_lookup -bundle -arch x86_64"
 export PYTHONPATH="/Library/Python/2.7/site-packages/"
 export CC=gcc-4.2


### PR DESCRIPTION
While trying to build PyMC on OS X 10.8 (64-bit), I kept getting linking problems on import.  It appears that the fortran compiler also needs the `-arch x86_64` option to function correctly.
