### PR TITLE
BinaryMetropolis always skipping to Metropolis

### DIFF
--- a/pymc/StepMethods.py
+++ b/pymc/StepMethods.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 import numpy as np
 from .utils import msqrt, check_type, round_array, float_dtypes, integer_dtypes, bool_dtypes, safe_len, find_generations, logp_of_set, symmetrize, logp_gradient_of_set
-from numpy import ones, zeros, log, shape, cov, ndarray, inner, reshape, sqrt, any, array, all, abs, exp, where, isscalar, iterable, multiply, transpose, tri, pi
+from numpy import rank, ones, zeros, log, shape, cov, ndarray, inner, reshape, sqrt, any, array, all, abs, exp, where, isscalar, iterable, multiply, transpose, tri, pi
 from numpy.linalg.linalg import LinAlgError
 from numpy.linalg import pinv, cholesky
 from numpy.random import randint, random
@@ -897,7 +897,7 @@ class BinaryMetropolis(Metropolis):
             return 0
 
     def step(self):
-        if not isscalar(self.stochastic.value):
+        if rank(self.stochastic.value):
             Metropolis.step(self)
         else:
 


### PR DESCRIPTION
BinaryMetropolis.step() redirects to Metropolis.step() if isscalar(self.stochastic.value) returns False.

However numpy.isscalar() also returns False for ndarrays of rank 0. Since stochastics like Bernoulli or Categorical automatically convert their value to an ndarray, the BinaryMetropolis step algorithm is never used.

I use numpy.rank() instead.
