### PR TITLE
Added a thresholded metropolis step method.

### DIFF
--- a/pymc/MCMC.py
+++ b/pymc/MCMC.py
@@ -334,6 +334,9 @@ class MCMC(Sampler):
             self.status = 'halt'
             self._halt()
 
+        if self.status == 'halt':
+            self._halt()
+            
     def tune(self):
         """
         Tell all step methods to tune themselves.


### PR DESCRIPTION
Halts if a variable exceeds upper or lower bounds.  Useful for
models like regression in which a noise parameter corresponds to
model fitness and you want to bail early if it reaches a threshold.

Also added _halt call to MCMC._loop
