### PR TITLE
Put model running calls in __main__ block for examples

### DIFF
--- a/pymc/examples/ARM12-6.py
+++ b/pymc/examples/ARM12-6.py
@@ -46,17 +46,20 @@ with model:
     lr = Normal(
         'lr', floor * floor_m + means[group], sd ** -2., observed=lradon)
 
-    start = {'groupmean': obs_means.mean(),
-             'groupsd': obs_means.std(),
-             'sd': data.groupby('group').lradon.std().mean(),
-             'means': np.array(obs_means),
-             'floor_m': 0.,
-             }
+if __name__ == '__main__':
 
-    start = find_MAP(start, [groupmean, sd, floor_m])
-    H = model.d2logpc()
-    h = np.diag(H(start))
+    with model:
+        start = {'groupmean': obs_means.mean(),
+                 'groupsd': obs_means.std(),
+                 'sd': data.groupby('group').lradon.std().mean(),
+                 'means': np.array(obs_means),
+                 'floor_m': 0.,
+                 }
 
-    step = HamiltonianMC(model.vars, h)
+        start = find_MAP(start, [groupmean, sd, floor_m])
+        H = model.d2logpc()
+        h = np.diag(H(start))
 
-    trace = sample(3000, step, start)
+        step = HamiltonianMC(model.vars, h)
+
+        trace = sample(3000, step, start)

--- a/pymc/examples/ARM12-6uranium.py
+++ b/pymc/examples/ARM12-6uranium.py
@@ -48,18 +48,23 @@ with model:
     lr = Normal('lr', floor * floor_m + means[group] + ufull * u_m, sd ** -
                 2., observed=lradon)
 
-    start = {'groupmean': obs_means.mean(),
-             'groupsd': obs_means.std(),
-             'sd': data.groupby('group').lradon.std().mean(),
-             'means': np.array(obs_means),
-             'u_m': np.array([.72]),
-             'floor_m': 0.,
-             }
 
-    start = find_MAP(start, model.vars[:-1])
-    H = model.d2logpc()
-    h = np.diag(H(start))
+if __name__ == '__main__':
 
-    step = HamiltonianMC(model.vars, h)
+    with model:
 
-    trace = sample(3000, step, start)
+        start = {'groupmean': obs_means.mean(),
+                 'groupsd': obs_means.std(),
+                 'sd': data.groupby('group').lradon.std().mean(),
+                 'means': np.array(obs_means),
+                 'u_m': np.array([.72]),
+                 'floor_m': 0.,
+                 }
+
+        start = find_MAP(start, model.vars[:-1])
+        H = model.d2logpc()
+        h = np.diag(H(start))
+
+        step = HamiltonianMC(model.vars, h)
+
+        trace = sample(3000, step, start)

--- a/pymc/examples/ARM5-4.py
+++ b/pymc/examples/ARM5-4.py
@@ -39,4 +39,4 @@ if __name__ == '__main__':
 
         step = HamiltonianMC(model.vars, h)
 
-    trace = sample(3e3, step, start)
+        trace = sample(3e3, step, start)

--- a/pymc/examples/ARM5-4.py
+++ b/pymc/examples/ARM5-4.py
@@ -29,11 +29,14 @@ with Model() as model:
 
     s = Bernoulli('s', p, observed=np.array(data.switch))
 
-    # move the chain to the MAP which should be a good starting point
-    start = find_MAP()
-    H = model.d2logpc()  # find a good orientation using the hessian at the MAP
-    h = H(start)
+if __name__ == '__main__':
 
-    step = HamiltonianMC(model.vars, h)
+    with model:
+        # move the chain to the MAP which should be a good starting point
+        start = find_MAP()
+        H = model.d2logpc()  # find a good orientation using the hessian at the MAP
+        h = H(start)
+
+        step = HamiltonianMC(model.vars, h)
 
     trace = sample(3e3, step, start)

--- a/pymc/examples/arbitrary_stochastic.py
+++ b/pymc/examples/arbitrary_stochastic.py
@@ -11,7 +11,11 @@ with Model() as model:
 
     x = DensityDist('x', logp, observed=(failure, value))
 
-    start = model.test_point
-    h = find_hessian(start)
-    step = Metropolis(model.vars, h)
-    trace = sample(3000, step, start)
+if __name__ == "__main__":
+
+    with model:
+
+        start = model.test_point
+        h = find_hessian(start)
+        step = Metropolis(model.vars, h)
+        trace = sample(3000, step, start)

--- a/pymc/examples/dirichlet.py
+++ b/pymc/examples/dirichlet.py
@@ -11,9 +11,12 @@ with model:
         'p', Dirichlet.dist(k, a, shape=k),
         simplextransform)
 
-    H = model.d2logpc()
+if __name__ == '__main__':
 
-    s = find_MAP()
+    with model:
+        H = model.d2logpc()
 
-    step = HamiltonianMC(model.vars, H(s))
-    trace = sample(1000, step, s)
+        s = find_MAP()
+
+        step = HamiltonianMC(model.vars, H(s))
+        trace = sample(1000, step, s)

--- a/pymc/examples/disaster_model.py
+++ b/pymc/examples/disaster_model.py
@@ -43,10 +43,17 @@ with Model() as model:
     # Data likelihood
     disasters = Poisson('disasters', rate, observed=disasters_data)
 
-    # Initial values for stochastic nodes
-    start = {'early_mean': 2., 'late_mean': 3., 'switchpoint': 50}
 
-    # Use slice sampler for means
-    step1 = Slice([early_mean, late_mean])
-    # Use Metropolis for switchpoint, since it accomodates discrete variables
-    step2 = Metropolis([switchpoint])
+if __name__ == '__main__':
+
+    with model:
+
+        # Initial values for stochastic nodes
+        start = {'early_mean': 2., 'late_mean': 3., 'switchpoint': 50}
+
+        # Use slice sampler for means
+        step1 = Slice([early_mean, late_mean])
+        # Use Metropolis for switchpoint, since it accomodates discrete variables
+        step2 = Metropolis([switchpoint])
+
+        tr = sample(1000, start=start, step=[step1, step2])

--- a/pymc/examples/disaster_model.py
+++ b/pymc/examples/disaster_model.py
@@ -43,10 +43,17 @@ with Model() as model:
     # Data likelihood
     disasters = Poisson('disasters', rate, observed=disasters_data)
 
-    # Initial values for some stochastic nodes
-    start = {'early_mean': 2., 'late_mean': 3.}
 
-    # Use slice sampler for means
-    step1 = Slice([early_mean, late_mean])
-    # Use Metropolis for switchpoint, since it accomodates discrete variables
-    step2 = Metropolis([switchpoint])
+if __name__ == '__main__':
+
+    with model:
+
+        # Initial values for stochastic nodes
+        start = {'early_mean': 2., 'late_mean': 3.}
+
+        # Use slice sampler for means
+        step1 = Slice([early_mean, late_mean])
+        # Use Metropolis for switchpoint, since it accomodates discrete variables
+        step2 = Metropolis([switchpoint])
+
+        tr = sample(1000, start=start, step=[step1, step2])

--- a/pymc/examples/latent_occupancy.py
+++ b/pymc/examples/latent_occupancy.py
@@ -74,11 +74,13 @@ _pymc3_dlogp = model.dlogpc()
 def pymc3_dlogp():
     _pymc3_dlogp(point)
 
-with model:
-    start = {'p': 0.5, 'z': (y > 0).astype(int), 'theta': 5}
+if __name__ == '__main__':
 
-    step1 = Metropolis([theta, p])
+    with model:
+        start = {'p': 0.5, 'z': (y > 0).astype(int), 'theta': 5}
 
-    step2 = BinaryMetropolis([z])
+        step1 = Metropolis([theta, p])
 
-    trace = sample(5000, [step1, step2], start)
+        step2 = BinaryMetropolis([z])
+
+        trace = sample(5000, [step1, step2], start)

--- a/pymc/examples/logistic.py
+++ b/pymc/examples/logistic.py
@@ -31,11 +31,18 @@ with model:
 
     o = Bernoulli('o', p, observed=outcomes)
 
-    # move the chain to the MAP which should be a good starting point
-    start = find_MAP()
-    h = np.diag(approx_hess(
-        start))  # find a good orientation using the hessian at the MAP
+def run():
 
-    step = HamiltonianMC(model.vars, h)
+    with model:
+        # move the chain to the MAP which should be a good starting point
+        start = find_MAP()
+        h = np.diag(approx_hess(
+            start))  # find a good orientation using the hessian at the MAP
 
-    trace = sample(3e2, step, start)
+        step = HamiltonianMC(model.vars, h)
+
+        trace = sample(3e2, step, start)
+
+if __name__ == '__main__':
+
+    run()

--- a/pymc/examples/speedtest_pymc3.py
+++ b/pymc/examples/speedtest_pymc3.py
@@ -72,14 +72,3 @@ _pymc3_dlogp = model.dlogpc()
 
 def pymc3_dlogp():
     _pymc3_dlogp(point)
-
-if __name__ == '__main__':
-
-    with model:
-        start = {'p': 0.5, 'z': (y > 0).astype(int), 'theta': 5}
-
-        step1 = Metropolis([theta, p])
-
-        step2 = BinaryMetropolis([z])
-
-        trace = sample(5000, [step1, step2], start)

--- a/pymc/examples/speedtest_pymc3.py
+++ b/pymc/examples/speedtest_pymc3.py
@@ -72,3 +72,14 @@ _pymc3_dlogp = model.dlogpc()
 
 def pymc3_dlogp():
     _pymc3_dlogp(point)
+
+if __name__ == '__main__':
+
+    with model:
+        start = {'p': 0.5, 'z': (y > 0).astype(int), 'theta': 5}
+
+        step1 = Metropolis([theta, p])
+
+        step2 = BinaryMetropolis([z])
+
+        trace = sample(5000, [step1, step2], start)

--- a/pymc/sample.py
+++ b/pymc/sample.py
@@ -79,7 +79,8 @@ def argsample(args):
     return sample(*args)
 
 
-def psample(draws, step, start, trace=None, model=None, threads=None):
+def psample(draws, step, start, trace=None, model=None, threads=None,
+    random_seeds=None):
     """draw a number of samples using the given step method.
     Multiple step methods supported via compound step method
     returns the amount of time taken
@@ -124,8 +125,11 @@ def psample(draws, step, start, trace=None, model=None, threads=None):
 
     p = mp.Pool(threads)
 
+    if random_seeds is None:
+        random_seeds = [None] * threads
+
     argset = zip([draws] * threads, [step] * threads, start, mtrace.traces,
-                 [False] * threads, [model] * threads)
+                 [False] * threads, [model] * threads, random_seeds)
 
     traces = p.map(argsample, argset)
 

--- a/pymc/tests/test_diagnostics.py
+++ b/pymc/tests/test_diagnostics.py
@@ -2,7 +2,6 @@ from pymc import *
 
 from pymc.examples import disaster_model as dm
 
-
 def test_gelman_rubin(n=1000):
 
     with dm.model:
@@ -10,7 +9,8 @@ def test_gelman_rubin(n=1000):
         step1 = Slice([dm.early_mean, dm.late_mean])
         step2 = Metropolis([dm.switchpoint])
         start = {'early_mean': 2., 'late_mean': 3., 'switchpoint': 50}
-        ptrace = psample(n, [step1, step2], start, threads=2)
+        ptrace = psample(n, [step1, step2], start, threads=2,
+            random_seeds=[1,3])
 
     rhat = gelman_rubin(ptrace)
 
@@ -23,7 +23,8 @@ def test_geweke(n=3000):
         # Run sampler
         step1 = Slice([dm.early_mean, dm.late_mean])
         step2 = Metropolis([dm.switchpoint])
-        trace = sample(n, [step1, step2], progressbar=False)
+        trace = sample(n, [step1, step2], progressbar=False,
+            random_seed=1)
 
     z_switch = geweke(trace['switchpoint'], last=.5, intervals=20)
 

--- a/pymc/tests/test_diagnostics.py
+++ b/pymc/tests/test_diagnostics.py
@@ -7,7 +7,10 @@ def test_gelman_rubin(n=1000):
 
     with dm.model:
         # Run sampler
-        ptrace = psample(n, [dm.step1, dm.step2], dm.start, threads=2)
+        step1 = Slice([dm.early_mean, dm.late_mean])
+        step2 = Metropolis([dm.switchpoint])
+        start = {'early_mean': 2., 'late_mean': 3., 'switchpoint': 50}
+        ptrace = psample(n, [step1, step2], start, threads=2)
 
     rhat = gelman_rubin(ptrace)
 
@@ -18,7 +21,9 @@ def test_geweke(n=3000):
 
     with dm.model:
         # Run sampler
-        trace = sample(n, [dm.step1, dm.step2], dm.start, progressbar=False)
+        step1 = Slice([dm.early_mean, dm.late_mean])
+        step2 = Metropolis([dm.switchpoint])
+        trace = sample(n, [step1, step2], progressbar=False)
 
     z_switch = geweke(trace['switchpoint'], last=.5, intervals=20)
 

--- a/pymc/tests/test_plots.py
+++ b/pymc/tests/test_plots.py
@@ -1,24 +1,34 @@
 from ..plots import *
-from pymc import psample
+from pymc import psample, Slice, Metropolis, find_hessian, sample
 
 
 def test_plots():
 
     # Test single trace
-    from pymc.examples import arbitrary_stochastic
+    from pymc.examples import arbitrary_stochastic as asmod
 
-    forestplot(arbitrary_stochastic.trace)
+    with asmod.model as model:
 
-    autocorrplot(arbitrary_stochastic.trace)
+        start = model.test_point
+        h = find_hessian(start)
+        step = Metropolis(model.vars, h)
+        trace = sample(3000, step, start)
+
+        forestplot(trace)
+
+        autocorrplot(trace)
 
 
 def test_multichain_plots():
 
     from pymc.examples import disaster_model as dm
 
-    with dm.model:
+    with dm.model as model:
         # Run sampler
-        ptrace = psample(1000, [dm.step1, dm.step2], dm.start, threads=2)
+        step1 = Slice([dm.early_mean, dm.late_mean])
+        step2 = Metropolis([dm.switchpoint])
+        start = {'early_mean': 2., 'late_mean': 3., 'switchpoint': 50}
+        ptrace = psample(1000, [step1, step2], start, threads=2)
 
     forestplot(ptrace, vars=['early_mean', 'late_mean'])
 


### PR DESCRIPTION
To better separate the model specification from model execution, for several (most) examples I've placed the model running calls in a `if __name__=='__main__'` block. I've left the ones derived from iPython notebooks and very simple models alone.

I have also added a `random_seeds` argument to `psample`, as I was starting to get stochastic errors with the diagnostic tests.
