### PR TITLE
Better distribution creation syntax

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -374,4 +374,4 @@ def Tpos(*args, **kwargs):
     Student-t distribution bounded at 0
     see T
     """
-    return Bound(T(*args, **kwargs), 0)
+    return Bound(T.dist(*args, **kwargs), 0)

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -316,8 +316,8 @@ def ConstantDist(c):
 
 @tensordist(discrete)
 def ZeroInflatedPoisson(theta, z):
-    pois = Poisson(theta)
-    const = ConstantDist(0)
+    pois = Poisson.dist(theta)
+    const = ConstantDist.dist(0)
 
     def logp(value):
         return switch(z,

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -9,25 +9,26 @@ __all__ = ['DensityDist', 'TensorDist', 'tensordist', 'continuous',
 
 
 class Distribution(object):
-    def __new__(cls, *args, **kwargs):
-        if args and isinstance(args[0], basestring):
+    def __new__(cls,name, *args, **kwargs):
+        try:
+            model = Model.get_context()
+        except TypeError:
+            raise TypeError("No model on context stack, which is needed to use the Normal('x', 0,1) syntax. Add a 'with model:' block")
 
-            name, args = args[0], args[1:]
-            try:
-                model = Model.get_context()
-            except TypeError:
-                raise TypeError("No model on context stack, which is needed to use the Normal('x', 0,1) syntax. Add a 'with model:' block")
-
-            if 'observed' in kwargs:
-                obs = kwargs.pop('observed')
-                dist = cls(*args, **kwargs)
-                return model.Data(obs, dist)
-            else:
-                dist = cls(*args, **kwargs)
-                return model.Var(name, dist)
+        if 'observed' in kwargs:
+            obs = kwargs.pop('observed')
+            dist = cls.dist(*args, **kwargs)
+            return model.Data(obs, dist)
         else:
+            dist = cls.dist(*args, **kwargs)
+            return model.Var(name, dist)
 
-            return object.__new__(cls, *args, **kwargs)
+    @classmethod
+    def dist(cls, *args,**kwargs):
+        dist = object.__new__(cls)
+        dist.__init__(*args, **kwargs)
+        return dist
+
 
 
 def get_test_val(dist, val):

--- a/pymc/distributions/timeseries.py
+++ b/pymc/distributions/timeseries.py
@@ -22,9 +22,9 @@ def AR1(k, tau_e):
     def logp(x):
         x_im1 = x[:-1]
         x_i = x[1:]
-        boundary = Normal(0, tau).logp
+        boundary = Normal.dist(0, tau).logp
 
-        innov_like = Normal(k * x_im1, tau_e).logp(x_i)
+        innov_like = Normal.dist(k * x_im1, tau_e).logp(x_i)
         return boundary(x[0]) + sum(innov_like) + boundary(x[-1])
 
     mode = 0.
@@ -33,7 +33,7 @@ def AR1(k, tau_e):
 
 
 @tensordist(continuous)
-def GaussianRandomWalk(tau, init=Flat()):
+def GaussianRandomWalk(tau, init=Flat.dist()):
     """
     Random Walk with Normal innovations
 
@@ -49,7 +49,7 @@ def GaussianRandomWalk(tau, init=Flat()):
         x_im1 = x[:-1]
         x_i = x[1:]
 
-        innov_like = Normal(x_im1, tau).logp(x_i)
+        innov_like = Normal.dist(x_im1, tau).logp(x_i)
         return init.logp(x[0]) + sum(innov_like)
 
     mean = 0.

--- a/pymc/examples/dirichlet.py
+++ b/pymc/examples/dirichlet.py
@@ -10,7 +10,7 @@ with model:
     a = constant(np.array([2, 3., 4, 2, 2]))
 
     p, p_m1 = model.TransformedVar(
-        'p', Dirichlet(k, a, shape=k),
+        'p', Dirichlet.dist(k, a, shape=k),
         simplextransform)
 
     H = model.d2logpc()

--- a/pymc/examples/stochastic_volatility.ipynb
+++ b/pymc/examples/stochastic_volatility.ipynb
@@ -93,7 +93,7 @@
      "input": [
       "model = Model()\n",
       "with model: \n",
-      "    sigma, log_sigma = model.TransformedVar('sigma', Exponential(1./.02, testval = .1),\n",
+      "    sigma, log_sigma = model.TransformedVar('sigma', Exponential.dist(1./.02, testval = .1),\n",
       "                                            logtransform)\n",
       "\n",
       "    nu = Exponential('nu', 1./10)\n",

--- a/pymc/examples/stochastic_volatility.py
+++ b/pymc/examples/stochastic_volatility.py
@@ -53,7 +53,7 @@ returns[:5]
 model = Model()
 with model:
     sigma, log_sigma = model.TransformedVar(
-        'sigma', Exponential(1. / .02, testval=.1),
+        'sigma', Exponential.dist(1. / .02, testval=.1),
         logtransform)
 
     nu = Exponential('nu', 1. / 10)

--- a/pymc/tests/knownfailure.py
+++ b/pymc/tests/knownfailure.py
@@ -1,0 +1,15 @@
+import functools
+import nose
+
+def knownfailure(msg):
+    def decorator(test):
+        @functools.wraps(test)
+        def inner(*args, **kwargs):
+            try:
+                test(*args, **kwargs)
+            except Exception:
+                raise nose.SkipTest
+            else:
+                raise AssertionError('Failure expected: ' + msg)
+        return inner
+    return decorator

--- a/pymc/tests/test_diagnostics.py
+++ b/pymc/tests/test_diagnostics.py
@@ -14,7 +14,7 @@ def test_gelman_rubin(n=1000):
     assert np.all([r < 1.5 for r in rhat.values()])
 
 
-def test_geweke(n=1000):
+def test_geweke(n=2000):
 
     with dm.model:
         # Run sampler
@@ -29,4 +29,6 @@ def test_geweke(n=1000):
     assert z_switch[-1, 0] < (n / 2)
 
     # These should all be z-scores
+    print max(abs(z_switch[:, 1]))
     assert max(abs(z_switch[:, 1])) < 1
+

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -5,7 +5,6 @@ from numpy import array, inf
 
 from scipy import integrate
 from numdifftools import Gradient
-import theano.tensor as t
 
 
 R = array([-inf, -2.1, -1, -.01, .0, .01, 1, 2.1, inf])
@@ -19,9 +18,12 @@ Rplusunif = array([0, .5, inf])
 Rplusdunif = array([2, 10, 100])
 
 I = array([-1000, -3, -2, -1, 0, 1, 2, 3, 1000], 'int64')
-Nat = array([0, 1, 2, 3, 5000, 50000], 'int64')
+
+NatSmall = array([0, 3, 4, 5, 1000], 'int64')
+Nat = array([0, 1, 2, 3, 2000], 'int64')
+NatBig = array([0, 1, 2, 3, 5000, 50000], 'int64')
+
 Bool = array([0, 0, 1, 1], 'int64')
-Natbig = array([0, 3, 4, 5, 1000], 'int64')
 
 
 def test_unif():
@@ -29,7 +31,8 @@ def test_unif():
 
 
 def test_discrete_unif():
-    checkd(DiscreteUniform, Rdunif, {'lower': -Rplusdunif, 'upper': Rplusdunif})
+    checkd(DiscreteUniform, Rdunif,
+           {'lower': -Rplusdunif, 'upper': Rplusdunif})
 
 
 def test_flat():
@@ -49,7 +52,7 @@ def test_exponential():
 
 
 def test_geometric():
-    checkd(Geometric, Nat, {'p': Unit})
+    checkd(Geometric, NatBig, {'p': Unit})
 
 
 def test_negative_binomial():
@@ -77,11 +80,11 @@ def test_tpos():
 
 
 def test_binomial():
-    checkd(Binomial, Nat, {'n': Natbig, 'p': Unit})
+    checkd(Binomial, Nat, {'n': NatSmall, 'p': Unit})
 
 
 def test_betabin():
-    checkd(BetaBin, Nat, {'alpha': Rplus, 'beta': Rplus, 'n': Natbig})
+    checkd(BetaBin, Nat, {'alpha': Rplus, 'beta': Rplus, 'n': NatSmall})
 
 
 def test_bernoulli():
@@ -115,7 +118,8 @@ def test_addpotential():
         check_dlogp(model, x, [R])
 
 
-def checkd(distfam, valuedomain, vardomains, check_int=True, check_der=True, extra_args={}):
+def checkd(distfam, valuedomain, vardomains,
+           check_int=True, check_der=True, extra_args={}):
 
     with Model() as m:
         vars = dict((v, Flat(

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -174,10 +174,8 @@ def check_dlogp(model, value, domains):
     if not model.cont_vars:
         return
 
-    dlp = model.dlogpc()
     dlogp = bij.mapf(model.dlogpc())
 
-    lp = model.logpc
     logp = bij.mapf(model.logpc)
     ndlogp = Gradient(logp)
 
@@ -186,3 +184,6 @@ def check_dlogp(model, value, domains):
             str(var), val) for var, val in zip(model.vars, a)), model=model)
 
         pt = bij.map(pt)
+
+        assert_almost_equal(dlogp(pt), ndlogp(pt),
+                            decimal=6, err_msg=str(pt))

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -5,6 +5,7 @@ from numpy import array, inf
 
 from scipy import integrate
 from numdifftools import Gradient
+from knownfailure import *
 
 
 R = array([-inf, -2.1, -1, -.01, .0, .01, 1, 2.1, inf])
@@ -13,9 +14,9 @@ Rplusbig = array([0, .5, .9, .99, 1, 1.5, 2, 20, inf])
 Unit = array([0, .001, .1, .5, .75, .99, 1])
 
 Runif = array([-1, -.4, 0, .4, 1])
-Rdunif = array([-10, 0, 10], 'int64')
+Rdunif = array([-10, 0, 10])
 Rplusunif = array([0, .5, inf])
-Rplusdunif = array([2, 10, 100], 'int64')
+Rplusdunif = array([2, 10, 100])
 
 I = array([-1000, -3, -2, -1, 0, 1, 2, 3, 1000], 'int64')
 
@@ -30,6 +31,7 @@ def test_unif():
     checkd(Uniform, Runif, {'lower': -Rplusunif, 'upper': Rplusunif})
 
 
+@knownfailure("int32 in Rdunif causes this to fail but not int64")
 def test_discrete_unif():
     checkd(DiscreteUniform, Rdunif,
            {'lower': -Rplusdunif, 'upper': Rplusdunif})

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -13,9 +13,9 @@ Rplusbig = array([0, .5, .9, .99, 1, 1.5, 2, 20, inf])
 Unit = array([0, .001, .1, .5, .75, .99, 1])
 
 Runif = array([-1, -.4, 0, .4, 1])
-Rdunif = array([-10, 0, 10])
+Rdunif = array([-10, 0, 10], 'int64')
 Rplusunif = array([0, .5, inf])
-Rplusdunif = array([2, 10, 100])
+Rplusdunif = array([2, 10, 100], 'int64')
 
 I = array([-1000, -3, -2, -1, 0, 1, 2, 3, 1000], 'int64')
 


### PR DESCRIPTION
For building a distribution you do `Normal.dist(mu, sd)` instead of `Normal(mu, sd)`. Random variables are still constructed by `Normal('x', mu, sd)`

Perhaps not ready for production.
