### PR TITLE
Remove duplicated NoStepper class

### DIFF
--- a/pymc/StepMethods.py
+++ b/pymc/StepMethods.py
@@ -785,20 +785,6 @@ class DrawFromPrior(StepMethod):
         return 0
 
 
-class NoStepper(StepMethod):
-
-    """
-    Step and tune methods do nothing.
-
-    Useful for holding stochastics constant without setting observed=True.
-    """
-    def step(self, *args, **kwargs):
-        pass
-
-    def tune(self, *args, **kwargs):
-        return False
-
-
 class DiscreteMetropolis(Metropolis):
 
     """


### PR DESCRIPTION
There's also two duplicated functions in [distributions.py](https://github.com/pymc-devs/pymc/blob/master/pymc/distributions.py).
`noncentral_t_expval` and `noncentral_t_like` I think might be the result of unfinished copy & paste and must be renamed and adapted [here](https://github.com/pymc-devs/pymc/blob/master/pymc/distributions.py#L2504) and [here](https://github.com/pymc-devs/pymc/blob/master/pymc/distributions.py#L2513)?
