### PR TITLE
Add rest of disaster_model to file

### DIFF
--- a/pymc/examples/disaster_model.py
+++ b/pymc/examples/disaster_model.py
@@ -50,3 +50,5 @@ with Model() as model:
     step1 = Slice([early_mean, late_mean])
     # Use Metropolis for switchpoint, since it accomodates discrete variables
     step2 = Metropolis([switchpoint])
+
+    trace = sample(10000, [step1, step2], start)


### PR DESCRIPTION
The rest of this example seemed to be missing. This change fixes that.
