### PR TITLE
Accessing Random variables and named deterministics by name through Model objects

### DIFF
--- a/pymc/examples/gelman_bioassay.py
+++ b/pymc/examples/gelman_bioassay.py
@@ -17,7 +17,7 @@ with Model() as model:
     beta = Normal('beta', 0, 0.01)
 
     # Calculate probabilities of death
-    theta = named('theta', tinvlogit(alpha + beta * dose))
+    theta = Deterministic('theta', tinvlogit(alpha + beta * dose))
 
     # Data likelihood
     deaths = Binomial('deaths', n=n, p=theta, observed=[0, 1, 3, 5])

--- a/pymc/examples/gelman_bioassay.py
+++ b/pymc/examples/gelman_bioassay.py
@@ -1,0 +1,30 @@
+from pymc import *
+from numpy import ones, array
+import theano.tensor as t
+
+# Samples for each dose level
+n = 5 * ones(4, dtype=int)
+# Log-dose
+dose = array([-.86, -.3, -.05, .73])
+
+def tinvlogit(x):
+    return t.exp(x) / (1 + t.exp(x))
+
+with Model() as model:
+
+    # Logit-linear model parameters
+    alpha = Normal('alpha', 0, 0.01)
+    beta = Normal('beta', 0, 0.01)
+
+    # Calculate probabilities of death
+    theta = named('theta', tinvlogit(alpha + beta * dose))
+
+    # Data likelihood
+    deaths = Binomial('deaths', n=n, p=theta, observed=[0, 1, 3, 5])
+
+    start = model.test_point
+    h = approx_hess(start)
+
+    step = NUTS(model.vars, h)
+
+    trace = sample(1000, step, start, trace=model.named_vars)

--- a/pymc/examples/tutorial.py
+++ b/pymc/examples/tutorial.py
@@ -178,7 +178,3 @@ traceplot(trace)
 # * With a name argument, it constructs a random variable using the distrubtion object as the prior distribution and inserts this random variable into the current model. Then the constructor returns the random variable.
 
 # <codecell>
-
-help(model)
-
-# <codecell>

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -180,14 +180,14 @@ def compilef(outs, mode=None):
     )
 
 
-def named(var, name, model=None):
+def named(name, var, model=None):
     """
     Name a theano variables
 
     Parameters
     ----------
-        var : theano variables
         name : str
+        var : theano variables
     Returns
     -------
         n : var but with name name

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -116,7 +116,7 @@ class Model(Context):
     def TransformedVar(model, name, dist, trans):
         tvar = model.Var(trans.name + '_' + name, trans.apply(dist))
 
-        return named(name, trans.backward(tvar)), tvar
+        return Deterministic(name, trans.backward(tvar)), tvar
 
     def AddPotential(model, potential):
         model.factors.append(potential)
@@ -180,9 +180,9 @@ def compilef(outs, mode=None):
     )
 
 
-def named(name, var, model=None):
+def Deterministic(name, var, model=None):
     """
-    Name a theano variables
+    Create a named deterministic variable
 
     Parameters
     ----------

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -9,7 +9,7 @@ from theanof import *
 
 from memoize import memoize
 
-__all__ = ['Model', 'compilef', 'modelcontext', 'Point']
+__all__ = ['Model', 'compilef', 'modelcontext', 'Point', 'named']
 
 
 class Context(object):
@@ -50,6 +50,7 @@ class Model(Context):
     def __init__(self):
         self.vars = []
         self.factors = []
+        self.named_vars = {}
 
     @property
     @memoize
@@ -86,7 +87,8 @@ class Model(Context):
     @property
     def test_point(self):
         """Test point used to check that the model doesn't generate errors"""
-        return Point(((var, var.tag.test_value) for var in self.vars), model=self)
+        return Point(((var, var.tag.test_value) for var in self.vars),
+                     model=self)
 
     @property
     def cont_vars(model):
@@ -97,7 +99,7 @@ class Model(Context):
     these functions add random variables
     """
     def Data(model, data, dist):
-        if  hasattr(data, 'values'):
+        if hasattr(data, 'values'):
             # Incase obs is a Series or DataFrame
             data = data.values
         args = map(t.constant, as_iterargs(data))
@@ -105,6 +107,7 @@ class Model(Context):
 
     def Var(model, name, dist):
         var = dist.makevar(name)
+        model.AddNamed(var)
 
         model.vars.append(var)
         model.factors.append(dist.logp(var))
@@ -118,8 +121,17 @@ class Model(Context):
     def AddPotential(model, potential):
         model.factors.append(potential)
 
+    def AddNamed(model, var):
+        model.named_vars[var.name] = var
+        if not hasattr(model, var.name):
+            setattr(model, var.name, var)
+
+    def __getitem__(self, key):
+        return self.named_vars[key]
+
 
 def Point(*args, **kwargs):
+
     """
     Build a point. Uses same args as dict() does.
     Filters out variables not in the model. All keys are strings.
@@ -129,11 +141,9 @@ def Point(*args, **kwargs):
         *args, **kwargs
             arguments to build a dict
     """
-    if 'model' in kwargs:
-        model = kwargs['model']
-        del kwargs['model']
-    else:
-        model = Model.get_context()
+    model = modelcontext(kwargs.get('model'))
+    kwargs.pop('model', None)
+
     try:
         d = dict(*args, **kwargs)
     except Exception as e:
@@ -146,10 +156,12 @@ def Point(*args, **kwargs):
                 for (k, v) in d.iteritems()
                 if str(k) in varnames)
 
+
 @memoize
 def compilef(outs, mode=None):
     """
-    Compiles a Theano function which returns `outs` and takes the variable ancestors of `outs` as inputs.
+    Compiles a Theano function which returns `outs` and takes the variable
+    ancestors of `outs` as inputs.
 
     Parameters
     ----------
@@ -168,6 +180,21 @@ def compilef(outs, mode=None):
     )
 
 
+def named(var, name, model=None):
+    """
+    Name a theano variables
+
+    Parameters
+    ----------
+        var : theano variables
+        name : str
+    Returns
+    -------
+        n : var but with name name
+    """
+    var.name = name
+    modelcontext(model).AddNamed(var)
+    return var
 
 
 def as_iterargs(data):
@@ -177,9 +204,6 @@ def as_iterargs(data):
         return [np.asarray(data[c]) for c in data.columns]
     else:
         return [data]
-
-
-
 
 # theano stuff
 theano.config.warn.sum_div_dimshuffle_bug = False

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -116,7 +116,7 @@ class Model(Context):
     def TransformedVar(model, name, dist, trans):
         tvar = model.Var(trans.name + '_' + name, trans.apply(dist))
 
-        return named(trans.backward(tvar), name), tvar
+        return named(name, trans.backward(tvar)), tvar
 
     def AddPotential(model, potential):
         model.factors.append(potential)

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -9,7 +9,7 @@ from theanof import *
 
 from memoize import memoize
 
-__all__ = ['Model', 'compilef', 'modelcontext', 'Point', 'named']
+__all__ = ['Model', 'compilef', 'modelcontext', 'Point', 'Deterministic']
 
 
 class Context(object):

--- a/pymc/sample.py
+++ b/pymc/sample.py
@@ -58,8 +58,11 @@ def sample(draws, step, start=None, trace=None, tune=None, progressbar=True, mod
 
         if not isinstance(trace, NpTrace):
             if trace is None:
-                trace = model.vars
-            trace = NpTrace(list(trace))
+                trace = model.named_vars
+            try:
+                trace = NpTrace(trace.values())
+            except AttributeError:
+                trace = NpTrace(list(trace))
 
     try:
         step = step_methods.CompoundStep(step)
@@ -139,12 +142,15 @@ def psample(draws, step, start=None, trace=None, tune=None, model=None, threads=
         start = threads * [start]
 
     if trace is None:
-        trace = model.vars
+        trace = model.named_vars
 
     if type(trace) is MultiTrace:
         mtrace = trace
     else:
-        mtrace = MultiTrace(threads, trace)
+        try:
+            mtrace = MultiTrace(threads, trace.values())
+        except AttributeError:
+            mtrace = MultiTrace(threads, trace)
 
     p = mp.Pool(threads)
 

--- a/pymc/tests/test_model_func.py
+++ b/pymc/tests/test_model_func.py
@@ -25,3 +25,12 @@ def test_dlogp2():
     d2logp = model.d2logpc()
 
     close_to(d2logp(start), H, np.abs(H / 100.))
+
+
+def test_named():
+    with pm.Model() as model:
+        x = Normal('x', 0,1)
+        y = pm.named(x**2, 'y')
+
+    assert model.y == y
+    assert model['y'] == y

--- a/pymc/tests/test_model_func.py
+++ b/pymc/tests/test_model_func.py
@@ -27,10 +27,10 @@ def test_dlogp2():
     close_to(d2logp(start), H, np.abs(H / 100.))
 
 
-def test_named():
+def test_deterministic():
     with pm.Model() as model:
         x = Normal('x', 0,1)
-        y = pm.named('y', x**2)
+        y = pm.Deterministic('y', x**2)
 
     assert model.y == y
     assert model['y'] == y

--- a/pymc/tests/test_model_func.py
+++ b/pymc/tests/test_model_func.py
@@ -30,7 +30,7 @@ def test_dlogp2():
 def test_named():
     with pm.Model() as model:
         x = Normal('x', 0,1)
-        y = pm.named(x**2, 'y')
+        y = pm.named('y', x**2)
 
     assert model.y == y
     assert model['y'] == y

--- a/pymc/theanof.py
+++ b/pymc/theanof.py
@@ -3,7 +3,7 @@ from theano import theano, tensor as t
 from theano.gof.graph import inputs
 from memoize import memoize
 
-__all__ = ['gradient', 'hessian', 'hessian_diag', 'inputvars', 'cont_inputs', 'named']
+__all__ = ['gradient', 'hessian', 'hessian_diag', 'inputvars', 'cont_inputs']
 
 def inputvars(a):
     """
@@ -33,20 +33,6 @@ def cont_inputs(f):
     """
     return typefilter(inputvars(f), continuous_types)
 
-def named(var, name):
-    """
-    Name a theano variables
-
-    Parameters
-    ----------
-        var : theano variables
-        name : str
-    Returns
-    -------
-        n : var but with name name
-    """
-    var.name = name
-    return var
 
 
 """


### PR DESCRIPTION
Random variables and named deterministics (named with the `named(var, name)` function) are now can be accessed by `model.variable_name or model['variable_name']`. 
