### PR TITLE
traceplot allows for MutliTrace traces to be plotted separately

### DIFF
--- a/pymc/plots.py
+++ b/pymc/plots.py
@@ -11,7 +11,7 @@ from .trace import *
 
 __all__ = ['traceplot', 'kdeplot', 'kde2plot', 'forestplot', 'autocorrplot']
 
-def traceplot(trace, vars=None, figsize=None, lines=None):
+def traceplot(trace, vars=None, figsize=None, lines=None, combined=False, ax=None):
     """Plot samples histograms and values
 
     Parameters
@@ -38,7 +38,10 @@ def traceplot(trace, vars=None, figsize=None, lines=None):
         vars = trace.varnames
 
     if isinstance(trace, MultiTrace):
-        trace = trace.combined()
+        if combined:
+            traces = [trace.combined()]
+        else:
+            traces = trace.traces
 
     n = len(vars)
 
@@ -47,27 +50,28 @@ def traceplot(trace, vars=None, figsize=None, lines=None):
 
     fig, ax = plt.subplots(n, 2, squeeze=False, figsize=figsize)
 
-    for i, v in enumerate(vars):
-        d = np.squeeze(trace[v])
+    for trace in traces:
+        for i, v in enumerate(vars):
+            d = np.squeeze(trace[v])
 
-        if trace[v].dtype.kind == 'i':
-            ax[i, 0].hist(d, bins=sqrt(d.size))
-        else:
-            kdeplot_op(ax[i, 0], d)
-        ax[i, 0].set_title(str(v))
-        ax[i, 0].grid(True)
-        ax[i, 1].set_title(str(v))
-        ax[i, 1].plot(d, alpha=.35)
+            if trace[v].dtype.kind == 'i':
+                ax[i, 0].hist(d, bins=sqrt(d.size))
+            else:
+                kdeplot_op(ax[i, 0], d)
+            ax[i, 0].set_title(str(v))
+            ax[i, 0].grid(True)
+            ax[i, 1].set_title(str(v))
+            ax[i, 1].plot(d, alpha=.35)
 
-        ax[i, 0].set_ylabel("Frequency")
-        ax[i, 1].set_ylabel("Sample value")
+            ax[i, 0].set_ylabel("Frequency")
+            ax[i, 1].set_ylabel("Sample value")
 
-        if lines:
-            try:
-                ax[i, 0].axvline(x=lines[v], color="r", lw=1.5)
-                ax[i, 1].axhline(y=lines[v], color="r", lw=1.5, alpha=.35)
-            except KeyError:
-                pass
+            if lines:
+                try:
+                    ax[i, 0].axvline(x=lines[v], color="r", lw=1.5)
+                    ax[i, 1].axhline(y=lines[v], color="r", lw=1.5, alpha=.35)
+                except exceptions.KeyError:
+                    pass
 
     plt.tight_layout()
     return fig
@@ -362,8 +366,7 @@ def forestplot(trace_obj, vars=None, alpha=0.05, quartiles=True, rhat=True,
                                 q[3]),
                             y=(y,
                                 y),
-                            linewidth=2,
-                            color="blue")
+                            linewidth=2)
 
                     else:
                         # Plot median
@@ -375,8 +378,7 @@ def forestplot(trace_obj, vars=None, alpha=0.05, quartiles=True, rhat=True,
                             q[-1]),
                         y=(y,
                             y),
-                        linewidth=1,
-                        color="blue")
+                        linewidth=1)
 
             else:
 
@@ -392,8 +394,7 @@ def forestplot(trace_obj, vars=None, alpha=0.05, quartiles=True, rhat=True,
                             quants[3]),
                         y=(y,
                             y),
-                        linewidth=2,
-                        color="blue")
+                        linewidth=2)
                 else:
                     # Plot median
                     plot(quants[1], y, 'bo', markersize=4)
@@ -404,8 +405,7 @@ def forestplot(trace_obj, vars=None, alpha=0.05, quartiles=True, rhat=True,
                         quants[-1]),
                     y=(y,
                         y),
-                    linewidth=1,
-                    color="blue")
+                    linewidth=1)
 
             # Increment index
             var += k

--- a/pymc/plots.py
+++ b/pymc/plots.py
@@ -11,7 +11,7 @@ from .trace import *
 
 __all__ = ['traceplot', 'kdeplot', 'kde2plot', 'forestplot', 'autocorrplot']
 
-def traceplot(trace, vars=None, figsize=None, lines=None, combined=False, ax=None):
+def traceplot(trace, vars=None, figsize=None, lines=None, combined=False):
     """Plot samples histograms and values
 
     Parameters
@@ -19,13 +19,16 @@ def traceplot(trace, vars=None, figsize=None, lines=None, combined=False, ax=Non
 
     trace : result of MCMC run
     vars : list of variable names
-        variables to be plotted, if None all variable are plotted
+        Variables to be plotted, if None all variable are plotted
     figsize : figure size tuple
-        if None, size is (12, num of variables * 2) inch
+        If None, size is (12, num of variables * 2) inch
     lines : dict
-        dictionary of variable name / value  to be overplotted as vertical lines
+        Dictionary of variable name / value  to be overplotted as vertical lines
         to the posteriors and horizontal lines on sample values
         e.g. mean of posteriors, true values of a simulation
+    combined : bool
+        Flag for combining MultiTrace into a single trace. If False (default)
+        traces will be plotted separately on the same set of axes.
 
     Returns
     -------

--- a/pymc/plots.py
+++ b/pymc/plots.py
@@ -12,7 +12,7 @@ from .trace import *
 
 __all__ = ['traceplot', 'kdeplot', 'kde2plot', 'forestplot', 'autocorrplot']
 
-def traceplot(trace, vars=None, figsize=None, lines=None):
+def traceplot(trace, vars=None, figsize=None, lines=None, combined=False, ax=None):
     """Plot samples histograms and values
 
     Parameters
@@ -39,7 +39,10 @@ def traceplot(trace, vars=None, figsize=None, lines=None):
         vars = trace.varnames
 
     if isinstance(trace, MultiTrace):
-        trace = trace.combined()
+        if combined:
+            traces = [trace.combined()]
+        else:
+            traces = trace.traces
 
     n = len(vars)
 
@@ -48,27 +51,28 @@ def traceplot(trace, vars=None, figsize=None, lines=None):
 
     fig, ax = plt.subplots(n, 2, squeeze=False, figsize=figsize)
 
-    for i, v in enumerate(vars):
-        d = np.squeeze(trace[v])
+    for trace in traces:
+        for i, v in enumerate(vars):
+            d = np.squeeze(trace[v])
 
-        if trace[v].dtype.kind == 'i':
-            ax[i, 0].hist(d, bins=sqrt(d.size))
-        else:
-            kdeplot_op(ax[i, 0], d)
-        ax[i, 0].set_title(str(v))
-        ax[i, 0].grid(True)
-        ax[i, 1].set_title(str(v))
-        ax[i, 1].plot(d, alpha=.35)
+            if trace[v].dtype.kind == 'i':
+                ax[i, 0].hist(d, bins=sqrt(d.size))
+            else:
+                kdeplot_op(ax[i, 0], d)
+            ax[i, 0].set_title(str(v))
+            ax[i, 0].grid(True)
+            ax[i, 1].set_title(str(v))
+            ax[i, 1].plot(d, alpha=.35)
 
-        ax[i, 0].set_ylabel("Frequency")
-        ax[i, 1].set_ylabel("Sample value")
+            ax[i, 0].set_ylabel("Frequency")
+            ax[i, 1].set_ylabel("Sample value")
 
-        if lines:
-            try:
-                ax[i, 0].axvline(x=lines[v], color="r", lw=1.5)
-                ax[i, 1].axhline(y=lines[v], color="r", lw=1.5, alpha=.35)
-            except exceptions.KeyError:
-                pass
+            if lines:
+                try:
+                    ax[i, 0].axvline(x=lines[v], color="r", lw=1.5)
+                    ax[i, 1].axhline(y=lines[v], color="r", lw=1.5, alpha=.35)
+                except exceptions.KeyError:
+                    pass
 
     plt.tight_layout()
     return fig
@@ -363,8 +367,7 @@ def forestplot(trace_obj, vars=None, alpha=0.05, quartiles=True, rhat=True,
                                 q[3]),
                             y=(y,
                                 y),
-                            linewidth=2,
-                            color="blue")
+                            linewidth=2)
 
                     else:
                         # Plot median
@@ -376,8 +379,7 @@ def forestplot(trace_obj, vars=None, alpha=0.05, quartiles=True, rhat=True,
                             q[-1]),
                         y=(y,
                             y),
-                        linewidth=1,
-                        color="blue")
+                        linewidth=1)
 
             else:
 
@@ -393,8 +395,7 @@ def forestplot(trace_obj, vars=None, alpha=0.05, quartiles=True, rhat=True,
                             quants[3]),
                         y=(y,
                             y),
-                        linewidth=2,
-                        color="blue")
+                        linewidth=2)
                 else:
                     # Plot median
                     plot(quants[1], y, 'bo', markersize=4)
@@ -405,8 +406,7 @@ def forestplot(trace_obj, vars=None, alpha=0.05, quartiles=True, rhat=True,
                         quants[-1]),
                     y=(y,
                         y),
-                    linewidth=1,
-                    color="blue")
+                    linewidth=1)
 
             # Increment index
             var += k

--- a/pymc/plots.py
+++ b/pymc/plots.py
@@ -12,7 +12,7 @@ from .trace import *
 
 __all__ = ['traceplot', 'kdeplot', 'kde2plot', 'forestplot', 'autocorrplot']
 
-def traceplot(trace, vars=None, figsize=None, lines=None, combined=False, ax=None):
+def traceplot(trace, vars=None, figsize=None, lines=None, combined=False):
     """Plot samples histograms and values
 
     Parameters
@@ -20,13 +20,16 @@ def traceplot(trace, vars=None, figsize=None, lines=None, combined=False, ax=Non
 
     trace : result of MCMC run
     vars : list of variable names
-        variables to be plotted, if None all variable are plotted
+        Variables to be plotted, if None all variable are plotted
     figsize : figure size tuple
-        if None, size is (12, num of variables * 2) inch
+        If None, size is (12, num of variables * 2) inch
     lines : dict
-        dictionary of variable name / value  to be overplotted as vertical lines
+        Dictionary of variable name / value  to be overplotted as vertical lines
         to the posteriors and horizontal lines on sample values
         e.g. mean of posteriors, true values of a simulation
+    combined : bool
+        Flag for combining MultiTrace into a single trace. If False (default)
+        traces will be plotted separately on the same set of axes.
 
     Returns
     -------


### PR DESCRIPTION
In the current master, `traceplot` concatenates the traces in a `MultiTrace` object into a single long chain before plotting them. Often, we will want to plot each chain separately on the same axes. I have added a `combined` argument that defaults to False, so that we get the following:

![unknown-2](https://f.cloud.github.com/assets/81476/1569144/85654770-50be-11e3-9987-df482cfa563f.png)

Setting `combined=True` will result in concatenation before plotting.

I also cleaned up the Gelman-Rubin diagnostic code while chasing a bug.
