### PR TITLE
Added stochastic_from_data for non-parametric distributions

### DIFF
--- a/pymc/distributions.py
+++ b/pymc/distributions.py
@@ -351,7 +351,7 @@ def stochastic_from_dist(name, logp, random=None, logp_partial_gradients={}, dty
 
 
 def stochastic_from_data(name, data, lower=-np.inf, upper=np.inf,
-                         value=None, observed=False, size=1, trace=True, verbose=-1, debug=False):
+                         value=None, observed=False, trace=True, verbose=-1, debug=False):
     """
     Return a Stochastic subclass made from arbitrary data.
 
@@ -366,11 +366,10 @@ def stochastic_from_data(name, data, lower=-np.inf, upper=np.inf,
        >>> from pymc import stochastic_from_data
        >>> pos = stochastic_from_data('posterior', posterior_samples)
        >>> prior = pos # update the prior with arbitrary distributions
-    """
-    if size != 1:
-        # TODO: requires a newer version of SciPy, mine is 0.10.1
-        raise NotImplementedError('Not implemented yet. Sorry.')
 
+    :Alias:
+      Histogram
+    """
     pdf = gaussian_kde(data) # automatic bandwidth selection
 
     # account for tail contribution
@@ -406,6 +405,10 @@ def stochastic_from_data(name, data, lower=-np.inf, upper=np.inf,
                       dtype    = float,
                       observed = observed,
                       verbose  = verbose)
+
+
+# Alias following Stochastics naming convention
+Histogram = stochastic_from_data
 
 #-------------------------------------------------------------
 # Light decorators


### PR DESCRIPTION
It's sometimes very useful to represent nonparametric distributions in Bayesian inference, specially when we try to update our prior knowledge using multimodal posteriors. Following is an example to solving an inverse problem with PyMC that requires nonparametric distributions fitted with arbitrary histograms. The solution is either 2 or -2 as represented by the posterior.

``` python
from pymc import *
import matplotlib.pyplot as plt

xtrue = 2 # unknown in the real application
prior = rnormal(0,1,10000) # initial guess is inaccurate
for i in range(5):
  x = stochastic_from_data('x', prior)
  y = x*x
  obs = Normal('obs', y, 0.1, xtrue*xtrue + rnormal(0,1), observed=True)

  model = Model([x,y,obs])
  mcmc = MCMC(model)
  mcmc.sample(10000)

  Matplot.plot(mcmc.trace('x'))
  plt.show()

  prior = mcmc.trace('x')[:]
```

This code uses [Kernel Density Estimation](http://en.wikipedia.org/wiki/Kernel_density_estimation) for fitting the histogram following a discussion on [Stackoverflow](http://stackoverflow.com/questions/17409324/solving-inverse-problems-with-pymc). I plan to add the multidimensional case after I update my SciPy installation.
