### PR TITLE
Fixed slicing in MultiTrace

### DIFF
--- a/pymc/tests/test_trace.py
+++ b/pymc/tests/test_trace.py
@@ -102,3 +102,27 @@ def test_slice():
     assert np.all([burned_again[v].shape==(iterations-2*burn, start[v].size) for v in burned_again.varnames])
     assert np.all([burned[v].shape==(iterations-burn, start[v].size) for v in burned.varnames])
 
+def test_multi_slice():
+
+    model, start, step, moments = simple_init()
+
+    iterations = 100
+    burn = 10
+
+    with model:
+        tr = psample(iterations, start=start, step=step, threads=2)
+
+    burned = tr[burn:]
+
+    # Slicing returns a MultiTrace
+    assert type(burned) is pm.trace.MultiTrace
+
+    # Indexing returns a list of arrays
+    assert type(tr[tr.varnames[0]]) is list
+    assert type(tr[tr.varnames[0]][0]) is np.ndarray
+
+    # # Burned trace is of the correct length
+    assert np.all([burned[v][0].shape==(iterations-burn, start[v].size) for v in burned.varnames])
+
+    # Original trace did not change
+    assert np.all([tr[v][0].shape==(iterations, start[v].size) for v in tr.varnames])

--- a/pymc/trace.py
+++ b/pymc/trace.py
@@ -183,8 +183,13 @@ class MultiTrace(object):
                 raise ValueError("vars can't be None if trace count specified")
             self.traces = [NpTrace(vars) for _ in xrange(traces)]
 
-    def __getitem__(self, key):
-        return [h[key] for h in self.traces]
+    def __getitem__(self, index_value):
+
+        item_list = [h[index_value] for h in self.traces]
+
+        if isinstance(index_value, slice):
+            return MultiTrace(item_list)
+        return item_list
 
     @property
     def varnames(self):


### PR DESCRIPTION
Slicing/indexing in MultiTrace now works analogously to that for NpTrace.
