### PR TITLE
Fix for orphan processes in psample

### DIFF
--- a/pymc/sample.py
+++ b/pymc/sample.py
@@ -166,4 +166,6 @@ def psample(draws, step, start=None, trace=None, tune=None, model=None, threads=
 
     traces = p.map(argsample, argset)
 
+    p.close()
+
     return MultiTrace(traces)


### PR DESCRIPTION
Added call to Pool.close() in psample to fix #407
