### PR TITLE
Input dimensions for normcdf/half_cauchy_like

### DIFF
--- a/pymc/distributions.py
+++ b/pymc/distributions.py
@@ -1321,7 +1321,7 @@ def half_cauchy_like(x, alpha, beta):
     """
 
     x = np.atleast_1d(x)
-    if sum(x < 0):
+    if sum(x.ravel() < 0):
         return -inf
     return flib.cauchy(x, alpha, beta) + len(x)*np.log(2)
 

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -25,7 +25,7 @@ import pdb
 import warnings
 import nose
 
-from numpy import exp, log, array, sqrt
+from numpy import exp, log, array, sqrt, arange
 from numpy.linalg import cholesky, det, inv
 from numpy.testing import *
 import numpy as np
@@ -465,6 +465,21 @@ class test_cauchy(TestCase):
         parameters = {'alpha': 0, 'beta': .5}
         integral = normalization(flib.cauchy, parameters, [-100, 100], 600)
         assert_almost_equal(integral, 1, 2)
+
+
+class test_half_cauchy_like_input_shape(TestCase):
+
+    def test_half_cauchy_like_1d_input(self):
+        x = arange(8.)
+        half_cauchy_like(x, 0, 1)
+
+    def test_half_cauchy_like_2d_input(self):
+        x = arange(8.).reshape(2, 4)
+        half_cauchy_like(x, 0, 1)
+
+    def test_half_cauchy_like_3d_input(self):
+        x = arange(8.).reshape(2, 2, 2)
+        half_cauchy_like(x, 0, 1)
 
 
 class test_chi2(TestCase):

--- a/pymc/tests/test_utils.py
+++ b/pymc/tests/test_utils.py
@@ -47,6 +47,33 @@ class test_logp_of_set(TestCase):
                 assert(cls is RuntimeError)
 
 
+class test_normcdf_input_shape(TestCase):
+
+    def test_normcdf_1d_input(self):
+        x = arange(8.)
+        utils.normcdf(x)
+
+    def test_normcdf_log_1d_input(self):
+        x = arange(8.)
+        utils.normcdf(x, log=True)
+
+    def test_normcdf_2d_input(self):
+        x = arange(8.).reshape(2, 4)
+        utils.normcdf(x)
+
+    def test_normcdf_log_2d_input(self):
+        x = arange(8.).reshape(2, 4)
+        utils.normcdf(x, log=True)
+
+    def test_normcdf_3d_input(self):
+        x = arange(8.).reshape(2, 2, 2)
+        utils.normcdf(x)
+
+    def test_normcdf_log_3d_input(self):
+        x = arange(8.).reshape(2, 2, 2)
+        utils.normcdf(x, log=True)
+
+
 if __name__ == '__main__':
     C = nose.config.Config(verbosity=1)
     nose.runmodule(config=C)

--- a/pymc/utils.py
+++ b/pymc/utils.py
@@ -432,8 +432,7 @@ def normcdf(x, log=False):
     y = np.atleast_1d(x).copy()
     flib.normcdf(y)
     if log:
-        # return np.where(y>0, np.log(y), -np.inf)
-        return np.array([-np.inf if not yi else np.log(yi) for yi in y])
+        return np.where(y>0, np.log(y), -np.inf)
     return y
 
 


### PR DESCRIPTION
Hi. I was getting errors for both the truncated normal and half-Cauchy stochastics that was related to them having more than one dimension.

Do these changes seem like a reasonable way to fix this?

Thanks
