### PR TITLE
Better distribution creation syntax

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -374,4 +374,4 @@ def Tpos(*args, **kwargs):
     Student-t distribution bounded at 0
     see T
     """
-    return Bound(T(*args, **kwargs), 0)
+    return Bound(T.dist(*args, **kwargs), 0)

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -316,8 +316,8 @@ def ConstantDist(c):
 
 @tensordist(discrete)
 def ZeroInflatedPoisson(theta, z):
-    pois = Poisson(theta)
-    const = ConstantDist(0)
+    pois = Poisson.dist(theta)
+    const = ConstantDist.dist(0)
 
     def logp(value):
         return switch(z,

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -9,25 +9,26 @@ __all__ = ['DensityDist', 'TensorDist', 'tensordist', 'continuous',
 
 
 class Distribution(object):
-    def __new__(cls, *args, **kwargs):
-        if args and isinstance(args[0], basestring):
+    def __new__(cls,name, *args, **kwargs):
+        try:
+            model = Model.get_context()
+        except TypeError:
+            raise TypeError("No model on context stack, which is needed to use the Normal('x', 0,1) syntax. Add a 'with model:' block")
 
-            name, args = args[0], args[1:]
-            try:
-                model = Model.get_context()
-            except TypeError:
-                raise TypeError("No model on context stack, which is needed to use the Normal('x', 0,1) syntax. Add a 'with model:' block")
-
-            if 'observed' in kwargs:
-                obs = kwargs.pop('observed')
-                dist = cls(*args, **kwargs)
-                return model.Data(obs, dist)
-            else:
-                dist = cls(*args, **kwargs)
-                return model.Var(name, dist)
+        if 'observed' in kwargs:
+            obs = kwargs.pop('observed')
+            dist = cls.dist(*args, **kwargs)
+            return model.Data(obs, dist)
         else:
+            dist = cls.dist(*args, **kwargs)
+            return model.Var(name, dist)
 
-            return object.__new__(cls, *args, **kwargs)
+    @classmethod
+    def dist(cls, *args,**kwargs):
+        dist = object.__new__(cls)
+        dist.__init__(*args, **kwargs)
+        return dist
+
 
 
 def get_test_val(dist, val):

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -5,7 +5,7 @@ from ..model import *
 import warnings
 
 __all__ = ['DensityDist', 'TensorDist', 'tensordist', 'continuous',
-           'discrete', 'arbitrary']
+           'discrete', 'arbitrary', 'evaluate']
 
 
 class Distribution(object):
@@ -44,6 +44,10 @@ def get_test_val(dist, val):
         return val.tag.test_value
     else:
         return val
+
+
+# Convenience function for evaluating distributions at test point
+evaluate = lambda dist: dist.tag.test_value
 
 
 class TensorDist(Distribution):

--- a/pymc/distributions/timeseries.py
+++ b/pymc/distributions/timeseries.py
@@ -22,9 +22,9 @@ def AR1(k, tau_e):
     def logp(x):
         x_im1 = x[:-1]
         x_i = x[1:]
-        boundary = Normal(0, tau).logp
+        boundary = Normal.dist(0, tau).logp
 
-        innov_like = Normal(k * x_im1, tau_e).logp(x_i)
+        innov_like = Normal.dist(k * x_im1, tau_e).logp(x_i)
         return boundary(x[0]) + sum(innov_like) + boundary(x[-1])
 
     mode = 0.
@@ -33,7 +33,7 @@ def AR1(k, tau_e):
 
 
 @tensordist(continuous)
-def GaussianRandomWalk(tau, init=Flat()):
+def GaussianRandomWalk(tau, init=Flat.dist()):
     """
     Random Walk with Normal innovations
 
@@ -49,7 +49,7 @@ def GaussianRandomWalk(tau, init=Flat()):
         x_im1 = x[:-1]
         x_i = x[1:]
 
-        innov_like = Normal(x_im1, tau).logp(x_i)
+        innov_like = Normal.dist(x_im1, tau).logp(x_i)
         return init.logp(x[0]) + sum(innov_like)
 
     mean = 0.

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -31,7 +31,7 @@ def transform(name, forward, backward, jacobian_det, getshape=None):
 
             return locals()
 
-        return TransformedDistribtuion()
+        return TransformedDistribtuion.dist()
 
     def __str__():
         return name + " transform"

--- a/pymc/examples/dirichlet.py
+++ b/pymc/examples/dirichlet.py
@@ -8,7 +8,7 @@ with model:
     a = constant(np.array([2, 3., 4, 2, 2]))
 
     p, p_m1 = model.TransformedVar(
-        'p', Dirichlet(k, a, shape=k),
+        'p', Dirichlet.dist(k, a, shape=k),
         simplextransform)
 
     H = model.d2logpc()

--- a/pymc/examples/stochastic_volatility.ipynb
+++ b/pymc/examples/stochastic_volatility.ipynb
@@ -93,7 +93,7 @@
      "input": [
       "model = Model()\n",
       "with model: \n",
-      "    sigma, log_sigma = model.TransformedVar('sigma', Exponential(1./.02, testval = .1),\n",
+      "    sigma, log_sigma = model.TransformedVar('sigma', Exponential.dist(1./.02, testval = .1),\n",
       "                                            logtransform)\n",
       "\n",
       "    nu = Exponential('nu', 1./10)\n",

--- a/pymc/examples/stochastic_volatility.py
+++ b/pymc/examples/stochastic_volatility.py
@@ -53,7 +53,7 @@ returns[:5]
 model = Model()
 with model:
     sigma, log_sigma = model.TransformedVar(
-        'sigma', Exponential(1. / .02, testval=.1),
+        'sigma', Exponential.dist(1. / .02, testval=.1),
         logtransform)
 
     nu = Exponential('nu', 1. / 10)


### PR DESCRIPTION
For building a distribution you do `Normal.dist(mu, sd)` instead of `Normal(mu, sd)`. Random variables are still constructed by `Normal('x', mu, sd)`
