### PR TITLE
Added discrete variable support to Metropolis

### DIFF
--- a/examples/latent_occupancy.py
+++ b/examples/latent_occupancy.py
@@ -35,7 +35,7 @@ from pymc import *
 from numpy import random, array, arange, ones
 import theano.tensor as t
 # Sample size
-n = 100000
+n = 100
 # True mean count, given occupancy
 theta = 2.1
 # True occupancy
@@ -71,7 +71,7 @@ def pymc3_dlogp():
     _pymc3_dlogp(point)
 
 with model:
-    start = {'p':0.5, 'z':(y>0).astype(int), 'theta':50}
+    start = {'p':0.5, 'z':(y>0).astype(int), 'theta':5}
 
     step1 = Metropolis([theta, p])
 

--- a/examples/latent_occupancy.py
+++ b/examples/latent_occupancy.py
@@ -3,15 +3,15 @@ From the PyMC example list
 latent_occupancy.py
 
 Simple model demonstrating the estimation of occupancy, using latent variables. Suppose
-a population of n sites, with some proportion pi being occupied. Each site is surveyed, 
+a population of n sites, with some proportion pi being occupied. Each site is surveyed,
 yielding an array of counts, y:
 
 y = [3, 0, 0, 2, 1, 0, 1, 0, ..., ]
 
 This is a classic zero-inflated count problem, where more zeros appear in the data than would
 be predicted by a simple Poisson model. We have, in fact, a mixture of models; one, conditional
-on occupancy, with a poisson mean of theta, and another, conditional on absence, with mean zero. 
-One way to tackle the problem is to model the latent state of 'occupancy' as a Bernoulli variable 
+on occupancy, with a poisson mean of theta, and another, conditional on absence, with mean zero.
+One way to tackle the problem is to model the latent state of 'occupancy' as a Bernoulli variable
 at each site, with some unknown probability:
 
 z_i ~ Bern(pi)
@@ -32,7 +32,7 @@ Copyright (c) 2008 University of Otago. All rights reserved.
 
 # Import statements
 from pymc import *
-from numpy import random, array, arange, ones 
+from numpy import random, array, arange, ones
 import theano.tensor as t
 # Sample size
 n = 100000
@@ -51,7 +51,7 @@ with model:
     p = Beta('p', 1,1)
 
     # Latent variable for occupancy
-    z = Bernoulli('z',p , y.shape)
+    z = Bernoulli('z', p, y.shape)
 
     # Estimated mean count
     theta = Uniform('theta', 0, 100)
@@ -64,8 +64,17 @@ point = model.test_point
 
 _pymc3_logp = model.logpc
 def pymc3_logp():
-    _pymc3_logp(point) 
+    _pymc3_logp(point)
 
 _pymc3_dlogp = model.dlogpc()
 def pymc3_dlogp():
-    _pymc3_dlogp(point) 
+    _pymc3_dlogp(point)
+
+with model:
+    start = {'p':0.5, 'z':(y>0).astype(int), 'theta':50}
+
+    step1 = Metropolis([theta, p])
+
+    step2 = BinaryMetropolis([z])
+
+    trace = sample(5000, [step1, step2], start)

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -66,9 +66,9 @@ class Metropolis(ArrayStep):
         self.accepted = 0
 
         # Determine type of variables
-        if all([v.dtype=='int64' for v in vars]):
+        if all([v.dtype in discrete_types for v in vars]):
             self.discrete = True
-        elif all([v.dtype=='float64' for v in vars]):
+        elif all([v.dtype in continuous_types for v in vars]):
             self.discrete = False
         else:
             raise ValueError('All variables in vars must be of the same dtype for Metropolis')
@@ -150,14 +150,13 @@ class BinaryMetropolis(ArrayStep):
         self.steps_until_tune = tune_interval
         self.accepted = 0
 
-        if not all([v.dtype.startswith('int') for v in vars]):
+        if not all([v.dtype in discrete_types for v in vars]):
             raise ValueError('All variables must be Bernoulli for BinaryMetropolis')
 
         super(BinaryMetropolis,self).__init__(vars, [model.logpc])
 
     def astep(self, q0, logp):
-        """docstring for astep"""
-        # import pdb; pdb.set_trace()
+
         # Convert adaptive_scale_factor to a jump probability
         p_jump = 1.-.5**self.scaling
 
@@ -170,8 +169,3 @@ class BinaryMetropolis(ArrayStep):
         q_new = metrop_select(logp(q) - logp(q0), q, q0)
 
         return q_new
-
-def subst(a, val, index):
-    ap = a.copy()
-    ap[index]=val
-    return ap


### PR DESCRIPTION
`Metropolis` now supports discrete as well as continuous variables. Added a `BinaryMetropolis` for use with Bernoulli random variables. Updated `latent_occupancy` example to use `BinaryMetropolis`.
