### PR TITLE
specify abbreviations in docstrings

### DIFF
--- a/pymc/utils.py
+++ b/pymc/utils.py
@@ -547,6 +547,9 @@ def rec_setattr(obj, attr, value):
 def hpd(x, alpha):
     """Calculate HPD (minimum width BCI) of array for given alpha
 
+    HPD - Highest Probability Density
+    BCI - Bayesian Confidence Interval
+
     :Arguments:
       x : Numpy array
           An array containing MCMC samples


### PR DESCRIPTION
Hi, I tried to track down what "HPD" and "BCI" meant, as they were not specified in the docs anywhere I could see. So I added them. Please feel free to correct, but these are my best guesses.
