### PR TITLE
Added burn arguments to all plotting/support functions

### DIFF
--- a/pymc/diagnostics.py
+++ b/pymc/diagnostics.py
@@ -87,7 +87,7 @@ def geweke(x, first=.1, last=.5, intervals=20):
         return np.array(zscores)
 
 
-def gelman_rubin(mtrace):
+def gelman_rubin(mtrace, burn=0):
     """ Returns estimate of R for a set of traces.
 
     The Gelman-Rubin diagnostic tests for lack of convergence by comparing
@@ -102,6 +102,8 @@ def gelman_rubin(mtrace):
     mtrace : MultiTrace
       A MultiTrace object containing parallel traces (minimum 2)
       of one or more stochastic parameters.
+    burn : int
+      Burn-in interval (defaults to zero)
 
     Returns
     -------
@@ -132,13 +134,13 @@ def gelman_rubin(mtrace):
             'Gelman-Rubin diagnostic requires multiple chains of the same length.')
 
     varnames = mtrace.traces[0].varnames
-    n = len(mtrace.traces[0][varnames[0]])
+    n = len(mtrace.traces[0][varnames[0]]) - burn
 
     Rhat = {}
     for var in varnames:
 
         # Get all traces for var
-        x = np.array([mtrace.traces[i][var] for i in range(m)])
+        x = np.array([mtrace.traces[i][var][burn:] for i in range(m)])
 
         # Calculate between-chain variance
         B_over_n = np.sum((np.mean(x, 1) - np.mean(x)) ** 2) / (m - 1)

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -7,7 +7,7 @@ from theano.gof.graph import inputs
 import numpy as np
 from functools import wraps
 
-__all__ = ['Model', 'compilef', 'gradient', 'hessian', 'modelcontext', 'Point']
+__all__ = ['Model', 'compilef', 'gradient', 'hessian', 'modelcontext', 'Point', 'named']
 
 
 class Context(object):

--- a/pymc/plots.py
+++ b/pymc/plots.py
@@ -9,7 +9,7 @@ from .stats import *
 
 __all__ = ['traceplot', 'kdeplot', 'kde2plot', 'forestplot', 'autocorrplot']
 
-def traceplot(trace, vars=None):
+def traceplot(trace, vars=None, burn=0):
     if vars is None:
         vars = trace.samples.keys()
 
@@ -17,7 +17,7 @@ def traceplot(trace, vars=None):
     f, ax = subplots(n, 2, squeeze=False)
 
     for i, v in enumerate(vars):
-        d = np.squeeze(trace[v])
+        d = np.squeeze(trace[v][burn:])
 
         if trace[v].dtype.kind == 'i':
             ax[i, 0].hist(d, bins=sqrt(d.size))
@@ -72,7 +72,7 @@ def kde2plot(x, y, grid=200):
     kde2plot_op(ax, x, y, grid)
     return f
 
-def autocorrplot(trace, vars=None, fontmap = None, max_lag=100):
+def autocorrplot(trace, vars=None, burn=0, fontmap = None, max_lag=100):
     """Bar plot of the autocorrelation function for a trace"""
 
     try:
@@ -90,7 +90,7 @@ def autocorrplot(trace, vars=None, fontmap = None, max_lag=100):
         vars = traces[0].varnames
 
     # Extract sample data
-    samples = [{v:trace[v] for v in vars} for trace in traces]
+    samples = [{v:trace[v][burn:] for v in vars} for trace in traces]
 
     chains = len(traces)
 
@@ -142,7 +142,7 @@ def var_str(name, shape):
     return names
 
 
-def forestplot(trace_obj, vars=None, alpha=0.05, quartiles=True, rhat=True,
+def forestplot(trace_obj, vars=None, burn=0, alpha=0.05, quartiles=True, rhat=True,
                main=None, xtitle=None, xrange=None, ylabels=None, chain_spacing=0.05, vline=0):
     """ Forest plot (model summary plot)
 
@@ -221,7 +221,7 @@ def forestplot(trace_obj, vars=None, alpha=0.05, quartiles=True, rhat=True,
 
             from .diagnostics import gelman_rubin
 
-            R = gelman_rubin(trace_obj)
+            R = gelman_rubin(trace_obj, burn)
             if vars is not None:
                 R = {v: R[v] for v in vars}
 
@@ -260,8 +260,8 @@ def forestplot(trace_obj, vars=None, alpha=0.05, quartiles=True, rhat=True,
     for j, trace in enumerate(traces):
 
         # Get quantiles
-        trace_quantiles = quantiles(trace, qlist)
-        hpd_intervals = hpd(trace, alpha)
+        trace_quantiles = quantiles(trace, qlist, burn=burn)
+        hpd_intervals = hpd(trace, alpha, burn=burn)
 
         # Counter for current variable
         var = 1

--- a/pymc/trace.py
+++ b/pymc/trace.py
@@ -35,7 +35,7 @@ class NpTrace(object):
         return dict((k, v.value[index]) for (k,v) in self.samples.iteritems())
 
 
-def summary(trace, vars=None, alpha=0.05, start=0, batches=100, roundto=3):
+def summary(trace, vars=None, alpha=0.05, burn=0, batches=100, roundto=3):
     """
     Generate a pretty-printed summary of the node.
 
@@ -51,7 +51,7 @@ def summary(trace, vars=None, alpha=0.05, start=0, batches=100, roundto=3):
       The alpha level for generating posterior intervals. Defaults to
       0.05.
 
-    start : int
+    burn : int
       The starting index from which to summarize (each) chain. Defaults
       to zero.
 
@@ -73,7 +73,7 @@ def summary(trace, vars=None, alpha=0.05, start=0, batches=100, roundto=3):
         print(' ')
 
         # Extract sampled values
-        sample = trace[var][start:]
+        sample = trace[var][burn:]
 
         shape = sample.shape
         if len(shape)>1:


### PR DESCRIPTION
In order to resolve #273, all support functions that deal with posterior summaries should accept a `burn` argument that truncates the trace before summarization. Argument `start` in `summary()` was switched to `burn` for consistency.
