### PR TITLE
traceplot support for overplotting lines

### DIFF
--- a/pymc/plots.py
+++ b/pymc/plots.py
@@ -12,7 +12,7 @@ from .trace import *
 
 __all__ = ['traceplot', 'kdeplot', 'kde2plot', 'forestplot', 'autocorrplot']
 
-def traceplot(trace, vars=None, figsize=None, values=None):
+def traceplot(trace, vars=None, figsize=None, lines=None):
     """Plot samples histograms and values
 
     Parameters
@@ -23,8 +23,8 @@ def traceplot(trace, vars=None, figsize=None, values=None):
         variables to be plotted, if None all variable are plotted
     figsize : figure size tuple
         if None, size is (12, num of variables * 2) inch
-    values : dict
-        dictionary of values to be overplotted as vertical lines
+    lines : dict
+        dictionary of variable name / value  to be overplotted as vertical lines
         to the posteriors and horizontal lines on sample values
         e.g. mean of posteriors, true values of a simulation
 
@@ -63,10 +63,10 @@ def traceplot(trace, vars=None, figsize=None, values=None):
         ax[i, 0].set_ylabel("Frequency")
         ax[i, 1].set_ylabel("Sample value")
 
-        if values:
+        if lines:
             try:
-                ax[i, 0].axvline(x=values[v], color="r", lw=1.5)
-                ax[i, 1].axhline(y=values[v], color="r", lw=1.5, alpha=.35)
+                ax[i, 0].axvline(x=lines[v], color="r", lw=1.5)
+                ax[i, 1].axhline(y=lines[v], color="r", lw=1.5, alpha=.35)
             except exceptions.KeyError:
                 pass
 

--- a/pymc/plots.py
+++ b/pymc/plots.py
@@ -1,4 +1,5 @@
 from pylab import *
+import exceptions
 import matplotlib.pyplot as plt
 try:
     import matplotlib.gridspec as gridspec
@@ -11,7 +12,7 @@ from .trace import *
 
 __all__ = ['traceplot', 'kdeplot', 'kde2plot', 'forestplot', 'autocorrplot']
 
-def traceplot(trace, vars=None, figsize=None):
+def traceplot(trace, vars=None, figsize=None, values=None):
     """Plot samples histograms and values
 
     Parameters
@@ -22,6 +23,10 @@ def traceplot(trace, vars=None, figsize=None):
         variables to be plotted, if None all variable are plotted
     figsize : figure size tuple
         if None, size is (12, num of variables * 2) inch
+    values : dict
+        dictionary of values to be overplotted as vertical lines
+        to the posteriors and horizontal lines on sample values
+        e.g. mean of posteriors, true values of a simulation
 
     Returns
     -------
@@ -57,6 +62,13 @@ def traceplot(trace, vars=None, figsize=None):
 
         ax[i, 0].set_ylabel("Frequency")
         ax[i, 1].set_ylabel("Sample value")
+
+        if values:
+            try:
+                ax[i, 0].axvline(x=values[v], color="r", lw=1.5)
+                ax[i, 1].axhline(y=values[v], color="r", lw=1.5, alpha=.35)
+            except exceptions.KeyError:
+                pass
 
     plt.tight_layout()
     return fig


### PR DESCRIPTION
not sure if you are interested in merging this,
I find it handy to quickly display vertical lines on top of the posteriors and horizontal lines on the sample values:

![download](https://f.cloud.github.com/assets/383090/1431337/f796a0ac-40cc-11e3-8d3d-0e2863d90eec.png)
