### PR TITLE
Install git version of Theano for python 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-numpy>=1.7.1
-scipy>=0.12.0
-Theano==0.6.0rc3
-matplotlib>=1.2.1

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,13 @@ classifiers = ['Development Status :: 3 - Alpha',
                'Topic :: Scientific/Engineering :: Mathematics',
                'Operating System :: OS Independent']
 
-with open('requirements.txt') as f:
-    required = f.read().splitlines()
+required = ['numpy>=1.7.1', 'scipy>=0.12.0', 'matplotlib>=1.2.1',
+            'Theano<=0.6.1dev']
 
 if __name__ == "__main__":
+    ## Current release of Theano does not support python 3, so need
+    ## to get it from upstream git repo
+    dep_links = ['https://github.com/Theano/Theano/tarball/master#egg=Theano-0.6.1dev']
 
     setup(name=DISTNAME,
           version=VERSION,
@@ -38,4 +41,5 @@ if __name__ == "__main__":
                     'pymc.step_methods', 'pymc.tuning', 
                     'pymc.tests', 'pymc.glm'],
           classifiers=classifiers,
+          dependency_links=dep_links,
           install_requires=required)


### PR DESCRIPTION
The current release of Theano on PyPI only supports python 2. For python
3, Theano now is installed from the master branch of the Theano git
repo.

Using '<=0.6.1dev' as the required version is a hack to get pip to
install the git version of Theano. If set to '==0.6.1dev' pip will
download the git version but then throw an error because the git version
is still 0.6.0rc3. If set to '==0.6.0rc3', pip will give preference to
the pypi version.

requirements.txt is no longer coupled to setup.py. `pip install -r
requirements.txt` will now install the developmental version of Theano
for python 2 and 3.

Fixes #388
