### PR TITLE
Implemented stoppable tuning

### DIFF
--- a/pymc/examples/disaster_model.py
+++ b/pymc/examples/disaster_model.py
@@ -56,4 +56,4 @@ if __name__ == '__main__':
         # Use Metropolis for switchpoint, since it accomodates discrete variables
         step2 = Metropolis([switchpoint])
 
-        tr = sample(1000, start=start, step=[step1, step2])
+        tr = sample(1000, tune=500, start=start, step=[step1, step2])

--- a/pymc/sample.py
+++ b/pymc/sample.py
@@ -94,7 +94,7 @@ def argsample(args):
     return sample(*args)
 
 
-def psample(draws, step, start, trace=None, model=None, threads=None,
+def psample(draws, step, start, trace=None, tune=None, model=None, threads=None,
     random_seeds=None):
     """draw a number of samples using the given step method.
     Multiple step methods supported via compound step method
@@ -144,7 +144,8 @@ def psample(draws, step, start, trace=None, model=None, threads=None,
         random_seeds = [None] * threads
 
     argset = zip([draws] * threads, [step] * threads, start, mtrace.traces,
-                 [False] * threads, [model] * threads, random_seeds)
+                 [tune] * threads, [False] * threads, [model] * threads,
+                 random_seeds)
 
     traces = p.map(argsample, argset)
 


### PR DESCRIPTION
Not sure how this slipped past, but until now step methods that tune kept tuning throughout sampling, with no opportunity for stopping. I've implemented a pretty simple way of doing so by having a `tuning` flag in the step method, and then a `tuning` argument in sample that takes an integer value for the number of steps to tune.
