### PR TITLE
Correction of a print statement to comply with Python3

### DIFF
--- a/pymc/Matplot.py
+++ b/pymc/Matplot.py
@@ -1165,7 +1165,7 @@ def summary_plot(
             for variable in vars:
                 R[variable.__name__] = gelman_rubin(variable)
         except ValueError:
-            print 'Could not calculate Gelman-Rubin statistics. Requires multiple chains of equal length.'
+            print('Could not calculate Gelman-Rubin statistics. Requires multiple chains of equal length.')
             rhat = False
 
     # Empty list for y-axis labels


### PR DESCRIPTION
Just a small correction so that pymc can be imported from python3.
