### PR TITLE
Update theano dependency to 0.6.0rc5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,13 +22,9 @@ classifiers = ['Development Status :: 3 - Alpha',
                'Operating System :: OS Independent']
 
 required = ['numpy>=1.7.1', 'scipy>=0.12.0', 'matplotlib>=1.2.1',
-            'Theano>=0.6.1dev']
+            'Theano==0.6.0rc5']
 
 if __name__ == "__main__":
-    ## Current release of Theano does not support python 3, so need
-    ## to get it from upstream git repo
-    dep_links = ['https://github.com/Theano/Theano/tarball/master#egg=Theano-0.6.1dev']
-
     setup(name=DISTNAME,
           version=VERSION,
           maintainer=MAINTAINER,
@@ -41,5 +37,4 @@ if __name__ == "__main__":
                     'pymc.step_methods', 'pymc.tuning', 
                     'pymc.tests', 'pymc.glm'],
           classifiers=classifiers,
-          dependency_links=dep_links,
           install_requires=required)


### PR DESCRIPTION
0.6.0rc5 (which supports python 3) is now on PyPI, so dependency link is
no long needed.

This should fix remaining issues with #389.

edit: typo in title
