### PR TITLE
Addresses problems with `find_MAP` and discrete stochastic variables

### DIFF
--- a/pymc/examples/discrete_find_MAP.ipynb
+++ b/pymc/examples/discrete_find_MAP.ipynb
@@ -1,0 +1,1388 @@
+{
+ "metadata": {
+  "name": ""
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "heading",
+     "level": 1,
+     "metadata": {},
+     "source": [
+      "Using `find_MAP` on models with discrete variables"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Maximum a posterior(MAP) estimation, can be difficult in models which have discrete stochastic variables. Here we demonstrate the problem with a simple model, and present a few possible work arounds."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import pymc as mc"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 1
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "We define a simple model of a survey with one data point. We use a $Beta$ distribution for the $p$ parameter in a binomial. We would like to know both the posterior distribution for p, as well as the predictive posterior distribution over the survey parameter."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "alpha = 4\n",
+      "beta = 4\n",
+      "n = 20\n",
+      "yes = 15\n",
+      "\n",
+      "with mc.Model() as model:\n",
+      "    p = mc.Beta('p', alpha, beta)\n",
+      "    surv_sim = mc.Binomial('surv_sim', n=n, p=p)\n",
+      "    surv = mc.Binomial('surv', n=n, p=p, observed=yes)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stderr",
+       "text": [
+        "WARNING (theano.gof.compilelock): Overriding existing lock by dead process '25402' (I am process '18668')\n"
+       ]
+      }
+     ],
+     "prompt_number": 2
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "First let's try and use `find_MAP`."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "with model:\n",
+      "    print(mc.find_MAP())"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "{'p': array(0.6086956533498806)}\n"
+       ]
+      }
+     ],
+     "prompt_number": 3
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "`find_map` defaults to find the MAP for only the continuous variables we have to specify if we would like to use the discrete variables."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "with model:\n",
+      "    print(mc.find_MAP(vars=model.vars, disp=True))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "Warning: vars contains discrete variables. MAP estimates may not be accurate for the default parameters. Defaulting to non-gradient minimization fmin_powell.\n",
+        "Optimization terminated successfully."
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "         Current function value: 3.111511\n",
+        "         Iterations: 3\n",
+        "         Function evaluations: 95\n",
+        "{'surv_sim': 14.0, 'p': array(0.695652178810167)}\n"
+       ]
+      }
+     ],
+     "prompt_number": 4
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "We set the `disp` variable to display a warning that we are using a non-gradient minimization technique, as discrete variables do not give much gradient information. To demonstrate this, if we use a gradient based minimization, `fmin_bfgs`, with various starting points we see that the map does not converge."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "with model:\n",
+      "    for i in range(n+1):\n",
+      "        s = {'p':0.5, 'surv_sim':i}\n",
+      "        map_est = mc.find_MAP(start=s, vars=model.vars, fmin=mc.starting.optimize.fmin_bfgs)\n",
+      "        print('surv_sim: %i->%i, p: %f->%f, LogP:%f'%(s['surv_sim'],\n",
+      "                                                      map_est['surv_sim'],\n",
+      "                                                      s['p'],\n",
+      "                                                      map_est['p'],\n",
+      "                                                      model.logpc(map_est)))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "surv_sim: 0->-1, p: 0.500000->0.391133, LogP:-inf\n",
+        "surv_sim: 1->1, p: 0.500000->0.500000, LogP:-14.298540\n",
+        "surv_sim: 2->2, p: 0.500000->0.500000, LogP:-12.047249\n",
+        "surv_sim: 3->3, p: 0.500000->0.500000, LogP:-10.255489\n",
+        "surv_sim: 4->4, p: 0.500000->0.500000, LogP:-8.808570\n",
+        "surv_sim: 5->5, p: 0.500000->0.500000, LogP:-7.645419\n",
+        "surv_sim: 6->6, p: 0.500000->0.500000, LogP:-6.729129\n",
+        "surv_sim: 7->7, p: 0.500000->0.500000, LogP:-6.035981\n",
+        "surv_sim: 8->8, p: 0.500000->0.500000, LogP:-5.550474\n",
+        "surv_sim: 9->8, p: 0.500000->0.558888, LogP:-5.161793"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 10->9, p: 0.500000->0.587384, LogP:-4.563607\n",
+        "surv_sim: 11->10, p: 0.500000->0.500000, LogP:-5.167477\n",
+        "surv_sim: 12->11, p: 0.500000->0.500000, LogP:-5.262785\n",
+        "surv_sim: 13->12, p: 0.500000->0.500000, LogP:-5.550465\n",
+        "surv_sim: 14->13, p: 0.500000->0.500000, LogP:-6.035970"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 15->14, p: 0.500000->0.681157, LogP:-3.133947\n",
+        "surv_sim: 16->16, p: 0.500000->0.500000, LogP:-8.808570\n",
+        "surv_sim: 17->17, p: 0.500000->0.500000, LogP:-10.255489\n",
+        "surv_sim: 18->18, p: 0.500000->0.500000, LogP:-12.047249\n",
+        "surv_sim: 19->19, p: 0.500000->0.500000, LogP:-14.298540\n",
+        "surv_sim: 20->20, p: 0.500000->0.500000, LogP:-17.294273\n"
+       ]
+      }
+     ],
+     "prompt_number": 5
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Once again because the gradient of `surv_sim` provides no information to the `fmin` routine and it is only changed in a few cases, most of which are not correct. Manually, looking at the log proability we can see that the maximum is somewhere around `surv_sim`$=14$ and `p`$=0.7$. If we employ a non-gradient minimization, such as `fmin_powell` (the default when discrete variables are detected), we might be able to get a better estimate."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "with model:\n",
+      "    for i in range(n+1):\n",
+      "        s = {'p':0.5, 'surv_sim':i}\n",
+      "        map_est = mc.find_MAP(start=s, vars=model.vars)\n",
+      "        print('surv_sim: %i->%i, p: %f->%f, LogP:%f'%(s['surv_sim'],\n",
+      "                                                      map_est['surv_sim'],\n",
+      "                                                      s['p'],\n",
+      "                                                      map_est['p'],\n",
+      "                                                      model.logpc(map_est)))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "surv_sim: 0->2, p: 0.500000->0.434783, LogP:-11.654827\n",
+        "surv_sim: 1->3, p: 0.500000->0.456522, LogP:-10.081356\n",
+        "surv_sim: 2->6, p: 0.500000->0.521739, LogP:-6.685637"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 3->7, p: 0.500000->0.543478, LogP:-5.861849\n",
+        "surv_sim: 4->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 5->14, p: 0.500000->0.674290, LogP:-3.159870\n",
+        "surv_sim: 6->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 7->14, p: 0.500000->0.695652, LogP:-3.111511\n",
+        "surv_sim: 8->14, p: 0.500000->0.695652, LogP:-3.111511\n",
+        "surv_sim: 9->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 10->14, p: 0.500000->0.695652, LogP:-3.111511\n",
+        "surv_sim: 11->14, p: 0.500000->0.695652, LogP:-3.111511\n",
+        "surv_sim: 12->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 13->14, p: 0.500000->0.695652, LogP:-3.111511\n",
+        "surv_sim: 14->14, p: 0.500000->0.695652, LogP:-3.111511\n",
+        "surv_sim: 15->15, p: 0.500000->0.717392, LogP:-3.149062"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 16->14, p: 0.500000->0.695652, LogP:-3.111511\n",
+        "surv_sim: 17->15, p: 0.500000->0.717391, LogP:-3.149062"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 18->14, p: 0.500000->0.695652, LogP:-3.111511\n",
+        "surv_sim: 19->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 20->14, p: 0.500000->0.712421, LogP:-3.142725"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n"
+       ]
+      }
+     ],
+     "prompt_number": 6
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "For most starting values this converges to the maximum log likelihood of $\\approx -3.15$, but for particularly low starting values of `surv_sim`, or values near `surv_sim`$=14$ there is still some noise. The scipy optimize package contains some more general 'global' minimization functions that we can utilize. The `basinhopping` algorithm restarts the optimization at places near found minimums. Because it has a slightly different interface to other minimization schemes we have to define a wrapper function."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def bh(*args,**kwargs):\n",
+      "    result = mc.starting.optimize.basinhopping(*args, **kwargs)\n",
+      "    # A `Result` object is returned, the argmin value can be in `x`\n",
+      "    return result['x']\n",
+      "\n",
+      "with model:\n",
+      "    for i in range(n+1):\n",
+      "        s = {'p':0.5, 'surv_sim':i}\n",
+      "        map_est = mc.find_MAP(start=s, vars=model.vars, fmin=bh)\n",
+      "        print('surv_sim: %i->%i, p: %f->%f, LogP:%f'%(s['surv_sim'],\n",
+      "                                                      floor(map_est['surv_sim']),\n",
+      "                                                      s['p'],\n",
+      "                                                      map_est['p'],\n",
+      "                                                      model.logpc(map_est)))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "surv_sim: 0->5, p: 0.500000->0.500000, LogP:-7.645419\n",
+        "surv_sim: 1->7, p: 0.500000->0.543478, LogP:-5.861849"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 2->10, p: 0.500000->0.608696, LogP:-4.071797"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 3->8, p: 0.500000->0.565217, LogP:-5.158052"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 4->10, p: 0.500000->0.608696, LogP:-4.071797"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 5->7, p: 0.500000->0.543478, LogP:-5.861849"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 6->12, p: 0.500000->0.652174, LogP:-3.385867"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 7->8, p: 0.500000->0.565217, LogP:-5.158052"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 8->11, p: 0.500000->0.630435, LogP:-3.679320"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 9->10, p: 0.500000->0.608696, LogP:-4.071797"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 10->12, p: 0.500000->0.652174, LogP:-3.385867"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 11->13, p: 0.500000->0.673913, LogP:-3.194359"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 12->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 13->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 14->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 15->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 16->15, p: 0.500000->0.717391, LogP:-3.149062"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 17->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 18->15, p: 0.500000->0.717391, LogP:-3.149062"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 19->18, p: 0.500000->0.782609, LogP:-4.247450"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 20->18, p: 0.500000->0.782609, LogP:-4.247450"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n"
+       ]
+      }
+     ],
+     "prompt_number": 7
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "By default `basinhopping` uses a gradient minimization technique, `fmin_bfgs`, resulting in inaccurate predictions many times. If we force `basinhoping` to use a non-gradient technique we get much better results"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "with model:\n",
+      "    for i in range(n+1):\n",
+      "        s = {'p':0.5, 'surv_sim':i}\n",
+      "        map_est = mc.find_MAP(start=s, vars=model.vars, fmin=bh, minimizer_kwargs={\"method\": \"Powell\"})\n",
+      "        print('surv_sim: %i->%i, p: %f->%f, LogP:%f'%(s['surv_sim'],\n",
+      "                                                      map_est['surv_sim'],\n",
+      "                                                      s['p'],\n",
+      "                                                      map_est['p'],\n",
+      "                                                      model.logpc(map_est)))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "surv_sim: 0->14, p: 0.500000->0.695652, LogP:-3.111511\n",
+        "surv_sim: 1->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 2->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 3->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 4->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 5->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 6->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 7->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 8->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 9->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 10->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 11->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 12->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 13->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 14->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 15->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 16->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 17->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 18->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 19->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n",
+        "surv_sim: 20->14, p: 0.500000->0.695652, LogP:-3.111511"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\n"
+       ]
+      }
+     ],
+     "prompt_number": 8
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Confident in our MAP estimate we can sample from the posterior, making sure we use the `Metropolis` method for our discrete variables."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "with model:\n",
+      "    step1 = mc.step_methods.HamiltonianMC(vars=[p])\n",
+      "    step2 = mc.step_methods.Metropolis(vars=[surv_sim])"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stderr",
+       "text": [
+        "/nfs/adaptive/bedwards/anaconda/envs/pymc-dev/lib/python2.7/site-packages/theano/scan_module/scan_perform_ext.py:85: RuntimeWarning: numpy.ndarray size changed, may indicate binary incompatibility\n",
+        "  from scan_perform.scan_perform import *\n"
+       ]
+      }
+     ],
+     "prompt_number": 9
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "with model:\n",
+      "    trace = mc.sample(25000,[step1,step2],start=map_est)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [                  1%                  ] 335 of 25000 complete in 0.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-                 2%                  ] 670 of 25000 complete in 1.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-                 4%                  ] 1004 of 25000 complete in 1.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [--                5%                  ] 1340 of 25000 complete in 2.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [--                6%                  ] 1673 of 25000 complete in 2.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [---               8%                  ] 2009 of 25000 complete in 3.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [---               9%                  ] 2345 of 25000 complete in 3.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [----             10%                  ] 2680 of 25000 complete in 4.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [----             12%                  ] 3016 of 25000 complete in 4.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----            13%                  ] 3350 of 25000 complete in 5.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----            14%                  ] 3686 of 25000 complete in 5.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [------           16%                  ] 4021 of 25000 complete in 6.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [------           17%                  ] 4357 of 25000 complete in 6.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-------          18%                  ] 4691 of 25000 complete in 7.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-------          20%                  ] 5026 of 25000 complete in 7.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [--------         21%                  ] 5362 of 25000 complete in 8.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [--------         22%                  ] 5700 of 25000 complete in 8.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [---------        24%                  ] 6036 of 25000 complete in 9.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [---------        25%                  ] 6370 of 25000 complete in 9.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [----------       26%                  ] 6705 of 25000 complete in 10.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [----------       28%                  ] 7040 of 25000 complete in 10.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------      29%                  ] 7375 of 25000 complete in 11.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------      30%                  ] 7709 of 25000 complete in 11.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [------------     32%                  ] 8041 of 25000 complete in 12.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [------------     33%                  ] 8375 of 25000 complete in 12.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-------------    34%                  ] 8710 of 25000 complete in 13.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-------------    36%                  ] 9042 of 25000 complete in 13.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [--------------   37%                  ] 9372 of 25000 complete in 14.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [--------------   38%                  ] 9708 of 25000 complete in 14.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [---------------  40%                  ] 10043 of 25000 complete in 15.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [---------------  41%                  ] 10378 of 25000 complete in 15.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [---------------- 42%                  ] 10713 of 25000 complete in 16.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [---------------- 44%                  ] 11049 of 25000 complete in 16.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------45%                  ] 11386 of 25000 complete in 17.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------46%                  ] 11721 of 25000 complete in 17.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------48%                  ] 12057 of 25000 complete in 18.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------49%                  ] 12393 of 25000 complete in 18.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------50%                  ] 12729 of 25000 complete in 19.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------52%                  ] 13064 of 25000 complete in 19.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------53%                  ] 13399 of 25000 complete in 20.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------54%                  ] 13733 of 25000 complete in 20.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------56%-                 ] 14070 of 25000 complete in 21.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------57%-                 ] 14404 of 25000 complete in 21.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------58%--                ] 14739 of 25000 complete in 22.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------60%--                ] 15073 of 25000 complete in 22.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------61%---               ] 15408 of 25000 complete in 23.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------62%---               ] 15744 of 25000 complete in 23.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------64%----              ] 16081 of 25000 complete in 24.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------65%----              ] 16416 of 25000 complete in 24.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------67%-----             ] 16752 of 25000 complete in 25.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------68%-----             ] 17087 of 25000 complete in 25.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------69%------            ] 17422 of 25000 complete in 26.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------71%------            ] 17758 of 25000 complete in 26.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------72%-------           ] 18094 of 25000 complete in 27.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------73%--------          ] 18430 of 25000 complete in 27.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------75%--------          ] 18765 of 25000 complete in 28.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------76%---------         ] 19100 of 25000 complete in 28.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------77%---------         ] 19435 of 25000 complete in 29.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------79%----------        ] 19770 of 25000 complete in 29.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------80%----------        ] 20106 of 25000 complete in 30.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------81%-----------       ] 20440 of 25000 complete in 30.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------83%-----------       ] 20775 of 25000 complete in 31.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------84%------------      ] 21111 of 25000 complete in 31.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------85%------------      ] 21446 of 25000 complete in 32.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------87%-------------     ] 21782 of 25000 complete in 32.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------88%-------------     ] 22116 of 25000 complete in 33.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------89%--------------    ] 22452 of 25000 complete in 33.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------91%--------------    ] 22789 of 25000 complete in 34.0 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------92%---------------   ] 23123 of 25000 complete in 34.5 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------93%---------------   ] 23458 of 25000 complete in 35.1 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------95%----------------  ] 23790 of 25000 complete in 35.6 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------96%----------------  ] 24125 of 25000 complete in 36.1 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------97%----------------- ] 24460 of 25000 complete in 36.6 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------99%----------------- ] 24796 of 25000 complete in 37.1 sec"
+       ]
+      },
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "\r",
+        " [-----------------100%-----------------] 25000 of 25000 complete in 37.4 sec"
+       ]
+      }
+     ],
+     "prompt_number": 10
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "mc.traceplot(trace);"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "metadata": {},
+       "output_type": "display_data",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAA1kAAAEaCAYAAADjUp3YAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzsnX9cFNX+/18r4E9A/AnKqquC4SoqmouVXpcUNFKyNAwq\nRe3Hw+5N++pNzfsosT4ldj/d0srbrY+m2ZUwzR9Xjaumi78Sf6dJKpL4YwVMEUUBEZjvH8fZnf3F\nLuzszgy8n4/HPnZndubM65w5M3Pec877fVQcx3EgCIIgCIIgCIIgRKGJ1AIIgiAIgiAIgiAaEmRk\nEQRBEARBEARBiAgZWQRBEARBEARBECJCRhZBEARBEARBEISIkJFFEARBEARBEAQhImRkEQRBEARB\nEARBiAgZWQRBEARBEARBECJCRhZBNED+/e9/Y9SoUVLLIAiCIBop9BwiGjsqmoyYIAiCIAiCIAhC\nPKgniyAkpqqqSmoJBEEQRCOGnkMEIT5kZBGEmyxevBhqtRqBgYGIiIjArl27kJKSgrffftu0jcFg\nQJcuXUzLGo0GH374Ifr16wd/f398+OGHePbZZy3SnTlzJmbOnFnrsVeuXImePXsiMDAQPXr0wJo1\na0zrhw0bZtquSZMm+Oc//4nw8HAEBgbinXfeQV5eHh555BEEBQXhueeew/3798UoDoIgCMLL0HOI\nIOSHr9QCCELJnD17Fp9//jmOHDmCkJAQXLp0CVVVVVCpVFCpVLXu+9133+HHH39E+/btUVRUhIUL\nF+LOnTvw9/dHdXU1vv/+e2zcuNHh/nfv3sXMmTNx5MgRhIeHo6ioCDdu3HC4/fbt23H8+HFcunQJ\nUVFR2LdvH9LT09G2bVs88sgjSE9Px6RJk+pdFgRBEIT3oecQQcgT6skiCDfw8fHBvXv3cPr0ady/\nfx9du3ZFjx49AAC1uTuqVCrMmDEDoaGhaNasGbp27YqBAwdiw4YNAIBdu3ahZcuW0Ol0tR6/SZMm\nOHXqFMrLyxEcHAytVutw2zlz5sDf3x9arRaRkZF44oknoNFoEBgYiCeeeALHjx+vRwkQBEEQUkLP\nIYKQJ2RkEYQbhIWF4ZNPPkFqaiqCg4ORlJSEgoICl/YVDtsAgOTkZKSnpwMA1qxZg+eff77W/Vu1\naoWMjAx88cUX6Ny5M8aMGYOzZ8863D44ONj0u0WLFjbLd+7ccUk3QRAEIR/oOUQQ8oSMLIJwk6Sk\nJOzduxcXL16ESqXC3Llz0apVK5SVlZm2KSwstNnPehjHhAkTYDAYYDQasXHjRiQnJzs9dlxcHLZv\n347CwkJERETg5Zdfdj9DBEEQhKKg5xBByA8ysgjCDc6dO4ddu3bh3r17aNasGZo3bw4fHx8MGDAA\n27Ztw82bN1FYWIhPPvnEaVodOnSAXq9HSkoKevTogYceeqjW7a9du4ZNmzbh7t278PPzQ6tWreDj\n4+OyduEwEprJgSAIQpnQc4gg5InHjKyKigpER0djwIAB0Gq1eOuttwAAqampUKvViIqKQlRUFH78\n8UfTPosWLUJ4eDgiIiKwfft20/qjR48iMjIS4eHhTqPcEIQ3uXfvHt566y106NABnTp1wvXr17Fo\n0SK8+OKL6N+/PzQaDUaPHo3nnnvOqQMywIZq/PTTTy69PaypqcHHH3+M0NBQtGvXDnv37sU///lP\nALBxeLZ3bOv/XdFHEA2dy5cvIyYmBn369EHfvn2xdOlSAEBxcTFiY2PRq1cvxMXFoaSkRGKlBMGg\n5xBByBOPTkZcVlaGli1boqqqCkOHDsX//u//4qeffkJAQABmzZplsW1OTg6Sk5Nx+PBhGI1GjBw5\nErm5uVCpVNDpdPjss8+g0+kQHx+PGTNmYPTo0Z6STRAEQTRSCgsLUVhYiAEDBuDOnTsYNGgQNm7c\niK+//hrt27fHnDlzsHjxYty8eRNpaWlSyyUIgiBkikeHC7Zs2RIAUFlZierqarRp0waA/S7hTZs2\nISkpCX5+ftBoNAgLC0N2djYKCgpQWlpqim4zadKkWsOJEgRBEER9CQkJwYABAwAA/v7+6N27N4xG\nIzZv3ozJkycDACZPnkzPIYIgCKJWPGpk1dTUYMCAAQgODjYNvwCATz/9FP3798e0adNMQy6uXr0K\ntVpt2letVsNoNNqsDw0NhdFo9KRsgpAV/v7+CAgIsPns379famkE0aDJz8/H8ePHER0djaKiIlMk\ntODgYBQVFUmsjiC8Bz2HCKLueHQy4iZNmuDEiRO4desWRo0aBYPBgOnTp+Odd94BALz99tuYPXs2\nli9f7vax2rdvX+sEeATR0Bg6dKjUEgjCbXr27Inz589LLcOGO3fuYPz48ViyZAkCAgIs/nPkOxIW\nFoa8vDxvSSQIyaHnENEQ8NRzyCvRBVu3bo0nn3wSR44cQceOHU0PqJdeegmHDh0CwHqoLl++bNrn\nypUrUKvVCA0NxZUrVyzWh4aG2hzjxo0b4DhO1p/JkydLroE0kj4laAwIaGO6tgMC2kiuR6nlqASN\ncjRK7t+/j/Hjx+PFF1/EuHHjALDeKz4EdkFBATp27GizX15eHjiOw++/c1izhn34fPLL2dnmdWvX\nmrc5cMBye36f9esdl9358/aP8f33ttuuX2/+3/o43vw888wCbNhQ//2FZebu5949acuCP2eFhbbr\nFyxYYPp944Z7Otes4WAwuLZtRoZnysSVsnZUdx19hGXkjU9Zmetls2YNh9JS8/K+fa7ta72fvf+L\ni+ummy8nR+e2utqxtjVrOPz8c/3LbM0aDseOmX9v2+Z4u/x898/RmjUcSkrqvp+nnkMeM7KuX79u\nGgpYXl6OHTt2ICoqymKehg0bNiAyMhIAkJCQgO+++w6VlZW4cOECcnNzodPpEBISgsDAQGRnZ4Pj\nOKxevdr00FMaGo1GaglOIY3uI3d9gHgaAwPbml6aBAa2FSVNACgtvQlgAQDuwW950pjOdWOB4zhM\nmzYNWq0Wb7zxhml9QkICVq1aBQBYtWqVKM8hzosRq715LIKwprHXPyXkXwkalYbHhgsWFBRg8uTJ\nqKmpQU1NDV588UWMGDECkyZNwokTJ6BSqdC9e3f861//AgBotVokJiZCq9XC19cXy5YtMw3HWLZs\nGVJSUlBeXo74+HiKLEgQMoEZQNyD3xR6l1A++/fvx7fffot+/fohKioKAJteZN68eUhMTMTy5cuh\n0Wiwdu1at49FjRoCaBz1oKZGagXeR27n1ZkejgPsRdAXM6q+3MrE03jMyIqMjMSxY8ds1n/zzTcO\n95k/fz7mz59vs37QoEE4deqUqPqkICgoSGoJTiGN7iN3fYAyNALy16iEclSCRjkxdOhQ1DhoEe7c\nudPLahoeWq3erf0bSyNNr9dLLUFUPHHeGloZeQpXy8kb15Y3jiGnqda84pNFMPiwwHKGNLqP3PUB\nytAIyF+jEspRCRobGrU1JAoKgNu3AWGcprt3gfx89ruiAvjjD/N/lZUAH8gwN9fyv6tXzb9LS82/\nhY0Mgauzy5SVmfVduWLuhbh8mWm/dcv+fhzHtgfY/kYjy5vRCFy6xNLRavUoL6+7Jp7qavPvwkLg\n999rz8fp00BVFVs+fRrIzrYse4CVsTVXrjDN1hQUmNPjKS4Gzpyx3fbqVXZeCwuB+/fZOv58lJYC\nvBvI5cus7E6eZOX188/A8OF63L3L0uYDKjs6l7dusfNivc2dO8C5c+y3sN5YU1nJ8rthg2XdvX+f\naefh9RQXs998HvPygAMHgGvXgPJyltaNG6z8efg6xOsE2LFyc4Hr15lW/pjFxSwfzupu//56037W\nCOuiK1RVAb/8Yq4Lf/zBrkWesjLgxAnLZWE9unULOHrUfjkbjbY9eXfuAFu32s9jdbX5nAOsjrsa\nzPS339h5AIAjR1h+9Ho9iorMGoTXkBD+3F+/bnnueA2nTgHC2BA3brDr4Y8/bMvaOs98fuxda3wd\nBVh58PWMp6aG7f/77/bvrXfuADetvApKSsxpXLnC9jt/Hjh40DK/dakj9YGMLC+ihLcupNF95K4P\nUIZGQC9aSrzvmJh+Y4AyylEJGhsTZWWscbV9u7nBsHmz+f8jRwBhhxnHAbt22f9P2EDIzLR/vH37\nbBtMzvj5Z6YPAPbuZY22igqW1o8/Atu22d/v2jW2PcD237MHMBjY9/79rjcUXWX3bmY0OWLfPma4\n8I24kydZQ43PG8/p07b77t3LNFtjMJiNI57//hc4ftx226wsVpa7d7PGL8cxTQA7jw/ifuH8eWas\nnD7Nyjc/nzUSDQaW9q+/mvNj71xu28b2488Rz08/sYY/YDby7PHrryy/FRWWDeOzZ5l2YZn897/s\nk5VlzuOhQ8DFi+x4u3ez7bZvZ3nn4Rv2W7ea15WUsDq9Y4e5jgMs/X37LPNij8xMy/2EFBWZ66Ir\n5OUBOTmsjgDs/PBlxy/zL0IAy2sEYOfg3DnL65Nnzx7buv/TT8zgtJfHK1fYPjzZ2Y7zac2JEyzt\nO3eYAZuTw9YL979wwXIfa8Nlxw7L6+rePbb866/A4cPmurR9O6ujO3falvWePZYGOp8fXzvj5/hy\nLi9n5cHXe57CQrZ/drZ9I23XLtv737595jq6dy8zCA8ftsx7SUnd6kh9ICOLIIgGD+87JucgGoQ8\nmDp1KoKDg01BmQDg0KFD0Ol0iIqKwuDBg3H48GFRjiXm0BlX/C08mb4Yx5AKOQ0v4qlrWbqTB0/5\n3MixXMXClbx56npoKMP6PElZmWVPpFSQkeVFDAaD1BKcQhrdR+76AGVoBAxSC3CKEspRCRrlxJQp\nU5Bp9Vp0zpw5eO+993D8+HG8++67mDNnjseOL4fGTW0NSCU2nOVQpmLhKC/unJcmIrYEG1KAi9rq\njbvXgZR1Uspje+v+YX0cqfJMRhZBEARBPGDYsGFo06aNxbpOnTrh1gNHpJKSErtzNUqNJ3sQXE1P\nacaMtw1GvnzslZMnorq5ej4cHac+x69LHRCmL7Xx7uz4UuurK7XVtYaG9bmR07nyWHRBwhYl+EaQ\nRveRuz5AGRrF9MnyFEooRyVolDtpaWkYOnQo/vrXv6KmpgY/C51NCEJE6ts4lntPVkNr7Cu5J6uu\nuKtVzJc09dUiVXl7zMiqqKjA8OHDce/ePVRWVuKpp57CokWLUFxcjIkTJ+LixYumuUb4EMOLFi3C\nihUr4OPjg6VLlyIuLg4AcPToUaSkpKCiogLx8fFYsmSJp2QTBEEQhAXTpk3D0qVL8fTTT+P777/H\n1KlTsWPHDrvbpqcDPj7m5bt3LQNbOIMPZpGebpsuz65dto70wsbtvXuW//3nP7aN37w84NgxIC6O\nBTjIywOSkth/fNr8MS9dMkcV4wMYWOsDAH9/23XCaHK8IzrAjn3vHgsm0L49i2gGAAEBwJgxLADB\n6dNA69ZA3762QSjslc/Eicxg4P/jZy84edIyKhq/fcuWtnr37LEMLpGeDjz7rKXD/rFjrNF2/DgQ\nHW1ev3s3EBNjv2yuXQM2bmS/v/vO9n8ePnLh9u0s79bwdal5c0ufk/v3WaQ3XkfXrrCJ4shxlsf2\n8wNCQ+1HURTmIS8PaNrUMoLbrVtARobtfsJjFhWxQBe3b7NjCdPu0AFo1852f3s6Jk4E1q1jdY+v\no3w+7t41X3PV1UBiouX1l54O6HQs6AHHAR07svU9egDdu7PfZ8+aA0Tk5pqNAo4D1q9n59Q6iiFf\n1vbgZxw6fRoIDGS/+fN67x4rS+G527bNMmInH3zDXlkA5qAQzz3Hzvv69Wz5scfM227Zwr7PnLGN\nfMkbHHl5LGAJP1/9999bbsMH+rAOmvL775aRTXnWrwfUanPET/56/+038zalpebzP2wY8MMP5v/4\naI3Ce0Z6OjB8uHl5wwbg0UdZNEtr+AAa166ZzyEfaOWnnyy3vXnTHCzDOpCNmHhsuGDz5s2xe/du\nnDhxAidPnsTu3buxb98+pKWlITY2FufOncOIESOQlpYGAMjJyUFGRgZycnKQmZmJ1157DdyDmjB9\n+nQsX74cubm5yM3NtRkvrxSU4BtBGt1H7voAZWgknyxxUIJGuXPo0CE8/fTTAIAJEybgEB8Wzg7r\n1qUiIyMV69alIifHYNFgEIu6Rumz17uQn88afiUlzhsZ9hpU9nAUTptH+Db57FlzI443sABzKHo+\n4t+tW6wh6ArW+RSGWrcXlY9fJ9RlNNqGg7YX0ezsWfYtjPAojKZmzR9/2Bq/zqitB8CeUz9fLwoL\n7RtO1ty/z86BMz+qS5csQ4rzuOJ/xdd/64a6vbDfjqipsQ07bt0zwf9vLzx5Xp55+2vX2Ed47JMn\nLctTGFK8stI25L89hEY4b9Dn59saTGVltuXmaEoEZ9TUWNZNe+eoNq5cYXVGGDVRiPWLFeF6e3W9\nsrL2KRWEWIfIBxyXs/W5dhTanz9vwvujo/vvjz8asG4du0+/916qU731xaPDBVs+eE1UWVmJ6upq\ntGnTBps3b0bWA/N28uTJ0Ov1SEtLw6ZNm5CUlAQ/Pz9oNBqEhYUhOzsb3bp1Q2lpKXQ6HQBg0qRJ\n2LhxI0aPHu1J6QRBEAQBAAgLC0NWVhaGDx+OXbt2oVevXg63nTAh1WJZScOC5EpjKEMx/EiE5WSv\nzOQ81EosPxp3/dDspeXKtlL4AXGce35tzrZX6nXniu7oaD1UKj0AoFMnYNWqhR7R4lEjq6amBgMH\nDkReXh6mT5+OPn36oKioCMHBwQCA4OBgFD0wOa9evYohQ4aY9lWr1TAajfDz84NarTatDw0NhbGu\n5rpMUIJvBGl0H7nrA5ShkXyyxEEJGuVEUlISsrKycP36dXTp0gXvvvsuvvzyS/z5z3/GvXv30KJF\nC3z55ZdSy2zwqFTmxlJDiljnSeTk8C8mSsuXN/W6E5xEOCzS0Ta17e9pvPVSwJPny6NGVpMmTXDi\nxAncunULo0aNwm7hrHYAVCoVVCLmLiUlBZoHg0uDgoIwYMAAUwODHzJDy7RMy+Itm7Fcdjd9c5ri\n6LXWKJfya4zLBoMBK1euBADT/VpOpNtzqAGQXdust7Ug97fBctcHiNs74cnji407+RGzJ0tJ1KX3\nyRsIXxZ4Kn1P7SuX+mKtw5U5AWVz/jnOO8X43nvvoUWLFvi///s/GAwGhISEoKCgADExMThz5ozJ\nN2vevHkAgNGjR2PhwoXo1q0bYmJi8NsDz7n09HRkZWXhiy++sMyISgUvZaXeGAwGq0af/CCN7iN3\nfYB4GtlLEv66E+8aZOnuBjOy3E/XrFPc+0RjOteeQgn3bldRqVRYs8YyLw89ZPbf8RRDhwL79lmu\nGzkSaNPG0pndHpGRZkf94cNZQAXesZ6nZUv7Pk2OiI9nzvz15cknzQ7rAPN3EfpXWZOUxBzkx4xh\ngResndydodGwABBVVYA9WzohgflTVVXZph0SYumfMmJE3Y8PAAMGACdO1H0/Ie3a1e4/9PTTLHBA\nXWnbltULV33zXMVVA+Sxx8yBT6KjgeBgx8Fkxo1jvkFXr9Zenq1bs/reqhW7RuzVr86dWTrW5/ip\np4BNm9jvZ59lx+OXndGrF9CtG+Agbo4Fjz/OenEdudWOGcN83fjr1dl1whMezurb5s2sXnfsyPzU\nhHTowI594wYL1CH0/fL3d+5/6QrWASxatWKBTHiGD2fBM3r1svSTCwpivqSOaNasdv/HhAR2z7tw\ngS0HBgJjxnjmOeSxnqzr16/D19cXQUFBKC8vx44dO7BgwQIkJCRg1apVmDt3LlatWoVx48YBABIS\nEpCcnIxZs2bBaDQiNzcXOp0OKpUKgYGByM7Ohk6nw+rVqzFjxgxPySYIgiAI0fC0gQXYGlgAsHMn\nM7KcwRtYgGX0P3dwx8ACLA0swHnDkW9Q8RHV6kp+vmPnfx5rw5PHOgBAfQwswH0DC3AeoGHPnvql\nW1xcv/2c4WqbVhhZ0lmH8q1bLLqiM27dYuf0mWecb2t9joUG1c8/ux7AA2DGgtBgqI1du2r/37q+\nu2JgASyCYm6uebldO1sjq6SERfoE7Ad+EQPrCIFBQZZGFn8/si6v2gwswHmAGWsD3RPBiXg8ZmQV\nFBRg8uTJqKmpQU1NDV588UWMGDECUVFRSExMxPLly00h3AFAq9UiMTERWq0Wvr6+WLZsmWko4bJl\ny5CSkoLy8nLEx8crNuiFnN8m85BG95G7vsDAtigtvYmAgDa4fdtDT09R0EstwClyP9eAMjR6irKy\nMly+fBkPPfSQ1FIkQdhgach42mergXS02oR0b4jYiy7oiLpGe7SHvSiPSsPeVAY1Nd6v902bevd4\n3sBjRlZkZCSOHTtms75t27bYuXOn3X3mz5+P+fPn26wfNGgQTglftxEEUW9KS28C4FBaKpNBywTh\nATZv3ow333wT9+7dQ35+Po4fP44FCxZgs5NJq6ZOnYqtW7eiY8eOFs+dTz/9FMuWLYOPjw+efPJJ\nLF682NNZcBuxjA+5+DcQ7tFQjMXaEDOPrqTVEK4NR/57jvLvqXrUEOunx+bJImyxDRYgP0ij+8hd\nH8MgtQAXMEgtwClKONdK0OgJUlNTkZ2djTYPxsxFRUXhdxcmcZkyZYrNXIy7d+/G5s2bcfLkSfz6\n66/461//6hHNYtMQGy32aCz5dJfGUE7ezmNDNbJqW+9tHUqGjCyCIAiiweHn54egoCCLdU2aOH/k\nDRs2zGSY8fzzn//EW2+9BT8/PwBAhw4dxBPqQRpio0UKqByVg7d7shoCdc0n9WS5DhlZXkQJvhGk\n0X3kro+hl1qAC+ilFuAUJZxrJWj0BH369MG///1vVFVVITc3F6+//joeffTReqWVm5uLPXv2YMiQ\nIdDr9Thy5IjIaj2DWMMF5e7b5Wpkt/pS34AacqMh+A85o64N9fR0xwEjrANe2MM6YIQSsRd0paaG\nBQexR10ijdaFS5c8k66UeHSeLIIgCIKQgk8//RTvv/8+mjVrhqSkJIwaNQpvv/12vdKqqqrCzZs3\ncfDgQRw+fBiJiYkOhx6uW5dq+q3V6qHV6ut1TIIg6k5D7A0hxCcnx4CcHIPHj0NGlheR+3w1AGkU\nA7nrYxikFuACBsi9N0sJ51oJGj1Bq1at8MEHH+CDDz5wOy21Wo1nHsR6Hjx4MJo0aYIbN26gXbt2\nNttOmJDq9vEIgqgfZGQRrmD9AuyHHxZ65DgeGy54+fJlxMTEoE+fPujbty+WLl0KgDkjq9VqREVF\nISoqCj/++KNpn0WLFiE8PBwRERHYvn27af3Ro0cRGRmJ8PBwzJw501OSCYIgiAZCTEyMzefxxx+v\nV1rjxo3DrgeT1pw7dw6VlZV2DSyCIAiC4FFxnpjiGEBhYSEKCwsxYMAA3LlzB4MGDcLGjRuxdu1a\nBAQEYNasWRbb5+TkIDk5GYcPH4bRaMTIkSORm5sLlUoFnU6Hzz77DDqdDvHx8ZgxY4bNXFkqlWdm\nayaIhgabf44D4P41Y04LoqTnqXTFzDOgpLnG5I+n7t1Cv6mKigqsX78evr6++Pvf/17rfklJScjK\nysKNGzfQsWNHvPvuu3jhhRcwdepUnDhxAk2bNsVHH31kt3dQpVJhzRp6DhGEVERHO5+wmCCsSU72\nzHPI6XDBU6dOITIyss4Jh4SEICQkBADg7++P3r17w2g0AoDdjGzatAlJSUnw8/ODRqNBWFgYsrOz\n0a1bN5SWlkKn0wEAJk2ahI0bNyp2QmKCIJQPzTUmfx5++GGL5aFDh2Lw4MFO90tPT7e7fvXq1aLo\nIgjCc3h6YmqCqAtOhwtOnz4dgwcPxrJly3DLUagRJ/ATQQ4ZMgQAc0ju378/pk2bhpKSEgDA1atX\noVarTfuo1WoYjUab9aGhoSZjTWkoYb4a0ug+ctfHMEgtwAUMUgtoECijPopPcXGx6XP9+nVkZmbi\n9u3bUssiCMKDHD4stQKCMOO0J2vfvn04d+4cVqxYgYEDB0Kn02HKlCmIi4tz6QB37tzBhAkTsGTJ\nEvj7+2P69Ol45513AABvv/02Zs+ejeXLl7uXiwekpKRAo9EAAIKCgjBgwADTkA6+oSHl8okTJ2Sl\nx94yj1z00LJnlgHLmK3u1hdrg8h9fbzG+u1vPz2zRrml15iWDQYDVq5cCQCm+7UnGDhw4INhooCv\nry80Go1ozxqCIAiCcIbLPllVVVXYuHEjZsyYgdatW6OmpgYffPABxo8f73Cf+/fvY8yYMXjiiSfw\nxhtv2Pyfn5+PsWPH4tSpU0hLSwMAzJs3DwAwevRoLFy4EN26dUNMTAx+++03AGwoR1ZWFr744gvL\njJBPFkG4BPlkua9R7PQaM3K7d0+dOhVbt25Fx44dcerUKYv/PvroI7z55pu4fv062rZta7Mv+WQR\nBEEoD8l8sn755ResXLkSW7ZsQWxsLLZs2YKBAwfi6tWrGDJkiEMji+M4TJs2DVqt1sLAKigoQKdO\nnQAAGzZsMPl7JSQkIDk5GbNmzYLRaERubi50Oh1UKhUCAwORnZ0NnU6H1atXY8aMGWLknSAIgmhg\nrF+/3tSDZQ8+FLsjpkyZgtdffx2TJk2yWH/58mXs2LED3bp1E0UnQRAE0bBxamTNmDED06ZNw/vv\nv4+WLVua1nfu3Bn/8z//43C//fv349tvv0W/fv0QFRUFAPjggw+Qnp6OEydOQKVSoXv37vjXv/4F\nANBqtUhMTIRWq4Wvry+WLVtmelAuW7YMKSkpKC8vR3x8vGKDXhgUMF8NaXQfuetjGKQW4AIGyH2e\nLCWgjPooHv/5z3/cMrKGDRuG/Px8m/WzZs3Chx9+iKeeespdiQRBEEQjwKmRtXXrVrRo0QI+Pj4A\ngOrqalRUVKBVq1Y2b/qEDB06FDV2wrw88cQTDveZP38+5s+fb7N+0KBBNsM2CIIgCMIa3t9LTDZt\n2gS1Wo1+/fqJnjZBEATRMHHqkzVkyBDs3LkT/v7+AIDS0lKMGjUKBw4c8IpAV5HbuH6CkCvkk0U+\nWXLCk/fuLVu2ICcnBxUVFaZ1fOCl2hD6C5eVlSEmJgY7duxAYGAgunfvjiNHjtidjFilUuGZZxaY\nlrVaPbSBSL/jAAAgAElEQVRavSh5IQiCIMQhJ8eAnByDafmHHxZK45NVUVFhMrAAICAgAGVlZaIL\nIQiCIAixePXVV1FeXo5du3bh5Zdfxvfff4/o6Og6p5OXl4f8/Hz0798fAHDlyhUMGjQIhw4dQseO\nHW22nzAh1V3pBEEQhAexfgH2ww8LPXIcp/NktWrVCkePHjUtHzlyBC1atPCImIaObdhr+UEa3Ufu\n+hgGqQW4gEFqAQ0CZdRH8Tlw4AC++eYbtG3bFgsWLMDBgwdx9uzZOqcTGRmJoqIiXLhwARcuXIBa\nrcaxY8fsGlgEQRAEweO0J+uTTz5BYmKiKSJgQUEBMjIyPC6MIAiCIOoL/zKwZcuWMBqNaNeuHQoL\nC53ul5SUhKysLNy4cQNdunTBu+++iylTppj+ry2oBkEQBEHwuDRPVmVlJc6ePQuVSoWHHnoIfn5+\n3tBWJ8gniyBcg3yyyCdLTnjq3v3uu+/i9ddfx65du/DnP/8ZAPDyyy/jvffeE/1YPDRPFkEQhPLw\n1DxZLhlZBw4cwIULF1BVVWV6i1dbZEGAzSkyadIkXLt2DSqVCq+88gpmzJiB4uJiTJw4ERcvXoRG\no8HatWsRFBQEAFi0aBFWrFgBHx8fLF26FHFxcQCAo0ePIiUlBRUVFYiPj8eSJUtsM0JGFtFACQxs\ni9LSmwgIaIPbt4vdTo+MLDKy5IQ37t0VFRWoqKgwPWs8BRlZBEEQysNTRpZTn6wXXngBf/3rX7F/\n/34cOXIEhw8fxuHDh50m7Ofnh48//hinT5/GwYMH8fnnn+O3335DWloaYmNjce7cOYwYMQJpaWkA\ngJycHGRkZCAnJweZmZl47bXXTBmePn06li9fjtzcXOTm5iIzM9PNbEuDEnwjSKP7iK2vtPQmAO7B\nt1gYREzLUxikFtAgkPv14in69euHDz74AHl5eWjevLnHDSyCIAiCEOLUJ+vo0aPIycmp8zj0kJAQ\nhISEAAD8/f3Ru3dvGI1GbN68GVlZWQCAyZMnQ6/XIy0tDZs2bUJSUhL8/Pyg0WgQFhaG7OxsdOvW\nDaWlpdDpdABYD9rGjRsVOyExQRAE4Xk2b96MjIwMJCYmQqVS4bnnnkNiYiK6du1a635Tp07F1q1b\n0bFjR9P8jG+++Sa2bNmCpk2bomfPnvj666/RunVrb2SDIAiCUChOe7L69u2LgoICtw6Sn5+P48eP\nIzo6GkVFRQgODgYABAcHo6ioCABw9epVqNVq0z5qtRpGo9FmfWhoKIxGo1t6pEKv10stwSmk0X3k\nro+hl1qAC+ilFtAgUEZ9FB+NRoO5c+fi6NGjSE9Px8mTJ9G9e3en+02ZMsVmtERcXBxOnz6NX375\nBb169cKiRYs8JZsgCIJoIDjtyfrjjz+g1Wqh0+nQrFkzAGzc+ebNm106wJ07dzB+/HgsWbIEAQEB\nFv+pVCqK1EQQBEF4hPz8fGRkZGDt2rXw8fHBhx9+6HSfYcOGIT8/32JdbGys6Xd0dDTWr18vtlSC\nIAiigeHUyEpNTQVg6ZzsqmF0//59jB8/Hi+++CLGjRsHgPVeFRYWIiQkBAUFBaa5RkJDQ3H58mXT\nvleuXIFarUZoaCiuXLlisT40NNTu8VJSUqDRaAAAQUFBGDBggOktLu+XIOXyiRMn8MYbb8hGj71l\nfp1c9NhbttYqtR5v6LP2T3I/vU9ESU+Qgsj6eI3iXC/WGuWWHr+ckPAMSktvokULf2zb9h/Z1kd3\n9axcuRIATPdrTxAdHY3KykokJibi+++/R48ePURJd8WKFUhKShIlLYIgCKLh4lJ0wfz8fJw/fx4j\nR45EWVkZqqqqEBgYWOs+HMdh8uTJaNeuHT7++GPT+jlz5qBdu3aYO3cu0tLSUFJSgrS0NOTk5CA5\nORmHDh2C0WjEyJEjcf78eahUKkRHR2Pp0qXQ6XR48sknMWPGDBufLCVEFzQYDFaNNPlBGt1HbH2e\niYy3G0CMzKML7gYbMth4ogt6Il25Xy+eunefOXMGERER9do3Pz8fY8eONflk8bz//vs4duyYw54s\nlUqFZ55ZYFrWavXQavX10kAQBEF4hpwcA3JyDKblH35YKE0I9y+//BJfffUViouLkZeXh3PnzmH6\n9On46aefak143759+NOf/oR+/fqZer4WLVoEnU6HxMREXLp0ySaE+wcffIAVK1bA19cXS5YswahR\nowCYQ7iXl5cjPj4eS5cutc2IAowsgqgPcjYQKIS7/I0suSPHe7c9I2vlypX46quv8NNPP6F58+Z2\n96MQ7sqgTRvgppjBWgmCUDSSzZPVv39/HDp0CEOGDMHx48cBAJGRkTZv+KRGjg9qghADORsIZGSR\nkeUucrx3WxtZmZmZmD17NrKystC+fXuH+5GRpQzatgWK3Z9ykCCIBoJk82Q1a9bMFPACgMWExETd\nsPVjkR+k0X3kro9hkFqACxikFtAgUEZ9lA9JSUl49NFHcfbsWXTp0gUrVqzA66+/jjt37iA2NhZR\nUVF47bXXpJZJuAE1YQiC8AZOA18MHz4c77//PsrKyrBjxw4sW7YMY8eO9YY2giAIgqgXd+/exT/+\n8Q9cunQJX331FXJzc3H27FmMGTOm1v3S09Nt1k2dOtVTMgkJICOLIAhv4HS4YHV1NZYvX47t27cD\nAEaNGoWXXnpJdr1ZchxyQhBiIOehbjRckIYLuoun7t2JiYkYNGgQvvnmG5w+fRp3797Fo48+il9+\n+UX0Y/HQcEFlEBoKKHS6TYIgPIBkwwV9fHzwyiuvYN26dVi3bh1efvll2RlYBEEQBCEkLy8Pc+fO\nRdOmTQEArVq18urxhw71TLpPP+2ZdBsiQ4bYX6/VeldHQ+bBLDyNjshI7xynZUvvHKc2EhLYt5Og\n4pIQFlb/fR88GjyKUyOre/fuNh+x5htpbCjBN4I0uo/c9TEMUgtwAYPUAhoEyqiP4tOsWTOUl5eb\nlvPy8iz8ix0xdepUBAcHI1LQiiouLkZsbCx69eqFuLg4lJSUOE2nS5f66XaGg8CGisDbDUZHMUqa\nOG35EPawd/48Vc/FxsdH3PS8dR0GBLifhrvGEf9+qk0b97WITUhI/ff1Rn6c3moOHz5s+uzduxcz\nZ87E888/73llBEEQBFFPUlNTMXr0aFy5cgXJycl4/PHHsXjxYqf7TZkyBZmZmRbr0tLSEBsbi3Pn\nzmHEiBFIS0vzlOwGTU2Nd4/naPQPDcZpfCj1nDeSUeP1xp3z6o064dTIat++vemjVqvxxhtvYOvW\nrS4lbu+NYGpqKtRqNaKiohAVFYUff/zR9N+iRYsQHh6OiIgIkw8YwObJioyMRHh4OGbOnFmX/MkK\nOU8IykMa3Ufu+hh6qQW4gF5qAQ0CZdRH8YmLi8P69evx9ddfIzk5GUePHkVMTIzT/YYNG4Y2Vq84\nN2/ejMmTJwMAJk+ejI0bN3pEc0OHGozKRsnnT6lGlpxQ8vmXCqfRBY8ePWrywaqpqcGRI0dQXV3t\nUuJTpkzB66+/jkmTJpnWqVQqzJo1C7NmzbLYNicnBxkZGcjJyYHRaMTIkSORm5sLlUqF6dOnY/ny\n5dDpdIiPj0dmZiZGjx5dl3wSBEEQjQDhMwsAOnXqBAC4dOkSLl26hIEDB9Y5zaKiIgQHBwMAgoOD\nUVRUJI7YRoa3e7IcQQ1u8VBKWSpFpycQyzhqaEaWN+qEUyNr9uzZpgeWr68vNBoN1q5d61Liw4YN\nQ35+vs16exE8Nm3ahKSkJPj5+UGj0SAsLAzZ2dno1q0bSktLodPpAACTJk3Cxo0bFWlkGQwG2b9V\nJo3u07JlAMrL7yAgoA1u35brjJcGqQW4gAHUm+U+cr9exEb4zLLH7t273UpfpVLVmv66dakAgLNn\ngepqPbRavVvHE5MmTaQ1dCIigAfzO4uOSiWPRqCvL1BVJd3xfXwAV96D16e8evYEfv3Vcp2L79xd\nomlToLJSvPSEiN2gbttW3PTsoVIxn7dr1+q2X7t2wI0bntEkpG9f2/qgFHJyDDh40IArVzx7HKfD\nBQ0GA3bv3o3du3djx44d+Oqrr/DQQw+5ddBPP/0U/fv3x7Rp00wOxFevXoVarTZto1arYTQabdaH\nhobCSLFXCRlTXn4HAIfS0ptSSyGIRofwmWXvUx+Cg4NRWFgIACgoKEDHWkKqTZiQigkTUpGamiqK\ngTVqFPt2NYpWt26263jH92eecVuOQ4YNM/+uS1Q/YePXnYbwc89ZLiclOffJSkpyLW0fH+Dxxx3/\nL3S+lzo4QGKia9v16we4EAfGAnsR9fz86n/erOuqMJiEveAkSUmunzMACAqyv16MYBJiGlmdO1su\n89d6nz7MsHUFjcb8Oy7Oub6ICNt1SUlA166O9+Gvpz/9iX3bqw/8Onvv9cSI5mcdfKW+dU+r1WPJ\nklTT/dpTOO3J+uijj2ze2vE9UfzQv7owffp0vPPOOwCAt99+G7Nnz8by5cvrlIYjUlJSoHlQ04KC\ngjBgwADTG1w+wpbUyzxy0aPEZb1eLys99pate4rkl54l7tZnueqzTM+sUW7p2ZanZQ9UQ7peDAYD\nVq5cCQCm+7UnKC8vx7Jly7Bv3z6oVCoMGzYM06dPR/N6hAVLSEjAqlWrMHfuXKxatQrjxo3zgOKG\nQ10aPsIeFbn0RhGuI/UwPFfrjNQ6a0OMOi/WdeNKObnSG+6t8pb7/cLpZMTJyck4fPgwEhISwHEc\ntmzZgsGDB6NXr14AgAULFtR6gPz8fIwdOxan7IwREP7HR2uaN28eAGD06NFYuHAhunXrhpiYGPz2\n228AgPT0dGRlZeGLL76wzAhNRkzIBLlPfEuTEcurDL2Rrpzx1L372WefRWBgIF544QVwHIc1a9bg\n1q1b+P7772vdLykpCVlZWbh+/TqCg4Px7rvv4qmnnkJiYiIuXbpkGjIfZOc1uXAy4qQkID3d/XyM\nHg1kZgLh4UBurvN0u3UDLl60XNe6NXDrFvDss4CT7NebP/0J2LOH/X7kEeDnn223mTgRyMiwXNdE\nMIRR+LuuWJdLUhLL87ZtttvGx7P1rp4jHx9g+HBg1y77/4eEAA86OtGhA/DHH3XXLxau5qlfPzak\n9d4999KOjgYOHapfY9e6rgYGArdvs9/26gLfiyXUUJuRFRQE8LMttGwJlJWx3wEBQGlp3fVaaxHj\n+gaATp2AggLzclgYcP48G46n1QKueOgIyzIpCfjvf4HiB94K9vIbEQGcOWO5LikJOHgQuHDBdn16\nunkS78ceA/bvt18GkZFsSPDjj9teL82a1a2+2aNVK+DuXfPysGHA3r31S0uo31OTETvtybp8+TKO\nHTuGgAf9qwsXLkR8fDz+/e9/1+uABQUFJkfkDRs2mCIPJiQkIDk5GbNmzYLRaERubi50Oh1UKhUC\nAwORnZ0NnU6H1atXY8aMGfU6ttQI30zLFdLYWDBILcAFDCCfLPdprNfL6dOnkZOTY1p+/PHHoXVh\nFtp0By2nnTt3iqZNKrz1drm+x5Grvrq0vRrJuxETcu4hIhj26qSj89akFiciPp369mQ1tmsDcMHI\nunbtGvz8/EzLfn5+uOaiF57wjWCXLl2wcOFCGAwGnDhxAiqVCt27d8e//vUvAIBWq0ViYiK0Wi18\nfX2xbNky0zDFZcuWISUlBeXl5YiPj1dk0AuCIAjCewwcOBA///wzHnnkEQDAwYMHMWjQIIlVeR5f\np091M35+wP37ntPiCp4MxNEYG3V1QYzykbORJcyfnHV6Ak++6JBLlFAl4DTwxaRJk6DT6ZCamooF\nCxYgOjraNF+IM9LT03H16lVUVlbi8uXLmDp1Kr755hucPHkSv/zyCzZu3GgKiwsA8+fPx/nz53Hm\nzBmM4r19AQwaNAinTp3C+fPnsXTp0npkUx4o4W0yaWws6KUW4AJ6qQU0CBrr9XLkyBE89thj6Nat\nGzQaDR599FEcOXIEkZGR6Nevn9TyaqVvX/NvvtHTr585+MKAAWzIDv+YFDqg9+1r36mdZ+hQ828X\npg2zoX1759vwmnkn+trejgsR5luII+f/+HjX0rUmIMAyUIcQRxH+a4l1AsCyXB97zPybDxLgCEFT\nx25aQp0jRlj+B5gDDISGAj16sN/8d13Qai3Pratl26WL+XdTQWCDuDgWuGHQIDZ81B61NdaFBlKL\nFpaBR4YPt7+Pdd20t11sLDB4sOW6yEimU4i1u6iw3Otb7+zh6L1PTAy7joVGj726GREBPPkk+2/Y\nMFZHrHng3WOBVmu+/vv0Meepf3/L7fggNsOHm891t26Oz8FDD7GhzR062P+/rvB1p21bYMwYc73Q\n6VheO3dm0RRdoT7Xhbs4fef1t7/9DaNHj8a+ffsAACtXrkRUVJTHhREEQRBEfcnMzBQ9zUWLFuHb\nb79FkyZNEBkZia+//hrNrEK0Cf0f6uuDEBnJfDIqKszrmjYF+HeSvXtbbh8aag6N3rIlawydOWM/\nnHeXLmZ/F0eNkxYtgPJy+/9ZR/eqjago4NIl1kC6ft359o564QSDaSxo3Zp9O4oiV1t0QUHQYgt6\n9ACOHbO/D2BZpsHBAD9lmtDYCA21/9sefBQ4YbrCtNRq9rlyxb6h98D7Al26AN27s9/R0cDvv5v3\ndyVMdf/+wE8/mZf5srWmTRvgpiBwro+P2S9q6FCzH067dpb1y56PnvV5FRoULVowH63CQnYdCd7H\nW0TjE/pktWljWc9atbI9Zvv2Zr8vHt64P3rUvO6RRwDhDETCcyIsG3d98Hr1Yn5O1vARK4WGaIcO\n7IVDXp55Xdeu5uihjuq0ry/g7w/cuWNe17Sp+RiRkeayFxrKwkiOnTubfb58fGwjIvL4+QEPP2xe\nHj4cyMqyv609X7Hmzc33vRYtmLErNHj5cy188RIX55p/nFptvi68hUvvl8rKyhAQEICZM2dCrVbj\ngrVXHOES9iKIyQ3S2FgwSC3ABQxSC2gQNNbrRaPRoHXr1rh9+zaKi4tNH41GU6+ohvn5+fjqq69w\n7NgxnDp1CtXV1fjuu+9sthN74k9Xhu8420YuQ6Wc6VDC8D65lKUY1Ke8a+t9qmvZ1LZ9fcq5tvwI\n01NCPXMVV8upoeRZaflw2pOVmpqKo0eP4uzZs5g6dSoqKyvxwgsvYP/+/d7QRxAEQRB15u2338bK\nlSvRo0cPNBGMV6vvXFmBgYHw8/NDWVkZfHx8UFZWhlBn3RReQg4ND7Hmu2oIiJ1/d9ITW4urhowr\n1La9q0NMpcbb1159jieH+wMgr1D13sKpkbVhwwYcP37c5DAcGhqKUndjXzZSlOAbQRobC3qpBbiA\nXmoBDYLGer1kZGQgLy8PTYXjX9ygbdu2mD17Nrp27YoWLVpg1KhRGDlyZK37uNPAVVpjwh5SG1ti\n9yoC9vMkRj6lON9iN9il7slqKNSWd6XdF7xp5MsRp+8KmjVrZvEW8K4wQD1BEARByJA+ffrgptB5\nxE3y8vLwySefID8/H1evXsWdO3fqNZVJXedCdqWRYv3Wn3cTa9GCffO+Mc7SatPG/Jv383BVD38s\noG5+W0L/FkdpO/IP4o/F+zVZY+Uu5xL2NAh9oewNO+PLrWlTSy28878r59zHp246xYD3yakLjsoa\nqD2f9s6F9XkV1rlOnWo/Fg9fxq1aMb8jR7Rvb/5f+N7FkT9fbTp5+PMdFORaQJj6IKxvfn62Whxd\nM66UXV2xd13zfnWOrrXarkF7ZSb0o7P3f/v29c+b8B7lLZz2ZD377LN49dVXUVJSgi+//BIrVqzA\nSy+95FLiU6dOxdatW9GxY0fTZMTFxcWYOHEiLl68aDOp46JFi7BixQr4+Phg6dKliIuLAwAcPXoU\nKSkpqKioQHx8PJYsWVLf/EqKEuarIY2NBYPUAlzAAOrNcp/Ger3Mnz8fUVFR6Nu3ryk4hUqlwubN\nm+uV3pEjR/Doo4+i3QOL5ZlnnsGBAwfw/PPPW2y3Zk0qKivZRK8+PnqEhelN/z37LGtM865cXboA\nly/bP56rb2wnTrScnBNgDuUAM67i41lDTOgsb02vXixIBWCeLDg+num0Dp5hbxiXXs8MDV9foKqK\nHXfiRHPQj9qMuz59mPM+x7HJlu3RoweLaMank5FhbmwmJNhu/9xz7LtVK6YDYPk/csT+tqdPmwOH\nAGyf48eBc+fYb2v9wkluARb5EQCeecZyOz7S27hxLH982TZtClRWAomJ5m39/FiQAH46NmF4fXvl\n9+STtRsVAwfaD+AhnBB66FBzXbTextG6Rx5hAQTseYz4+9vfFwCeftr2WOHhbOJdfn1YGLseIiNZ\nvQCAnJza648wQmZpKXDihK1u6/1btDBP8i2cEei554ADB1iwFmGe+f2jo4HsbPP21uebv2atJ9y2\nJjGRBSM5cMBWa237BgSwoDcREfbPm5CoKMfXk/UxrcvH0Tns0MH2v/HjmZa4OFsjxnpblYqtu3SJ\nBUKJjmY6f/jBvE1wMHDjBovQKQw2wuMsWifPc8+x4D2bNpnXtW3LIrOeOAF07GhAaqoBt26Zz7cn\nqNXI4jgOEydOxJkzZxAQEIBz587hvffeQ2xsrEuJT5kyBa+//jomTZpkWpeWlobY2FjMmTMHixcv\nRlpaGtLS0pCTk4OMjAzk5OTAaDRi5MiRyM3NhUqlwvTp07F8+XLodDrEx8cjMzOT5soiCIIgHDJp\n0iTMmzcPffv2NY3GULkxdiUiIgLvvfceysvL0bx5c+zcuRM6nc5mu+TkVNy5wyJzbdhgGSHQOnqe\nGMOCnPmu+Pg4n9dGpbJNh9dmrdGeZn5fYRpNmrg+VEilcr6tdU+PI33W63hNjiIUqlS2aTdpYj9P\njrRaa7EOWmK9jzBSofVx7eXBHkKN9nBlstm6TEjLr3N2rhxpcrSPvfV8xEJXcKWcaltvfV6s63Bt\nablybdjDx6f2MnaGmEPw6qqjtjKwV5+t7z3C+0JtdclRHahLvagtHyNG6DFihB5GI7BnD/DDDwtd\nS7iOOO3Jio+Px6+//mrqVaoLw4YNQ74wBiaAzZs3I+tBPMfJkydDr9cjLS0NmzZtQlJSEvz8/KDR\naBAWFobs7Gx069YNpaWlpofZpEmTsHHjRkUaWUp4m0waGwt6qQW4gF5qAYonMLAtSktvIiCgDW7f\nLpZajlfx9/fHjBkzREuvf//+mDRpEh5++GE0adIEAwcOxCuvvCJa+o6Qm2+KJ30i6pJXT5WLK5Ea\nrY2pulLX/dyJtCe3+kN4B2EdU5ofkyfxdlnUamSpVCoMGjQIhw4dsvvGrj4UFRWZJiAODg5G0YNJ\nJq5evYoh/KxnANRqNYxGI/z8/KAWBP8PDQ2F0d6kAgRBEIQFpaU3AXAoLW18La1hw4bhrbfeQkJC\ngsVcVgMdzTbrAnPmzMGcOXPEkOcUMRsDnm5ou9pL4SxPcmoM1qXnpT7bOENOZWGNXLWJUe5KM0ob\nWwj3uuBK2Xi6XJz2ZB08eBDffvstunXrhlYPPNJUKhVOnjzp9sFVKpVbwzesSUlJMc1/EhQUhAED\nBph6Pfi5YqRcPnHiBN544w3Z6LG3zK+Tix57y9ZapdZjb9na50l+6X0iSnqCFETWx2sU53qx1ii3\n9GzL09KXyr30DKKlJ9b1u3LlSgCo13xVrnLs2DGoVCocPHjQYn19Q7i7SlWV+bcY0QU90eiTIsiC\n2EjVGPaWAeVu48+bjWqlGSZyQ8yIjXJD6frdRcVx9k/vpUuX0LVrV+Tn50OlUsF6M1cfjvn5+Rg7\ndqwp8EVERAQMBgNCQkJQUFCAmJgYnDlzBmlpaQCAefPmAQBGjx6NhQsXolu3boiJicFvv/0GAEhP\nT0dWVha++OILy4zY0Sg3hI0cudKYNHpqKBV7ccABEKdOeia93QBi3E7PrA0QS5853d1gQwbdT1fu\n58RT6Yp5rj2FEu7drqJSqbBhA4fycuaTdfkysG+f+f+kJPadns6+Y2OB8+eBCxfM22g0LLjAxYvM\nn6FrVxZkoDaH79JSYMsWoHNnFjwBYIEcOndmQSg4jjmnT5zI/BSMRpZ2ly4swEP37uYoa+fPs4hg\nXboAv//O/MiOHGER9po3Z0EorlxhwSJ4xo9nwRx+/50FBuDzee8ec2rv2BG4do05o2dlMcf2ykq2\nzaOPsqAWAAs0cfQoc+5/8MhHeDjw8MOW+T17lkWi69TJcn16OmvU8YEvhOTnM2f77t0BwaAZAOxY\nJ06w9IYPZ2ncusXywwcE4cumeXNmpN66xYJ9FBczvdYYDCwgiPW6zp1ZgIDffzefq/R0tu7JJ1n5\nDR3KnPGrqlh537gBXL3KAkIAzIfkscfMxvKpUyxohDDwwJ07LF/duwMFBcAffwBFRezc5OSweuXv\nb66LSUksOMihQ+bzd+YMqx/8/zyXLpkDXyQlmetq9+625SCEPxYADB7MNAvXx8QAu3cDY8eag3o4\nOtc7drD8Dh1qXsdfBzxCzdbcugVs22a7TXExq998MBMhfB2qLV3hdgALtvDQQ+ZlXldFBSvbRx4B\ndu0yn5uzZ1nUR2EUwfR0832B5+ef2XGefdbW1xNg1/yePez6794duHmTBYLgg784y0NdSE+3PGfW\nOvggHQMHsrIoLwd++YVdhzU1lsE+tFpWP//0J6Au0xCePMnq4Z07bDkpyXz/Adh9b+JEVkfOnjXf\nU8rLWT0fONAzzyGHPVlPPfUUjh8/Do1Gg/Hjx2P9+vWiHDAhIQGrVq3C3LlzsWrVKowbN860Pjk5\nGbNmzYLRaERubi50Oh1UKhUCAwORnZ0NnU6H1atXizrO3pvI3XgBGpfGxjyUShn+TnqpBTQQ9FIL\nkIwtW7YgJycHFYLoE++8845Hjyl8c9ulC2swFRbahiNu1oyta9+eGVkhIZaR0njDA3A9ohbfaAfM\nDXJ7CBsvQiMCMDd8AdbAB1iDXEjbtszIatqUGVj20gXsBwbQ61kjh498Z69d07mz2ciyNrAA1lBz\nhL/kNFwAACAASURBVLPw8dYGlhDho6V169rLhm/0P/B+qDUte+vsRU7z8zMbDcIyb9fOHIYfsK0P\n9s61vz8zZABWx377jTXkAdaQ5ena1RxdzTpsf0QEMwSc9XwK66orjBtXezhtYWPd0bl2Mf5anWnb\n1v3w5xoN+6SnsxcMGo2lkQUwY11oNPE4yq/1dRAczIwsewYWwK414f2AD41+5Ijlem/CXystWpiv\nwyZNgJ49a49+6gr9+rHPunXmqJxC+DocEGBZli1a2F7nYuJSLJPff/+9XoknJSXh0UcfxdmzZ9Gl\nSxd8/fXXmDdvHnbs2IFevXph165dpp4rrVaLxMREaLVaPPHEE1i2bJlpKOGyZcvw0ksvITw8HGFh\nYYoMekEQBEF4j1dffRVr167F0qVLwXEc1q5di4sXL7qVZklJCSZMmIDevXtDq9XaDEW0h6PhMg2h\n885TQ4EaQtkoBSrrxofczrmzyb6VjFOfLHdIF/YNC9jJTwRhxfz58zF//nyb9YMGDTINN1QyjWko\nnidRgkb5Y5BagAsY0Jh7YcTDILUASThw4ABOnTqFfv36YcGCBZg9e7bbL+hmzpyJ+Ph4rFu3DlVV\nVbhrPUFVI8OVSHyEa8it4UsQYtMY7wcOjayTJ08i4MGMhuXl5abfABt3fvv2bc+rIwiCIIh60OLB\neKSWLVvCaDSiXbt2KCwsrHd6t27dwt69e7Fq1SoAgK+vL1oLHSccIIeGhbc0yNlQkMN5aCjI9TzT\nOXYNuZ6/hohDI6taOMU7IQpK6H0hjY0FvdQCXEAvtYAGgl5qAZIwduxY3Lx5E2+++SYGDhwIlUqF\nl19+ud7pXbhwAR06dMCUKVPwyy+/YNCgQViyZAlaWjkBtWjBnKl5mje3/AaY7421T4o3Gj5iT2Jq\n7f/UxMFEpcK8A47zyvuXWKcjBo58VwDHExV7Cx+f2n2UPAnvq+OIZs2Y752Q2srSHdxN1xP1Rkh9\n6glfdu3bs0AmJSW22whmmPCoFh5PnD93yl5Yv9y9Flu2BMrK3EtDTDw6XJAgCIIgpODtt98GAIwf\nPx5jxoxBRUWFSz1PjqiqqsKxY8fw2WefYfDgwXjjjTeQlpaGd99912K7vXtTwXFAaip7ITRsmB5h\nYZbRwsaOVf5b93HjbBtWTZsCY8aYl319gdGjmbO50LncUYOse3dmkPEGR0KCeHpDQy21CenZkwUe\nkYqnnvJ8fXBk2EZGsgiOjnjySVtttZWlO7Rv7166zoKeuEvnzkB8vOvbJySY6/KwYezbXlCG6GgW\nea8uqNX1K6sxY9j1KCZjxjgue5WK/S+M+mhNv35Ar16sjrZsySJ91peRI117YWUwGOxOnSI2ZGR5\nESX4EpHGxoJBagEuYEBj7YURF4PUArzKoUOH0KVLF3R6EP5t1apVWL9+PTQaDVJTU9G2nqHD1Go1\n1Go1Bj8I2TZhwgTT1CNC3nsv1WadMDIcUL8313LDUR6sG3Bt2rBv4dtzR0aWSsUasnwYZme9LHXF\nUeNSpbIfftpbSFkffH1rz7ur51ksPJWuGKhUli9LnCGsv/Z6tHl8feveu6RS1a+sPFG+ztJ09r+P\nj3jXunWvqyP0er1FO3LhwoXiCLDCw52rBEEQBOE9Xn31VTR70DLcs2cP5s2bh8mTJyMwMBCvvPJK\nvdMNCQlBly5dcO7cOQAsgFOfPn1E0UwQnsYbEyATnkPpPd+NFerJ8iJK6H0hjY0FvdQCXEAvtYAG\ngl5qAV6lpqbG1FuVkZGBV199FePHj8f48ePRv39/t9L+9NNP8fzzz6OyshI9e/bE119/LYZkr8Fx\n1FgjCCVCBrAykawnS6PRoF+/foiKioJOpwMAFBcXIzY2Fr169UJcXBxKBB6CixYtQnh4OCIiIrB9\n+3apZBMEQRAyprq6GvcfOD7s3LkTMYIZfquqqtxKu3///jh8+DB++eUX/PDDD275eBEMe41HalCK\nD5UpQXgfyYwslUoFg8GA48eP49ChQwCAtLQ0xMbG4ty5cxgxYoRpvHtOTg4yMjKQk5ODzMxMvPba\na6ipqZFKer3xhpOdu5DGxoJBagEuYJBaQAPBILUAr5KUlIThw4cjISEBLVu2xLAHHue5ubkICgqS\nWJ19OnUCunb1/HGU0otlz2+FcI+OHZ37vXjLL83a4BMz6IhG49p2SqtjPj5SK3AfV8u8SRMgMFC8\n44aF1R7cxZNIOlyQs7rSNm/ejKysLADA5MmTodfrkZaWhk2bNiEpKQl+fn7QaDQICwvDoUOHMGTI\nEClkEwRBEDLlb3/7Gx5//HEUFhYiLi4OTR5EWeA4Dp9++qnE6uzj7ghoV3opkpLcO4Y38fNTll4l\n0LGj82iNLVtKU+6Czma3eeQRoLAQqKiofbtmzZRTx5SiszbqkoeJE8U99oNYRZIgmZGlUqkwcuRI\n+Pj44NVXX8XLL7+MoqIiBAcHAwCCg4NRVFQEALh69aqFQaVWq2E0GiXR7Q5K8CWSu8bAwLYoLb2J\ngIA2uH27WGo5CkYvtQAX0EstoIGgl1qA13nkkUds1vXq1UuUtKurq/Hwww9DrVbjP//5jyhpEgRB\nEA0PyYys/fv3o1OnTvjjjz8QGxuLiIgIi/9VKhVUtYxtsPdfSkoKNA/6ioOCgjBgwACT0cAPMaNl\nZS+Xlt4EwKG0VGURyr2+6fGIrdd6iFZDTU+Qgsj6+DTrt7/j9MTWJ056tuVpOVWBXNITY9lgMGDl\nypUAYLpfK4klS5ZAq9WitLRUaikEQRCEjFFx1mP2JGDhwoXw9/fHV199BYPBgJCQEBQUFCAmJgZn\nzpwx+WbNmzcPADB69GgsXLgQ0dHRpjRUKpXN8EO5IWzkyBW5a2TG9W4AMW6fb5YWB0DcuiN2up5J\nT+wyBMQsR7NGvSjpyv2ceCpdMc+1p1DCvZvnypUrSElJwd/+9jf84x//sOnJkiovt28DW7cqZ1jR\n+fPA4cPs95AhbBJiMUhPZ35FY8eKkx4hLunp7Puppzw7cfCGDWy4oFKuB8IzVFYC69e7Vg88de+W\nJPBFWVmZ6S3g3bt3sX37dkRGRiIhIQGrVq0CwCaQHDduHAAgISEB3333HSorK3HhwgXk5uaaIhIS\nBEEQhDf4f//v/+Hvf/+7yc+LkB8KsdcJgmgESDJcsKioCE8//TQAFlL3+eefR1xcHB5++GEkJiZi\n+fLl0Gg0WLt2LQBAq9UiMTERWq0Wvr6+WLZsWa1DCeWKnHuIeJSgsTH6mIiPXmoBLqCXWkADQS9K\nKrw/JIBG6RO5ZcsWdOzYEVFRUXaHY/Kkpqaafuv1eoXcU71L9+6sJ+NBnCvRGD2aBc0g5MnQoezb\nk71YADByJFBd7dljEPKnaVNznbPGYDDUeh8XC1kMFxQDJQ05IeqPmMOplDXkS57peXa4oHjpyrkM\nPZmuUs61Eu7d8+fPx+rVq+Hr64uKigrcvn0b48ePxzfffGPahoYL1o30dHGHCxIEQdSHBjVcsLHi\nDavZXZSgsbHN++MZDFILcAGD1AIaCAapBTQIPvjgA1y+fBkXLlzAd999h8cff9zCwCIIgiAIIWRk\nEQRBEEQdUeKQdTmigE5MgiCIekHDBQmPIva8VjRcUF7p0XDBxlN3GvtwQVeg4YJ1Iz0diI4GevSQ\nWglBEI0ZT927JZsni2gcCOe1IgiCIMRHycEeWrWSWgFBEIRnoOGCXkQJ/k5K0Eg+JmJgkFqACxik\nFtBAMEgtgPAwLVoAEydKraLuTJwIBAdLrYIgCMIzKMbIyszMREREBMLDw7F48WKp5dSLEydOSC3B\nKUrQCChBo9xRQhkqQaMSoHIUg8uXLyMmJgZ9+vRB3759sXTpUqklWaCUqbuEL/KUolkKlPHCU1qo\njFyDykk6FHGLq66uxl/+8hdkZmYiJycH6enp+O2336SWVWdKSkqkluCQwMC2UKlUmDv3LamluIB8\ny1E5KKEMlaBRCVA5ioGfnx8+/vhjnD59GgcPHsTnn3+uyOeQ1FCDzzWonJxDZeQaVE7SoQgj69Ch\nQwgLC4NGo4Gfnx+ee+45bNq0SWpZDQred6qyskJqKQRBNAL4FztKISQkBAMGDAAA+Pv7o3fv3rh6\n9arEqgiCIAi5oggjy2g0okuXLqZltVoNo9Ho0WOuX78eEydOxOzZs1FaWipKmvn5+aKkA5gbKIGB\nbUVLUznkSy2gAZAvtQAXyJdaQAMhX2oBduFf7CiR/Px8HD9+HNHR0VJLIQiCIOQKpwDWrVvHvfTS\nS6bl1atXc3/5y18stunZsycH9sSmD33oQx/6KOTTs2dPbz9S3KK0tJQbNGgQt2HDBpv/6DlEH/rQ\nhz7K+3jqOaSIEO6hoaG4fPmyafny5ctQq9UW25w/f97bsgiCIIhGxP379zF+/Hi88MILGDdunM3/\n9BwiCIIgeBQxXPDhhx9Gbm4u8vPzUVlZiYyMDCQkJEgtiyAIgmgkcByHadOmQavV4o033pBaDkEQ\nBCFzFGFk+fr64rPPPsOoUaOg1WoxceJE9O7dW2pZBEEQRCNh//79+Pbbb7F7925ERUUhKioKmZmZ\nUssiCIIgZIqK4zhOahEEQRAEQRAEQRANBUX0ZNWG3CeI5KmurkZUVBTGjh0rtRS7lJSUYMKECejd\nuze0Wi0OHjwotSQbFi1ahD59+iAyMhLJycm4d++e1JIwdepUBAcHIzIy0rSuuLgYsbGx6NWrF+Li\n4iSfH82exjfffBO9e/dG//798cwzz+DWrVuy0sfz0UcfoUmTJiguLpZAmRlHGj/99FP07t0bffv2\nxdy5cyVSx7Cn8dChQ9DpdIiKisLgwYNx+PBhCRU6vl/L7ZqpD5mZmYiIiEB4eDgWL14stRyvo9Fo\n0K9fP0RFRUGn0wGo/bwuWrQI4eHhiIiIwPbt203rjx49isjISISHh2PmzJlez4eY1PX5UNcyuXfv\nHiZOnIjw8HAMGTIEFy9e9E7GRMReGaWmpkKtVpt6jH/88UfTf42xjID63TsbW1k5KiNJ65NHwml4\nkYKCAu748eMcx7GoT7169eJycnIkVmXLRx99xCUnJ3Njx46VWopdJk2axC1fvpzjOI67f/8+V1JS\nIrEiSy5cuMB1796dq6io4DiO4xITE7mVK1dKrIrj9uzZwx07dozr27evad2bb77JLV68mOM4jktL\nS+Pmzp0rlTyO4+xr3L59O1ddXc1xHMfNnTtXUo329HEcx126dIkbNWoUp9FouBs3bkikjmFP465d\nu7iRI0dylZWVHMdx3LVr16SSx3GcfY3Dhw/nMjMzOY7juG3btnF6vV4qeRzHOb5fy+2aqStVVVVc\nz549uQsXLnCVlZVc//79Zfkc8iT2rlNH5/X06dNc//79ucrKSu7ChQtcz549uZqaGo7jOG7w4MFc\ndnY2x3Ec98QTT3A//vijF3MhLnV5PtSnTD7//HNu+vTpHMdx3HfffcdNnDjRa3kTC3tllJqayn30\n0Uc22zbWMuK4ut87G2NZOSojKeuT4nuylDBB5JUrV7Bt2za89NJL4GQ4OvPWrVvYu3cvpk6dCoD5\nwLVu3VpiVZYEBgbCz88PZWVlqKqqQllZGUJDQ/8/e+ceF0X1///XInhBDcS7oKJiKopcBNHUxEup\nlHhX7JO31Mi8ZPXpU3YTv6WZdlMps36V+UnxQn5EDai8rJUGiKCZmCJKAirmNRERWOb3x2l2Z3dn\nd2eX2Z1deD8fDx7s7M7lNWfOzJz3eb/P+ygtC4MGDUKzZs30vtu9ezdmzJgBAJgxYwZ27dqlhDQt\nYhofeeQRuLmx2z8yMhJFRUVKSAMgrg8AXnjhBaxatUoBRcaIaVy/fj2WLFkCDw8PAEDLli2VkKZF\nTGPbtm21Xspbt24pfs+IPa+Li4ud7p6xlszMTAQEBMDf3x8eHh6IjY1FcnKy0rIcjuH7zdR1TU5O\nxtSpU+Hh4QF/f38EBAQgIyMDly9fxp07d7SesOnTp7tcXRBizfvBljIR7mvChAnYv3+/o05NNkw9\n/8XaSnW1jADrn511saxMlRGgXH1yeSNLiLNOEPn8889j9erV2kats3HhwgW0bNkSs2bNQlhYGObO\nnYuysjKlZenh4+ODF198ER06dEC7du3g7e2N4cOHKy1LlJKSErRu3RoA0Lp1a5SUlCisyDxffvkl\noqOjlZahR3JyMvz8/NC7d2+lpZgkLy8PP/30E/r164eoqChkZWUpLcmIlStXau+bl156Ce+8847S\nkrQIn9euds8YUlxcjPbt22uX/fz8tC/3uoJKpcLw4cMRHh6Ozz//HIDpZ+GlS5f0pmHhy8vwe19f\n31pXjnKWibDe8Z2jSodWy8W6desQHByM2bNna0PgqIwYUp6ddb2s+DLq168fAOXqk3O2+m2gtLQU\nEydOxJo1a9CkSROl5WjZu3cvWrVqhdDQUKf0YgFAVVUVsrOz8eyzzyI7OxuNGzfGypUrlZalR35+\nPj766CMUFBTg0qVLKC0txebNm5WWZRGVSgWVSqW0DJMsX74c9evXxxNPPKG0FC1lZWVYsWIFli1b\npv3OGe+dqqoq3Lx5E+np6Vi9ejUmT56stCQjZs+ejbVr1+LixYv48MMPtd5qpSktLcWECROwZs0a\nNG3aVO83Z79nxHA1vfbg8OHDyMnJQWpqKj7++GP8/PPPer+74nW1N1Qm4sybNw8XLlzA8ePH0bZt\nW7z44otKS3Iaatuz0x4Y2gNK1qdaYWRZmiBSSY4cOYLdu3ejU6dOmDp1Kg4cOIDp06crLUsPPz8/\n+Pn5ISIiAgAwceJEZGdnK6xKn6ysLDz00ENo3rw53N3dMX78eBw5ckRpWaK0bt0aV65cAQBcvnwZ\nrVq1UliROBs3bkRKSorTGav5+fkoKChAcHAwOnXqhKKiIvTp0wdXr15VWpoefn5+GD9+PAAgIiIC\nbm5uuH79usKq9MnMzMS4ceMAsPs6MzNTYUW65/W0adO0z2tXuWdM4evri8LCQu1yYWGhXk9oXaBt\n27YAWNjsuHHjkJmZafK6GpZXUVER/Pz84Ovrqxe6XFRUpHiIq9zIUSZ83fL19cXFixcBsE6f27dv\nw8fHx1GnYjdatWqlNRjmzJmjfW7V9TKy5tlZV8tKzB5Qsj65vJHFOfkEkStWrEBhYSEuXLiArVu3\nYujQodi0aZPSsvRo06YN2rdvj7NnzwIA9u3bh549eyqsSp/u3bsjPT0d9+7dA8dx2LdvHwIDA5WW\nJUpMTAy+/vprAMDXX3/tdIY/wDKhrV69GsnJyWjYsKHScvQICgpCSUkJLly4gAsXLsDPzw/Z2dlO\n1/AeO3YsDhw4AAA4e/YsKioq0Lx5c4VV6RMQEIBDhw4BAA4cOIAHH3xQUT2mnteucM+YIzw8HHl5\neSgoKEBFRQW2bduGmJgYpWU5jLKyMty5cwcAcPfuXfzwww8ICgoyeV1jYmKwdetWVFRU4MKFC8jL\ny0Pfvn3Rpk0bPPDAA8jIyADHcfjvf//rcnXBEnKUyZgxY4z2lZSUhGHDhilzUjJz+fJl7ef//e9/\n2syDdbmMrH121sWyMlVGitYnm9N4OAk///wzp1KpuODgYC4kJIQLCQlx2mxEarXaabMLHj9+nAsP\nD+d69+7NjRs3zumyC3Icx7377rtcYGAg16tXL2769OnarG5KEhsby7Vt25bz8PDg/Pz8uC+//JK7\nfv06N2zYMK5r167cI488wt28edOpNH7xxRdcQEAA16FDB+09w2fLUVJf/fr1tWUopFOnTopnFxTT\nWFFRwT355JNcr169uLCwMO7gwYNOoVFYF48ePcr17duXCw4O5vr168dlZ2crqtHU89rZ7hlbSElJ\n4R588EGuS5cu3IoVK5SW41DOnz/PBQcHc8HBwVzPnj2152/uui5fvpzr0qUL161bN20GTI7juKys\nLK5Xr15cly5duIULFzr8XOTE2veDtWVSXl7OTZo0iQsICOAiIyO5CxcuOPL0ZEHs/TRt2jQuKCiI\n6927NzdmzBjuypUr2vXrYhlxnG3PzrpWVmJllJKSomh9osmICYIgCIIgCIIgZMTlwwUJgiAIgiAI\ngiCcCTKyCIIgCIIgCIIgZISMLIIgCIIgCIIgCBkhI4sgCIIgCIIgCEJGyMgiCIIgCIIgCIKQETKy\nCIIgCIIgCIIgZISMLIIgCIIgCIIgCBkhI4sgCIIgCIIgCEJGyMgiCIIgCIIgCIKQETKyCIIgCIIg\nCIIgZISMLIIgCIIgCIIgCBkhI4sgCIIgCIIgCEJGyMgiCIIgCIIgCIKQETKyCMJJ8ff3x8qVK9Gz\nZ0/4+Pjgqaeewv3795WWRRAEQdQR6D1EELZDRhZBODFbtmzBDz/8gPz8fJw9exZvv/220pIIgiCI\nOgS9hwjCNsjIIggnRaVSYcGCBfD19UWzZs3w2muvITExUWlZBEEQRB2B3kMEYTtkZBGEE9O+fXvt\n5w4dOuDSpUsKqiEIgiDqGvQeIgjbICOLIJyYixcv6n1u166dgmoIgiCIuga9hwjCNsjIIggnheM4\nfPLJJyguLsaNGzewfPlyxMbGKi2LIAiCqCPQe4ggbIeMLIJwUlQqFZ544gk8+uij6NKlC7p27YrX\nX39daVkEQRBEHYHeQwRhO05jZGk0GoSGhmL06NFGv6nVanh5eSE0NBShoaGU2YaoM0RERODUqVO4\nefMmvvrqKzRs2FBpSQRR63jqqafQunVrBAUFmVxn0aJF6Nq1K4KDg5GTk+NAdQShLPQeIgjbcBoj\na82aNQgMDIRKpRL9ffDgwcjJyUFOTg71ohAEQRCyMWvWLKSlpZn8PSUlBefOnUNeXh4+++wzzJs3\nz4HqCIIgCFfEKYysoqIipKSkYM6cOeA4TnQdU98TBEEQRE0YNGgQmjVrZvL33bt3Y8aMGQCAyMhI\n3Lp1CyUlJY6SRxAEQbgg7koLAIDnn38eq1evxt9//y36u0qlwpEjRxAcHAxfX1+89957CAwMdLBK\ngnAsFy5cUFoCQRAAiouL9dJY+/n5oaioCK1bt1ZQFUHYH3oPEYTtKG5k7d27F61atUJoaCjUarXo\nOmFhYSgsLISnpydSU1MxduxYnD17Vm+dFi1a4Pr16w5QTBAEQchFly5dcO7cOaVlWMQwmkIstD0g\nIAD5+fmOkkQQBEHIgL3eQ4qHCx45cgS7d+9Gp06dMHXqVBw4cADTp0/XW6dp06bw9PQEAIwaNQqV\nlZW4ceOG3jrXr18Hx3Eu9zdjxgzFNZBu5/9zJt25uRzGj+fg68th+XIOxcXG69y9y+HDDzk0ajQD\nCxdyqKxUXrerlndt1sxxnEsYJb6+vigsLNQuFxUVwdfX12i9/Px8xcvT2f+WLl2quAZX+KNyojKi\ncnLcn73eQ4obWStWrEBhYSEuXLiArVu3YujQodi0aZPeOiUlJeA41ouYmZkJjuPg4+OjhFzZ8ff3\nV1qCTZBux+IMuk+eBGbNAgYPBvr1A/LygFdfBcTmpfT0BBYvBhYt8seZM8BjjwG3bjles604Q3lb\niytqdhViYmK076X09HR4e3tTqCBBEARhFsXDBQ3hQzA2bNgAAIiLi0NSUhLWr18Pd3d3eHp6YuvW\nrUpKJIg6w717QGoqkJAA/PEHMG8ecPYs4O0tbfuGDYHvvgOefx7o35997tzZvpoJwlqmTp2KQ4cO\n4dq1a2jfvj2WLVuGyspKAOwdFB0djZSUFAQEBKBx48b46quvFFZMEARBODtOZWQNHjwYgwcPBsBe\nbDzz58/H/PnzlZJlV7yltladDNLtWBypu7QU+N//2N/+/UBoKPD008DEiUD9+tbty9vbG+7uwLp1\nzFAbPBj4/nvA2fPWuGI9cUXNzkJiYqLFdRISEhygpPYTFRWltASXgMrJMlRG0qByUg6nMrLqIiEh\nIUpLsAnS7VgcoTsrC/j8c2DHDmDAAGZUffYZ0KKF7fsU6l6wgHnAhg1jHq2wMBlE2wlXrCeuqJmo\ne1CDTxpUTpahMpIGlZNyqDh+sJOLo1KpUEtOhSAcyt9/Ay+8wDxM8+YBM2eKj7OSi//9D4iLA779\nFhg0yH7HIVyD2vTsrk3nQhByotEA27cDU6cqrcS1qaoC3Mk9Ijv2enYrnvgCADQaDUJDQzF69GjR\n3xctWoSuXbsiODgYOTk5DlZHELWXAweA3r0BNzfg1CnTiSzkZNw4YPNmYMIEICnJvsciCIIglKe6\nWmkFNYPjnOMcduxgIf2Ea+AURtaaNWsQGBgoOu9ISkoKzp07h7y8PHz22WeYN2+eAgrth6m5wZwd\n0u1Y7KF7wwbgySeB9etZWOADD8h+CJO6H3kE+OEHloHwo4/kP25NccV64oqanYW0tDR0794dXbt2\nxbvvvmv0+82bNzFu3DgEBwcjMjISp06dUkBl3aSqijVwCUJJcnKYJ84Z+CcnD+ECKG5kFRUVISUl\nBXPmzBF11e3evRszZswAAERGRuLWrVsoKSlxtEyCqFV8+CGwciXw88/AqFHKaAgJAQ4fZgbewoX0\n4iCUQaPRYMGCBUhLS0Nubi4SExNx+vRpvXVWrFiBsLAwnDhxAps2bcJzzz2nkNq6x44dbLoIwnm4\nfBkwmKrULJWVLFzQlbl1i4x9wnoUN7Kef/55rF69Gm5u4lKKi4vRvn177bKfnx+KioocJc/uuOqA\nRNLtWOTUvXw58MknwKFDQJcusu1WFEu6O3YEjhwBzp9nCTGuXLGvHqm4Yj1xRc3OQGZmJgICAuDv\n7w8PDw/ExsYiOTlZb53Tp09jyJAhAIBu3bqhoKAAf/31lxJy6yR37yqtwLX59VdAMJd2jVGrWQeZ\nGBwHFBfrf5eUBKSny3d8gvHjj8CxY0qrIMyh6PC5vXv3olWrVggNDTUb6mLo4RILKwSAmTNnaifk\n9Pb2RkhIiLbhwe+flmm5Li9nZUXhm2+AlSvVOH8e6NBBeX3e3sCLL6rx9ddAREQUduwAysuV4UDk\nQwAAIABJREFU00PL9l1Wq9XYuHEjAOeYQFmsIy8jI0NvneDgYOzcuRMDBw5EZmYm/vzzTxQVFaFl\ny5Ym93v/PrBzp+sP9C8tBZo0UVpF3YLjABPNHNy8yYxOPz/T21++zMK/GzdmywUFQEUFIKjmNnH9\numWD96+/gJ9+Mq73towjunMHaNpUt8yPi6pXz/p91UauXWPPGcKJ4RRkyZIlnJ+fH+fv78+1adOG\n8/T05KZNm6a3TlxcHJeYmKhd7tatG3flyhWjfSl8KjZz8OBBpSXYBOl2LHLo3rSJ4zp04LiLF2uu\nRyrW6k5O5riWLTnu0085rrraPpqk4Ir1xBU1c5zyz+6kpCRuzpw52uX//ve/3IIFC/TW+fvvv7lZ\ns2ZxISEh3LRp07iIiAjuxIkTRvsSnsutWxy3ZYv+7+XlytZrni1bOK60VPq6V6/aV4+l42dn27bt\nX39x3I4duuXjxzlu1y5p296/z3FlZdLWra7muIoK6/WZYssWjisuFv8tLc24Xoltf+iQ/rJaLb7u\nX39x3J070nSlprJ9bdnCcbt36/926RIrg5ISY31btrDrYEn333/r6mVFhfH66ekct22bNK0cx3Hn\nznHc9u3S1zfHvn2W9TuCLVs47sYN3ec9e0yvu38/x12/Lm2/e/fa59lUXS2tzXHunPzHtgZ7vYcU\n9WStWLECK1asAAAcOnQI7733HjZt2qS3TkxMDBISEhAbG4v09HR4e3ujdevWSsglCJclNRV46SXg\n4MGa92bak5gY4JdfWAbCzEzg44+Bhg2VVkXUZnx9fVEoiKUqLCyEn4GboGnTpvjyyy+1y506dULn\nzp1F9xcfHw8AKC8HPDyiAERpf9u5k41F7NHDvKbKStaL7+3NMn/WlPv3gdxclkmU9wKUl+s8HZZQ\nejyNKa+OJW7c0B/r+ddfQFmZ+LqGXpN9+9h3U6ZYPs5vv7HyFfNalpay/bRta/54YttJpbKSXU9z\n+zPFjz8CzZsDjz5q/bZC1GrmPevbV/x3PjPfkSPAQw+Jr7N3L3vejxsnPv7p9m3r6uK1ayxxSl2l\npIR5NX18LK/799/28RLeuMHe6eY8+hUV7H1vzfCFnTuBxx8H6te3TZdardZGWNgTxcdkCeHDADds\n2IANGzYAAKKjo9G5c2cEBAQgLi4On3zyiZISZYcPp3E1SLdjqYnurCxgxgw2P5Wlxp3c2KL7wQeB\njAzWCBk61LoB1nLhivXEFTU7A+Hh4cjLy0NBQQEqKiqwbds2xMTE6K1z+/ZtVFRUAAA+//xzDB48\nGE1MxNDFx8cjPj4eS5bEIzAwyuj3e/fY/+vXTWs6fpzNW7dtm2X9UtJKX74M/PEHmwScR61mWv45\nLbNwHGvcJiZaXtcSFRXy7KemZGToX4O9e5kxymczLC+XnrKbD6G7cAE4d07/t8xMVtZCrl9nxwNY\nWVy9Kr5fqcmAjh7V7c8arL0OlhI//P235W0KC4GTJ03vw9CIcmQiz8xMZpip1YCjhv5XVLAQULm4\ncoXVWyn3tRwkJgL5+aZ/P3LE8j74ei419JHj2Lo1GasZFRWlfVbzHWP2wGmMrMGDB2P37t0AgLi4\nOMTFxWl/S0hIwLlz53DixAmEhYUpJZEgXI7CQmDsWJbBr39/pdVIp0kT1sAcMAB4+GHjgdQEIRfu\n7u5ISEjAiBEjEBgYiClTpqBHjx56nX25ubkICgpC9+7d8f3332PNmjU2H4/3rvzwg/735eW6DgWp\njfurVy0bYkLPjbBRUlHBGpTffsv+m+PWrZpn/7x6lRl1pjwLv/5q/hhVVcy7JBfnz7NrIPQYcRzL\nZnj2rG3es/R0ZvCYOseSEpYp0dCQEMuhUloqPo+gWOPZnLfm7Fn9ZY3GeH2pWfNMNdyFHWF8IgaN\nhiVX2rpVf93qauD33y0fiy//335j10RITg7rOJDK7dvApUuWG/H5+ezv8mXgzz/ZdyUlzJAwvEeu\nXwcMkpAa8d13TL85cnKAtDTz60ihuprdPwcPMu3ffmu8jkbDnjNi29aEzEzTvwnvrxMnjDshADZm\nEGAdq/fuGXdKGGLK8M7MdL5EIE5jZNVVHOGutAek27HYovvOHeZOf/55ZmgpQU3KW6UCVq8Gpk8H\nBg50bBpnV6wnrqjZWRg1ahTOnDmDc+fOYcmSJQD0O/v69++PM2fO4I8//kBSUhK8vLxsPtZffxk3\nNK5dY57m779n9fz8ed1vt26Z3pfQgCoqYj3iJ0+yhiFvxCUnm26E37nD/ltqfAq3z81ljU6hYZCX\nx7wYhqF4hYWsYXX0KLB/P2tQmqKggDWGxaiuZvsXM0ZMbSPElKcIAPbsMf5OrIf8xAldeVlixw5x\nwzQnh0UWGCIWGmi4LT9zjbkwQjFPEt/o5K/x/v3GRosUI6u01HSo5fff6z7zXpmkJGbYSD0Gf75i\nhrZh/f3jD2Pj0RyHDzODb+dO0+fAI7z3AF1WRkNDJDeXeZx5iov1zxdg1+PUKVZvjx1jGgwx3G9i\nouUODbGy3LZN3CgXcuwYe84I9yPVG/Tjj0B2trR7gPd6C+vq7t2szI4e1V9XaMD++CMz2C9fNu/d\nE2rOztZ56PPzWb0w7Ay4e9c2T68ckJFFELWQqiogNhbo1w944QWl1dSM//wHeO01luLd8CVGEM7I\n3bu6hqfYGBK+kVRVZdy7fOaM/ro//aT7XFFhugH2888sBO7331njTxgKZ6qBe+IE+2/KKyAMJ+P3\n8ccfuuPxZGWxho7QYCktZQ3M3Fzx3msp8A26M2d05Xn4sE5XdTWQkqILwTTF/v3WHVesvHJzWUNN\n+AwyZ5ymprJGr7XTevLXV+hJu3EDOHDA9Pp8HROGgxrC1wf+v7Ce8efLH/vqVeN6ZliPLY0Zs8Y7\nUlJi2UBITbV8PMOGOV+GwrI0mJ3BIoade4blwt9DP/0kbkQBzAN79iyrO4blJuYxNTQqt29noag8\nBw5InxhZ2AlheJ+cO8eMH55fftF/Ngm5do3VmePHWUiiuVBT3rMpNPqFhlFVlf6ymOFm6N3jQ5aL\nivTvu6tXjTsXDDsybt7UHeOnnxwXCgo4gZFVXl6OyMhIhISEIDAwUNuLKEStVsPLywuhoaEIDQ3F\n22+/rYBS++Cq4yhIt2OxVvcbb7CGW0KC7YPG5UCu8p4zB5g3j3nmbEkFbC2uWE9cUbPclJWV4Yyh\nlaIAf/2la5Ru3266B33HDtYwEzbcDBscd+/qGqzffssao4aNSb5hZOvYjrw8/ePyDRox+OeJmIFR\nXa1rYO3ZY6znzz/Fe855j4CwYZ6dLd77fPGiTiMfKlldzRp9hgaNsMwrKnQ93KZ64/lz48dkAcYN\nUz5ELDGRXVf+vCzBpx/ntQj3JTTqeINXrPyFDdvff2fakpJsm18wO1t/WRieuH8/MyqFyD02Ni9P\nVx6GIWy5ucZG161b+vXj0iV9Q+D0adYw/+svVk6Jiaa9nDdvsjonNFwMjUJToZFJSfrbiYWy82F7\nYgg1378vfpyKCn3jTqPRn2dMaFgL6xWPsIOF9+Levq1bj69H/LH5d+qlS6xsTp/WeTtv3dLv6FGp\nTJ+bIaa88Gq1vnFniZ07Wdjp9u2sc4cvc8M6zMPfs3fuGBt6xcXG96s9x4gqml0QABo2bIiDBw/C\n09MTVVVVGDhwIH755RcMHDhQbz3hmC2CIEyzZw+weTMLDfDwUFqNfLzyCut5e+IJFvJAc6UQQnbv\n3o2XXnoJ9+/fR0FBAXJycrB06VJF3hu8IcBz/75+D7qwUX3njn7YkRjbtgENGuiW09L0s3UZjnsx\nl4HNVIM8IwMYPpx9zsrS9z5VVQG7drHPwgaxYUMXYB4nc5nE+HChoiLWWOzUSedV2b8f8PUFAgKM\nPXqGCM+ZDze6dg1o3Zpte+mS/rkKx6gYGm/mQtl27QIee0y3fPWqfkeP1BDC69d1jX6+cSs0Lisq\nmJeOf2bz41RMcfKk+NgmYYNRaiKB8nKdoc9PMmx4XQ3DvHhsnZM7Kwto1oz9GRpZppLCGBrtFRXM\n+GvaVHeuwnF7fL0w7GgUekk8Pdm9Zegpu3JF57U1JD2dZWQE2DUV1p8zZ1jIobkw38REYOJEnZEO\nsLoQEMA+88lBOnTQv5fFvNilpcbjMoUGGm9wpKToryPsgBCONxOGfnKccbkI64XQ2Lx3j3nYhg7V\nfcd7+Qzh6wxfVy3dQ6bq8dWr4hk1ecMqNZWVX5s2bJkPnb14kY33dgSKe7IAwNPTEwBQUVEBjUYD\nH5F8k5zUkZkuhquOoyDdjkWq7vPnmddn2zbAzDypDkPO8lapgE8/ZS+Hl16SbbeiuGI9cUXNchIf\nH4+MjAw0a9YMABAaGorzhgMsHADHmR8DBBgP3JYSWiXW0DAVisY35sUGuZvqhRY2lg3D+0yN6Tp0\nSNcoF2LOs8Nry8hgjdXERP3zLy423UNtCsMMZtnZtnl3+EavYbUxbNwLl6UaMj/+qPtsmEThzz9Z\ng/TKFePf1GrTXiRLzSJhIx4w3WNfXq47Z76DwHDMk6mICKnJSMTq+MWLrCFseL2lpmnnOGaYZ2eb\nj9gwt78DB0x7vMyNIRQagkJvVna2eQOLx7DenD6tu2/4urtzp37njKlwRFtITdVdc0OvJY/YfSgM\nLRZ613btYsbNrl2WO43MIfSaAeavASBuoJWXs7rOX3e+PIXXqaDAtmeEtTiFkVVdXY2QkBC0bt0a\nQ4YMQWBgoN7vKpUKR44cQXBwMKKjo5FrqkYQRB2mvByYNAl49VXXyiRoDR4eLIxh507lBrISzomH\nhwe8vb31vnOTOMlUWloaunfvjq5du+Ldd981+v3atWsYOXIkQkJC0KtXL2zcuNHkvs6dszxw3bDR\nZ2tIryUbkm+wiCVbEOP+fTYuwxBrx1SZS9HNY+6cpXqH5MIwZMvw+hgacULj1Zb+XzEjnC9jw/DE\ny5cdMxZVLJHEr7/qGtpi5ykcl2cLZ86IX2upmQN5J7VGYz6M3JIhXNPsetbUAb5uiRlMfCZCU95B\nW72GYlRW6srM1P1ma/ixpWyl1mDKm2iIteGsv/7KOnrsPY+a4uGCAHsRHj9+HLdv38aIESOgVqv1\nxheEhYWhsLAQnp6eSE1NxdixY3FW5Ikwc+ZM+Pv7AwC8vb0REhKi3Q/fy0vL8izz3zmLntq+zH9n\nbv3164FOnaKwaJHyeu253KwZ8MILakyfDpw6FYW2bal+88tC7c6gR2xZrVZrjRT+eS0HPXv2xObN\nm1FVVYW8vDysXbsWD5ma9VSARqPBggULsG/fPvj6+iIiIgIxMTHoIZhULiEhAaGhoXjnnXdw7do1\ndOvWDU8++STc3Y1foVINGh6VSro3RIiUcQTWNiCysnTZ1OyNLedsibNngZ49rd/O0ONjCeE1Fsvo\nZwlrjUilprAoKGBh2WFh4t4gRyYQMIel8rFU14QeGVuwxmHOG5CO7EgQe1ZIMQzlNOpsQUpnDY8w\nzFEqZWXGmTblRsU5WRzeW2+9hUaNGuHf//63yXU6deqEY8eO6YUVqlSqWhtSSBCWOHyYebF++w1o\n0UJpNY5h6VL2ckxNBdycwidP2IJcz+67d+9i+fLl+OGf3OUjRozAG2+8gYYNG5rd7tdff8WyZcuQ\n9s9AjZUrVwIAXnnlFe06GzZswG+//YaPP/4Y58+fx8iRI0U7+lQqFbZsofdQkyaOSVAjxtSpjp3s\nODjY9NgTJfH1lc84e+wx85kL6zoeHjWfR45QlieesI8NoXjT5Nq1a7j1TwDrvXv38OOPPyI0NFRv\nnZKSEu3JZ2ZmguM40XFbrohhD7SrQLodizndZWXArFnAxx87n4Flz/J+4w3WG1iDeWFN4or1xBU1\ny0njxo2xYsUKZGVlISsrC8uXL7doYAFAcXEx2rdvr1328/NDsUHrdO7cuTh16hTatWuH4ODgGk1G\nXBdQysACLE9kKjfOaGAB8nq/yMAyj5IZfAnnRvFwwcuXL2PGjBmorq5GdXU1pk2bhmHDhmHDhg0A\n2ISQSUlJWL9+Pdzd3eHp6YmthqmUCKIO89prQEQEMG6c0koci7s7y6LYty8wciQgiO4i6iBDhgwx\n+k6lUuGAqQmGBOtYYsWKFQgJCYFarUZ+fj4eeeQRnDhxAk1FUlslJcVrPwcGRiEwMMri/gn5kDqe\nhyDkwlS6d8J5yc1VIzdXbffjyBIuePLkSQQFBcmhx2YoXJCoi/zyCzBlCgsT5FPK1jU+/RT46isW\nMikyRIZwcuR6dmcJBsqUl5fj22+/hbu7O1avXm12u/T0dMTHx2vDBd955x24ubnh5Zdf1q4THR2N\n1157DQP+yfs7bNgwvPvuuwgPDzc6FwoXJAiCcC2cOlxw3rx5iIiIwCeffILbpnJhEgQhK/fvA3Pn\nAmvX1l0DCwDi4tgYkPffV1oJoSTh4eHav4EDB+LDDz+UFEIZHh6OvLw8FBQUoKKiAtu2bUNMTIze\nOt27d8e+f3JVl5SU4MyZM+jcubM9ToMgCIKoJchiZP3yyy/YvHkzLl68iLCwMEydOlU7+Jgwj6uO\noyDdjkVM97vvAt26AePHO16PVBxR3ioV8MUXwHvvmZ7vw1pcsZ64omY5uXHjhvbv2rVrSEtLw98S\nUr+5u7sjISEBI0aMQGBgIKZMmYIePXpgw4YN2rD1V199FVlZWQgODsbw4cOxatWqWjMumCAIgrAP\nsgXXPPjgg3j77bcRHh6ORYsW4fjx46iursaKFSswYcIEk9uVl5dj8ODBuH//PioqKjBmzBi88847\nRustWrQIqamp8PT0xMaNG42SYxBEXeKPP5gHKyeHBt0CgL8/8NZbLAEIhQ3WTcLCwrTjq9zd3eHv\n748vvvhC0rajRo3CqFGj9L6Li4vTfm7RogX27Nkjn1iCIAii1iPLmKwTJ05g48aN2Lt3Lx555BHM\nmTMHYWFhuHTpEvr164eL/BTiJigrK4OnpyeqqqowcOBAvPfeexg4cKD295SUFCQkJCAlJQUZGRl4\n7rnnkG4wsQGNySLqCtXVQFQUS9m+cKHSapwHjgOGDwdGjAD+8x+l1RBSqU3PbhqTRRAE4XrYa0yW\nLP29ixYtwuzZs7F8+XJ4enpqv2/Xrh3efvtti9vz21RUVECj0RiFYezevRszZswAAERGRuLWrVso\nKSlB69at5ZBPEC7F//t/bDzWs88qrcS54MMGIyKA0aMp22Bd4dtvvzWbIXC8M8fTEgRBELUWWcZk\nfffdd/jXv/6lNZY0Gg3u3r0LAJg+fbrF7aurqxESEoLWrVtjyJAhCAwM1PtdbB6TImeZaryGuOo4\nCtLtWHjdBQUsZfuXXwL16ikqSRKOLm9/f+D//o+FDWo0tu/HFeuJK2qWgz179pj9IwiCIAglkMWT\nNXz4cOzbtw9NmjQBwML/RowYgSNHjkja3s3NDcePH8ft27cxYsQIqNVqREVF6a1j6MaTMrcJQdQm\nqquBp54C/v1voGdPpdU4L3FxwI4dwIcfsrIiajcbN25UWgJBEARBGCGLkVVeXq41sACgadOmKCsr\ns3o/Xl5eeOyxx5CVlaVnZPn6+qKwsFC7XFRUBF9fX6PtZ86cCX9/fwCAt7c3QkJCtPvhe3lpWZ5l\n/jtn0VPblwHg+efVuHcvCv/+t/J6nHnZzQ2YO1eNZ54BYmKi8OCDdad+C7U7gx6xZbVarTWM+Oe1\nXOzduxe5ubkoLy/Xfvfmm29K2jYtLQ2LFy+GRqPBnDlz9ObJAoD33nsPmzdvBgBUVVXh9OnTuHbt\nGry9veU7AYIgCKLWIEviiwEDBmDt2rXo06cPADYp5MKFC/Hrr79a3PbatWtwd3eHt7c37t27hxEj\nRmDp0qUYNmyYdh1h4ov09HQsXryYEl8QdYpz54D+/VnmvAcfVFqNa7B2LfNoHToEuMkSGE3YA7me\n3XFxcbh37x4OHDiAuXPnYseOHYiMjJSUYVCj0aBbt27Yt28ffH19ERERgcTERPQwMbBv7969+Oij\nj7RzZwnPhRJfEARBuBZOPRnxRx99hMmTJ2PgwIEYOHAgpkyZgnXr1kna9vLlyxg6dChCQkIQGRmJ\n0aNHY9iwYXpzlERHR6Nz584ICAhAXFwcPvnkEzlkOwWGPdCuAul2HOXlQHS0Gm++6XoGlpLlPX8+\nG5f16afWb+uK9cQVNcvJkSNHsGnTJvj4+GDp0qVIT0/HmTNnJG2bmZmJgIAA+Pv7w8PDA7GxsUhO\nTja5/pYtWzB16lS5pBMEQRC1EFnCBSMiInD69GmcOXMGKpUK3bp1g4eHh6Rtg4KCkJ2dbfS9cI4S\nAEhISJBDKkG4HM8/D7RtCyxYoLQS16JePZZt8OGHgcceAzp2VFoRYU8aNWoEgGWrLS4uRvPmzXHl\nyhVJ24olV8rIyBBdt6ysDN9//32t6uwjCIIg5Ee2KTuzsrJw4cIFVFVVaY0mKZkF6zrCMSCuBOl2\nDN98Axw4ABw9GuWSkw4rXd49ejAjNS4OSE2VPnGz0rptwRU1y8njjz+Omzdv4qWXXtKGrs+dO1fS\nttYkUtqzZw8GDhxocixWUlK89nNgYBQCA6Mk75sgCIKwP7m5auTmqu1+HFnGZD355JM4f/48QkJC\nUE+QV1pqyKAc0JgsorZx6hSbdPjAASAoSGk1rktlJRAeDrzyCkARXs6HPZ7d5eXlKC8vl5yUIj09\nHfHx8UhLSwMAvPPOO3BzczNKfgEA48aNw5QpUxAbG2v0G43JIgiCcD2cekzWsWPHcPjwYXzyySdY\nt26d9o+wjKuOoyDd9uXGDWDsWOCDD5iB5Sq6DXEG3R4ewIYNwAsvADdvStvGGXRbiytqlpPevXtj\nxYoVyM/PR8OGDa3K+hceHo68vDwUFBSgoqIC27ZtQ0xMjNF6t2/fxk8//YQxY8bIKZ0gCIKohchi\nZPXq1QuXL1+2advCwkIMGTIEPXv2RK9evbB27VqjddRqNby8vBAaGorQ0FC8/fbbNZVMEE5LZSUw\neTIwZgwwbZrSamoH/foB48czbxZRO9m9ezfq1auHyZMnIzw8HO+99x4uXrwoaVt3d3ckJCRgxIgR\nCAwMxJQpU9CjRw+9BEwAsGvXLowYMUI7/osgCIIgTCFLuGBUVBSOHz+Ovn37okGDBmzHKhV2795t\ncdsrV67gypUrCAkJQWlpKfr06YNdu3bppc5Vq9X44IMPzO6PwgWJ2sLChUB+PrBnD0veQMjD7dtA\nYCCwfTswYIDSaggeezy78/Ly8NZbb2Hz5s3QaDSy7tscFC5IEAThetgrXFCWxBfx8fEA9F+WUgcS\nt2nTBm3atAEANGnSBD169MClS5eM5ichA4qoC2zYAOzbB6Snk4ElN15ewIcfsiQYOTksjJCoXRQU\nFGDbtm3Yvn076tWrh1WrViktiSAIgqijyBIuGBUVBX9/f1RWViIqKgp9+/ZFaGio1fspKChATk4O\nIiMj9b5XqVQ4cuQIgoODER0djdzcXDlkOwWuOo6CdMvPvn3A0qXMg+Xlpf+bM+s2h7PpnjQJaN8e\n+Ogj8+s5m24puKJmOYmMjMS4ceNQXV2NHTt2IDMzEy+++KLSsgiCIIg6iiyerM8++wyff/45bty4\ngfz8fBQVFWHevHnYv3+/5H2UlpZi4sSJWLNmDZo0aaL3W1hYGAoLC+Hp6YnU1FSMHTsWZ8+eNdrH\nzJkz4e/vDwDw9vZGSEiINq0x3wBxtmUeZ9Ejdfn48eNOpcfVy/vrr9VYvBhITo5CQACVtz2X160D\n+vRRo2NHYPJk8fVdsbyPHz/uVHpMLavVamzcuBEAtM9rOfj666/RvXt32fZHEARBEDVBljFZwcHB\nyMzMRL9+/ZCTkwOATTJ88uRJSdtXVlbi8ccfx6hRo7B48WKL63fq1AnHjh2Dj4+P9jsak0W4Kn/9\nxRIzLF0K0NRyjmHZMuC334Bvv1VaCeEMz+60tDQsXrwYGo0Gc+bMEU3drlar8fzzz6OyshItWrQw\n6kgAaEwWQRCEK+LUKdwbNGigTXgBAFVVVZLHZHEch9mzZyMwMNCkgVVSUqI9+czMTHAcp2dgEYSr\nUlbGsgjGxpKB5UhefpkZWSkpSishlEaj0WDBggVIS0tDbm4uEhMTcfr0ab11bt26hfnz52PPnj34\n/fffkZSUpJBagiAIwlWQxcgaPHgwli9fjrKyMvz444+YNGkSRo8eLWnbw4cP45tvvsHBgwe1KdpT\nU1P1UucmJSUhKCgIISEhWLx4MbZu3SqHbKdArDfUFSDdNaeqihlXAQGApVkJnEm3NTir7oYNgY8/\nZpkc790z/t1ZdZvDFTU7A5mZmQgICIC/vz88PDwQGxuL5ORkvXW2bNmCCRMmwM/PDwDQokULJaQS\nBEEQLoQsY7JWrlyJL774AkFBQdiwYQOio6MxZ84cSdsOHDgQ1dXVZteZP38+5s+fL4dUgnAKOA6Y\nNw+4fx/44gtAouOXkJFHHwX69AFWrmThg4Rrc/fuXXzwwQe4ePEiPv/8c+Tl5eHMmTN4/PHHzW5X\nXFyM9u3ba5f9/PyQkZGht05eXh4qKysxZMgQ3LlzB8899xym0SR2BEEQhBlkMbLq1auHp59+Gk8/\n/bQcu6tT8APDXQ3SXTPi41ka8YMHpaUSdxbd1uLsuj/4AAgJAZ58EujaVfe9s+sWwxU1y8msWbPQ\np08fHDlyBADQrl07TJw40aKRJSW0vbKyEtnZ2di/fz/KysrQv39/9OvXD12FleYfkpLitZ8DA6MQ\nGBhl1XkQBEEQ9iU3V43cXLXdjyOLkdWpUyej71QqFc6fPy/H7gmiVrFuHbBlC/DLL0DTpkqrqdv4\n+QFLlgALFgBpaeRRdGXy8/Oxfft2bTh548aNJW3n6+uLwsJC7XJhYaE2LJCnffv2aNGiBRo1aoRG\njRrh4YcfxokTJ0SNrIkT420/CYIgCMLuGHaA7dxpn3AWWcZkHT16VPv3888/47nnnsMmNx4fAAAg\nAElEQVS//vUvSdsWFhZiyJAh6NmzJ3r16oW1a9eKrrdo0SJ07doVwcHB2gyGtQFXHUdBum1jyxbg\n3XeBH34AWreWvp3Sum3FFXQvWgQUFwPCXAauoNsQV9QsJw0aNMA9wQC7/Px8vYRMpggPD0deXh4K\nCgpQUVGBbdu2ISYmRm+dMWPG4JdffoFGo0FZWRkyMjIQGBgo+zkQBEEQtQdZPFmGg4AXL16MsLAw\nvPXWWxa39fDwwIcffoiQkBCUlpaiT58+eOSRR9CjRw/tOikpKTh37hzy8vKQkZGBefPmIT09XQ7p\nBOEw0tKA558H9u8HRJy/hEJ4eADr1wNTpwIjR5J30VWJj4/HyJEjUVRUhCeeeAKHDx/WzsdlDnd3\ndyQkJGDEiBHQaDSYPXs2evTooU28FBcXh+7du2PkyJHo3bs33NzcMHfuXItGlkrFxl4SBEEQdRNZ\n5sk6duyYNq69uroaWVlZWL9+PU6cOGH1vsaOHYuFCxdi2LBh2u+eeeYZDBkyBFOmTAEAdO/eHYcO\nHUJrgSvAGeZaIQhTnDgBDB8OJCcDDz2ktBpCjOnTgTZtgFWrlFZSt5Dz2X3t2jVtB1y/fv0cngVQ\nOE9Wly5Afr5DD08QBEHYgL3myZLFk/Xiiy9qjSx3d3f4+/tj+/btVu+noKAAOTk5iIyM1PteLPtT\nUVGRnpFFEM7K5ctATAxLGU4GlvOyahXQqxcwaxYgcKQTTo6wkw8A2rZtCwC4ePEiLl68iLCwMEV0\nUZ8fQRBE3UYWI0uOsQClpaWYOHEi1qxZgyZNmhj9bmhhimWEmjlzJvz9/QEA3t7eCAkJ0Wbc4jU6\n2zL/nbPokbr80UcfuUT5Kl3ekZFRGDsWGDpUjVatAMC2/VF5O2b59dejsHAh8NhjHyE01LXK+/jx\n49oJ3Z1Bj6lltVqtDePjn9c1QdjJJ8bBgwdrfAyCIIjajKcnUFamtIrahyzhgu+//77RS47frUql\nwgsvvGB2+8rKSjz++OMYNWqUtpEg5JlnnkFUVBRiY2MB1K5wQbVarW2IuBKk2zIcB/D5XzZvrlnm\nOipvx1BVBYSFAePHqxEfH6W0HKtwtbLmcdVntxgULkg4mvr1gYoK3fKwYWzcL2FffHyAGzcce8zG\njYG7d+2zb29v4NYt++zbFbBXuKAs2QWPHTuG9evXo7i4GEVFRfj000+RnZ2N0tJS3Llzx+y2HMdh\n9uzZCAwMFDWwACAmJgabNm0CAKSnp8Pb27vWhAq6YqMIIN1S+OwzIDdXnsmGqbwdg7s7kJAAfPll\nFEpLlVZjHa5W1nJz7949vP/++xg3bhzGjx+PDz/8EOXl5UrLIgiHwiImlKdXL6UV2BclpvsIDnb8\nMQHXmdqkWzelFRgjS7hgYWEhsrOz0fSftFzLli1DdHQ0Nm/ebHHbw4cP45tvvkHv3r0RGhoKAFix\nYgUuXrwIgGV2io6ORkpKCgICAtC4cWN89dVXcsgmCLtx8iTw+utsLqxGjZRWQ1jDww+zvxUr2B/h\nGkyfPh0PPPAAFi1aBI7jsGXLFkybNg07duyQtH1aWhoWL14MjUaDOXPm4OWXX9b7Xa1WY8yYMejc\nuTMAYMKECXj99dfN7rNRI0CQVV4WnLXHuU0b4MoVpVXUPZy1AVy/vtIKpNO8OXD9unXbtGlj/TY1\nReLUf7ITGwskJipzbFdHFiPr6tWr8PDw0C57eHjg6tWrkrYdOHAgqqurLa6XkJBgsz5nxlVDfEi3\nae7eBSZPBt5/X76eFSpvxzJ2rBrPPBOFp54CAgKUViMNVy1ruTh16hRyc3O1y0OHDpU8l5VGo8GC\nBQuwb98++Pr6IiIiAjExMXpTiQDA4MGDsXv3bkn7tFfjd9Qo52zwtGtHRpYpGjYE7OVUrV8fuH/f\n/DrjxwM7d9rn+HWV3r2BU6eUVuFYHnwQOHtWt9y5M3D+vHJ6XAFZwgWnT5+Ovn37Ij4+HkuXLkVk\nZCRmzJghx64JwuVYtAjo25elBCdckxYtgP/8BzARwUw4IWFhYfj111+1y+np6ejTp4+kbTMzMxEQ\nEAB/f394eHggNjYWycnJRus5YuzYAw9YXsfLy+4yrMbT0/HHdLexm9jW7WzFnjMJCHPH1Ksnvo6E\nObmN+MdhazNydDL07FnzfTgCue/HmnbOSim3du3M/y7wm2jhr+nUqazz0VIdcZPFwpDOP4llnQpZ\niuC1117DV199hWbNmsHHxwcbN27Eq6++Kseuaz2u2vNMusXZsQP4+WeWrl1OqLwdS1RUFBYvBvLy\ngO++U1qNNFy1rOUiKysLAwYMQMeOHeHv74+HHnoIWVlZCAoKQu/evc1uKzZNSHFxsd46KpUKR44c\nQXBwMKKjo/W8Zo4mOtq6cCzhBNuCKShlxdENKkDfwDBF9+7G3z36qO6zLQ0zkQTIehganPYM6ROG\nkE2eLN9+BbeDlgYNzE/W7u0t3/GtRcxw9vERX9fwe1PGqVRGjqzZ9jzh4brP1j7OrR2LN3iw+TFe\n/foZfyesxxERQMuW5o8hV7lIxdp7OSbGPjqEyPZYLCsrQ9OmTfHcc8/Bz88PFy5ckLTdU089hdat\nWyMoKEj0d7VaDS8vL4SGhiI0NBRvv/22XJIJQlaKioAFC4BvvrH8Eiacn/r1gTVrmDfLUjgOoTxp\naWk4f/48Dh06BLVajfPnzyM1NRV79uyxGOJnLgU8T1hYGAoLC3HixAksXLgQY8eOFV0vKSkeSUnx\n2LQpHr//rrblVFySFi0sN7oGDLBt31K8e1Onin8v9iwWGoS8ETZxonQ9lqqL0IgDAGvzdBlMFaql\nSxfr9lMTxAyUhg3Nb2OqXOTs/wkKYiGzhjz0kHj5iIV7R0ToL/v51UyTLR0MI0aw/0LjSDh+W8xg\nMOVIr18fCAmxXoO5eix2LGuNUTEP39ixQLNm1u1HaLyb6lwaP17avnjvW26uGqtXx2uf1/ZCFiMr\nPj4eq1atwsqVKwEAFRUVePLJJyVtO2vWLKSlpZldZ/DgwcjJyUFOTo7FgcauhnA+IVeCdOtTXQ3M\nnAksXMhCBeWGytux8LpHjmShF6tXK6tHCq5a1nLh7+8PLy8v/P3337hx44b2z9/f3+J8XL6+vigs\nLNQuFxYWws+g5dW0aVN4/uOiGDVqFCorK3FDJIfzxInxmDgxHuvWxSMsLMrq87Cn1yMkhA3yrwmm\nGpQNGgDDhzMvG4+hd6FDB/P7btNG/Hu+QWoLlsqTb7SJhUcJMWX4WCIy0rRHxRSmwrDEGr72qi/u\n7uLX2rCh7eur+yy3N9OwMT56NMtaaI3HjNfk4QGMGcOMcR8f4PHHdetIKUOhM9xSPZaC1HOwR7bI\nf2ZDgkZj/Nujj4obbI8/bj7xxvjxwLhxumVTXqxGjYB/ctyJ0rGj6d+aN9c3RIX3lZSQ2NhYNq4M\nAAIDoxAfH699XtsLWW6J//3vf0hOTkbjf66Ar6+vxdTtPIMGDUIzC2ZtbZlDhai9fPQRG9i8ZInS\nSgi5WbOGXd9z55RWQpjjjTfeQO/evbFw4UK8+OKL2j8phIeHIy8vDwUFBaioqMC2bdsQYxBLUlJS\non0XZWZmguM4+FhoPYuF5llqzJtDGIYm5bX40EP6y926Se+NNtW7P3Cg8XfCc/LyYh6FgADrPVem\nIgAMjbXBg6Xtb+RInVFpyoATw9Aj17u3fgPT2iZJ8+bA0KH630kdFzZ4sM6QETYwIyL0PQXC8C4p\nY4TatDE2/oYM0V82PE+VSn+drl1ZJtbwcF3DXQxbDUHDkEVzddfUmED+2PXr66/TuLH5Br05xOo1\nf31tCZmsqSfNWvgyETNMmjcHDPL9ADAfJgqwayP0dIo16ydMsKzN0n3B1zfA+qRUKpX1XrSaIouR\n1aBBA7gJujDuyjhbmjPFwdsDVx1HQbp1HD0KrFwJ/Pe/NY/tNgWVt2MR6u7YEXj5ZWD+fOsbV47E\nVctaLrZt24b8/HwcOnQIBw8e1P5Jwd3dHQkJCRgxYgQCAwMxZcoU9OjRAxs2bMCGDRsAAElJSQgK\nCkJISAgWL16MrVu3WtyvWCPG1GWy1BAdMEB8nIQ5OnYE+vTR9UxLCed6+GHgkUeAQYPE1/X1Ne7J\nN7wv+vZlRoAUr1nXrrpB+J06mV5PGHJnadA+T7Nm7G/qVNsa1HyDr2dP/Wtp6Tkg9OjwZS4l5FGM\ndu1075VevXRhUW3a6HsNhUhpfKpU+qFXpsItDRE2pHmPRNeu8nvUhM5n3tgSlqthXRFrPKtUpsfp\nuLnpd0IY3lteXvq/8+dnKvSTv76jRlmfWEXu94rYeDoxhNesZUt9Q4rv8BDWi5pc4yZNrBtHGhho\nbDg3b872wz9XeL1i95azzBcnS46dSZMmIS4uDrdu3cJnn32GL7/8EnPmzJFj19o4eE9PT6SmpmLs\n2LE4K8whKWDmzJnasBBvb2+EhIRoGx58KA0t07Kcy717R2HyZGDBAjX+/BPo1Mm59NGyPMuhoWp8\n8gmwfXsUpkxRXo8rL6vVamzcuBEALIbxWUPPnj1x8+ZNmyeqHzVqFEYZDPaIi4vTfp4/fz7mz59f\nI42AacOjeXPg2jX9hkzv3qyRnZZmbNh07Mi850VF5o/34INAVRX7bKqRJGyICsO/TCE1k6CUxqOP\nD/N8Xbpkfr2hQ+VLXS/UJfz86KPADz/olv39dR5soYfioYeA334DSkqYgZGXx4zSn39moY32yl7o\n5mZsuItdU6FWU2N1fHyYx+LgQfH5nlQqy9fPsFNx4EDg11+Bq1fFOxhatgT++sv8PnnNQm9Ko0Zs\nLI9wnyEh7PqY60eJjNR59SwZCJ06AenpumXegD1yRH89Q4+kUOMjj7DP/fuzuiCV5s2B27elry+G\nOS+Sqbn12rdnncSAftINfh9SDW8p9O+v+yysV4Zp4PnfmjdnGg4fZs+wmzdZhxGgu5Zubuw7YX3v\n2ZOl1u/aldVDMRyZer7GjwKO4zBlyhT88ccfaNq0Kc6ePYu33noLj/C1rYY0FZjWo0aNwrPPPosb\nN26IhmnwL24x+Je9sy2r/5nbxln0SF02/E5pPUqUd3U1y04zbhzw5pv21W/4nbOUp6Xl2lK/hw+P\nwubNwKRJrBGltD6xZd6QcRY9ppYN68OyZcsgB6+++ipCQ0PRq1cvNPinNaZSqSTPa+UoVCrWOOCn\nhzTVAGrcmDUYbt4U3w8/eF+K4WGusSwlfLF1a2ZQ8I2u4GDgjz9qdlweYWibm5vl9Q3x8LCccEMq\nljxvAwYAhYUsyYevLyuT8HD9BqphY16ql8LdXWcMG2Ktp0NoBIuFfgHMKPDw0A9BtIauXcWPO3Qo\nsHUr6wQwNFAs0b27cb0aO5Z5QAwNuoYNmTevY0fxsUWA9NTq/DULDweys3X3ptg6hgjvH2tS9atU\n7D5q3pzdXz17Wu4wMawHnp5AWRnbV+PGzFDkc855eekMNy8v1gnw999sHk+eBg2YkXLsmHTdlhC7\nhoDlcEMx6v/j+TKX8IUfY2UJ4bPFkYnJZOlviY6Oxu+//45HDVPqyEBJSQlatWoFlUolOQ6eIBzB\nqlXAjRvAu+8qrYRwBA89xIzqRYuATZuUVkMYMn36dLzyyivo1auXNnxdStZAJQgMBH7/nTWSDCcX\nVqlYD7PU8LL69YGKCvPreHiYHsckbJAbzt0cEgIcP27cwJRqDFkyDnijjTckfXyYzvv39b0KQnhP\nQkQEa5yGhhrre+AB1qCUmw4ddB5FW0O8oqMBtZo1ioVeHXd31vjjDe4mTYDSUvF9BAeb9yY2acJC\nNjMzbdMIiF9jvpzHjzdtnKtU5j0grVqZ9jCI3a6WjEBhSF9gIJCfb359c3TtyibUFho7zZqx+lm/\nvrEXa8AA8XLg60bTpoBYegK+fCTOlS6Z8HD9BB1CmjQRNy78/MQ7eeyJ2L3j52dsZLZpI5410MuL\ndazYmsTH0MsqTIIiNzU2slQqFfr06YPMzEz0tSGt2tSpU3Ho0CFcu3YN7du3x7Jly1BZWQmAhWok\nJSVh/fr1cHd3h6enp6Q4eFdCrAfdFajrunfuBNauBTIyajaQXSp1vbwdjSnd770HhIUB27YBU6Y4\nVpMlXLWs5aJJkyZYtGiR0jIkERTEjCxTY4vEkkuYIjoauHcP+P571iC9d098PVPHEno6DJ9lPXro\nQspsgW9M+fszr48UeJ2mjCzea2Vu3FFYmHE5CEOK7PnMtpTl7IEHWJa7jAzj0DmpfQJijXPDhquP\nj7iWzp2B4mJdA9XUWDOVyrSX1ZbJjXmGDWPPT2u8RVJp0oQZGb/9pv99t262ey8efRT45RfW4DfM\nrmcpy+DjjwN79zJDS+i9thfu7sahqmFh5scneXraJyOyXIjVNTc3lsnUGuTydluLLJ6s9PR0fPPN\nN+jYsaM2w6BKpcJvhjVdhEQLsQ5yxcEThFwcOgQ88wwbJyF1gClRO2jcGNi8mTVs+/eXJ5UvIQ+D\nBg3CkiVLEBMTow0XBNi4XkukpaVh8eLF0Gg0mDNnDl5++WXR9Y4ePYr+/ftj+/btGG9iYhZzHggp\nGDY0vbx0YxHEaNRI1zh+7DE2rsuabP7mkk0INVy5In2fPPxlEI7HqAlSx4i0aWNcjj4+zPNw+DAr\ns0mTmAewrMx4ey8vZgB16mTaYxUQYByOxuszFb5mCj8/1tgVeniEniRzCZVMZaZr1kzfCyA0mITf\n9+nDEmoI4ZNAPPoosH27bntbPS+G1yIgABAbWm9NuJ01SHgEmMTNjSWDsYYWLYzbBo0a6YfqWdpe\nDL4e+PsDBQW6780Zp926STumXBh6QHv0AE6ftu/UFEJM3a+GmTMdRY2MrIsXL6JDhw74/vvvoVKp\nKNW6DfBjVlyNuqr7xAn2ck5MrNmD21rqankrhTnd4eHACy8A06cD+/fbL6OktbhqWctFdnY2VCoV\n0g1cIJYyDGo0GixYsAD79u2Dr68vIiIiEBMTgx4Gg1k0Gg1efvlljBw50qp3Xbt2ppM6SGl4uLlZ\nHnfAy/Hw0HlspDyfDCfgNaUnNJSFqJlCbHwOwHrVpRhG/NiLmtKmDTt/KeXK9/obGlljx7LxPqGh\n7HdTDV53d9OZ68SqB+/F4LUJNfKZHIVVdcgQ3RitPn1Mj62S+vzx92ehn4aJMOrVMw495A3vevXY\nn0bDnnvWegPGj2dhmy1aMG8Kn1SlTx+dkSUMa1Qqulfu4zZqZJ032hBTnXe891Gu+8Ue9Oypb/i3\nbMmMLFOaDb+X61oY7sfcfu1Z72pkZI0ZMwY5OTnw9/fHhAkT8O2338qliyCcjpMnmQcjIUF8/hui\n7vDSSyw86803geXLlVZDALZPxpyZmYmAgABtpsPY2FgkJycbGVnr1q3DxIkTcZRPxyURqeOXavKi\nF4YhNWok3eMjNWxOpTLdmG/Zsua95Y0bs86rmmKpt1qKbcyPAZI7Q6Chd6tXL6CyErh4Ufdd9+46\nj6HQ8KlfX76GtbWhft27s2xttiQladBAZ5gZvjN5o71LF5asQUrWQXtg77mTaup74Lc3NIQjI1n5\nXr+un1nQ0UyZwsI/edzd9cdK+fqy8FghLVvqEmT07s06kbKz2W9inRC2IHVevBYtbE/+IgXZHiPn\nbcyH+NRTT+G7775Dq1atcPLkSdF1Fi1ahNTUVHh6emLjxo0INTddtIvhqj3PdU33gQNsssW1a4HJ\nk+XVJIW6Vt5KY0l3vXosjKZfP9aLP3OmQ2SZxVXLWk727t2L3NxclJeXa7978803zW5TXFyM9oLY\nHj8/P2RkZBitk5ycjAMHDuDo0aM2JdQYMMB4rAif3KJlS9YYCQ627YXfuLFxyJejsHZsBCCemMJe\nac+dBUMj1dOThZQJjayaNCzt1dDmpxGwNcmAKYShh0FB7B2rBIaTKHt5Wc7yZwteXsxraovR9cAD\nbGJtgNWbVq104YhSplywJ1KMb0MD0d2dXf8//mD3RePGzNguKpLPq+ThYT5jJ49MidBNovhjbdas\nWVi4cCGmT58u+ntKSgrOnTuHvLw8ZGRkYN68eUbhIARhTzZvZuFh27cD1I4leFq2ZIOao6JYKA7V\nDWWJi4vDvXv3cODAAcydOxc7duxAZGSkxe2kGEyLFy/GypUrtWHxtoTGCzPTAawHmG+g2GKoCHFz\nYw1VazA87VatpPf+8pgKlzNHbCybo6Ymme/kxFEhao0bG3fQtWxp2yTJhkycaN9kHvYaK2WILd4y\nuQkKkrfD4oEH2Ni/QYNsT3zx2GO6z4ZeIWdg2LCad5JInWDcGpwhuWyNiuW3337TzmN17949vTmt\nVCoV/paQQ3XQoEEoEI7gM2D37t2YMWMGACAyMhK3bt1CSUmJzRNOOhuuOo6iLui+fx94+WVg1y42\n9kapnmKgbpS3MyFVd48ebHwem6DY9LgJR+CqZS0XR44cwcmTJ9G7d28sXboUL774Ikby3b9m8PX1\nRWFhoXa5sLAQfgbZBI4dO4bYf7q8r127htTUVHh4eCAmJsZof1u2xKOiAjhzhnkX3d2jRI+rZIPS\nw8PYs2JtCPTYsbZ53VQqaY2fmBiWjvvUKeuPYQ0+Po4L/zYs80aN9FOQ24ojMtw6Amdo1kmtn1IZ\nOJB5r9zcnMOItAfmshdaS03L3t9fF5o7ciRLBPTrr8br5eaqER+vrtnBJFAjI0tjbQodGxAL5Sgq\nKqo1RhbhnJw5w3pcO3dmscI0NRthiqFDgdWrWSauAwdMJwEg7Eujf1r8np6eKC4uRvPmzXFFQkq8\n8PBw5OXloaCgAO3atcO2bduMst4Kw+FnzZqF0aNHixpYAPDEE/EoLdWNi+LHGjgTwp5xW7HnOAaA\neX7kbpSKTYiqUsnbSCRsxxk8D3JTk8RIrVsrHw7oaGpaB7y8dEl/+LnBxCalDgyMwtSpUdrlZcuW\n1ezAJlA8XFAKhqEZpsI7Zs6cqR287O3tjZCQEG3PLj8ompblWea/cxY9ci0//HAUNmwAXnlFjdmz\ngfffj4JKpbw+/july6euLPPfSV2/Qwc1YmOBoUOjoFYDhYXK6BdqV+L4UpbVajU2btwIANrntRyM\nHj0aN2/exEsvvYSwsDCoVCrMnTvX4nbu7u5ISEjAiBEjoNFoMHv2bPTo0QMbNmwAwMIQa0JICMu4\n5UzY20ByVnx8pCcFUQJK0EwIMZz82BpcsS41bcoMyzNn5N2vPRObWELFOUHe9YKCAowePVo08cUz\nzzyDqKgobahG9+7dcejQISNPFqWQJ2rKn38Cs2eziQO//pplvyEIa9iwAVixgoUOSpl/iLDPs/v+\n/fsoLy+Hl1gXph1RqVTYvZvT82QRxpw/zybjtVRGv//Osrq6WllWVQE7drDPkZEsIkIKJSXMG26P\n8z19mqVwN7fvy5fZs8vR5S0878RE1jFha+j1qVMswUzHjvKEYjqSoiLg55/lKf/vvmPJZeS8llLv\nW6lcvSruRU5MBAYPts84LQA4dw44elT/POxlQzh9hGhMTAw2bdoEgE167O3tXatCBQ17oF2F2qSb\n44AvvmDzgAwfziardDYDqzaVtytgq+64ODaOb8gQ9kJyJK5a1jUlMzMTly9f1i5//fXXmDRpEt54\n4w3cuHFDQWUEYR2tWtU8CQrBcDUDC2DX39KceLUJU2G6zZop632SE8XDBadOnYpDhw7h2rVraN++\nPZYtW4bKykoALEwjOjoaKSkpCAgIQOPGjfHVV18prJioTVy5Asydy3qQDhywPkMXQRjy7LPs/5Ah\nbHJRqb3YhG3ExcVh//79AICffvoJr7zyChISEpCTk4Onn34aSUlJDtUzYABLmkOYRjDMulYi7BBv\n3Fj6diqV9RP+yomXlzKhpM2a2c9r4UrUr88mapaDbt2AW7fk2ZejkZCvyGVQ3MgyHGAsRkJCggOU\nKINwDIgrURt0f/stMH8+MGcO+1zfiWdRrw3l7UrUVPezz7JB+1FRzNDq0kUWWWZx1bKuKdXV1fD5\nJzPNtm3bEBcXhwkTJmDChAkI5mc8dSCUJMcyHh7SOh9cfQSAME2/K+DpybJGOpr69Vl4GCEfAQFK\nK3BeHPlcUdzIIghHc+sWsGgRS+u5axebUJYg5OaZZ1jP9NChwKFDLLUsIT8ajQaVlZXw8PDAvn37\n8Nlnn2l/q7I0EyXh1FjjBXJGnMnAcvWylIqrG+ZE7cKJHgF1E1cdR+GquletUiM4mKX1PH7cdQws\nVy3vuq47Lg546SVmaAmmYrILrlrWNWXq1KkYPHgwYmJi4OnpiUGDBgEA8vLy4O3tLXk/aWlp6N69\nO7p27Yp3333X6Pfk5GQEBwcjNDQUffr0wYEDB2Q7B0Kczp2BSZOUVlE76NCBypIgHI1TGFmWXm5q\ntRpeXl4IDQ1FaGgo3n77bQVUEq7MX38BTz4JfPAB8NlnwCef1J2ePUJZFixgYalDhwKXLimtpvbx\n2muv4f3338esWbPwyy+/wO0f9wHHcVi3bp2kfWg0GixYsABpaWnIzc1FYmIiTp8+rbfO8OHDceLE\nCeTk5GDjxo14+umnZT8Xwhh3ireRDSpLoiY485AKZ0XxW45/ue3btw++vr6IiIhATEwMehjk7xw8\neDB2796tkEr74arjKFxFd1UVyxz45pvAtGlAfn6USxpXrlLehpBuxosvAhUVzNA6eBBo21bW3QNw\n3bKWg/79+xt996AVaboyMzMREBCgnbcrNjYWycnJeu+hxoIHR2lpKVq0aGG7YKJWU5MJaOs6HTpQ\nEgxnxc8PGDNGaRWuheJGlpSXG2A8ITFBmIPj2DwR//kP0KYNkJYGhIYqrYqoyyxZAmg0OkOrTRul\nFRE8xcXFaC9Ieefn54eMjAyj9Xbt2oUlS5bg8uXL+OGHHxwpkXAh3Nxcb24vZ2HAAKUVEObw9FRa\ngWuheLig2MutuLhYbx2VSoUjR44gODgY0dHRyM3NdbRMu+Gq4yicVTfHMYNq4G42HT0AABKJSURB\nVEBmYK1eDezfrzOwnFW3JUi3Y7GX7tdfB554gqV3v3JF3n27alk7AyqVStJ6Y8eOxenTp7Fnzx5M\nmzZNdJ34+HjtH10TgiAI56JZMyA3V633rLYXinuypLzcwsLCUFhYCE9PT6SmpmLs2LE4e/asA9QR\nroJGAyQnA++8A9y7xxqzkyZR2AbhfLzxBusMGDQISE2lVLvOgK+vLwoFmUkKCwvh5+dncv1Bgwah\nqqoK169fR/PmzfV+s+cLmyAI8/j4sKyuBGGKFi2At96KAhCl/W7ZsmV2OZbiRpaUl1vTpk21n0eN\nGoVnn30WN27c0M6NwjNz5kxt2KG3tzdCQkK04xT4HkValmeZ/05pPf36RWHTJuD//k+Npk2B5cuj\nMHYs8NNPavz8s/OUV20p77qyzH9nr/0//LAat24BAwdGYedOoKJCnv0LtcupV85ltVqNjRs3AoD2\nea004eHhyMvLQ0FBAdq1a4dt27YZzeGYn5+Pzp07Q6VSITs7GwCMDCyCIJSlXTsgNlZpFQTBUHEK\nD3aqqqpCt27dsH//frRr1w59+/ZFYmKi3piskpIStGrVCiqVCpmZmZg8eTIKCgr09qNSqWjcVh3i\n+nWWIfDjj9kM6S+/zDwD1INFuBKpqcD06cDatXV3DIezPLtTU1OxePFiaDQazJ49G0uWLMGGDRsA\nAHFxcVi1ahU2bdoEDw8PNGnSBB988AEiIiL09uEs50IQBEFIx17PbsWNLMDyy+3jjz/G+vXr4e7u\nDk9PT3zwwQfo9//bu/ugqMo9DuDfHeFWvoShQrRQyrIosnB2S0RLu8P1pVAjDb3CTGQjmRJZNuXk\nP3ciK5Xp7ZI4l+pqZmk2k12VG6C30tErAoagE5gXkvcXLwIboDdY4Hf/OLMrC0scbDlnz/L7zJwR\n9oX5np/PnrPPeXmefhMcqXXn1vdouZoolfs//xG/kB44IM5M//LLQGio9PdzveXFuYdWXAz8+c9A\nRASQni5eL34r1FprtW67HXGndWGMsdFipLbdil8uCIiXAEZHR9s9tn79etvPycnJSE5OljsWcxG9\nvcC33wI7dwL5+cCzzwI//sjDvDL3YDSKHa0tW4DwcOBvfwOWLuWzsowxxpiaucSZLGfgI4jup6IC\n+PRT4JNPxBsVN2wQJxS+4w6lkzE2Mr77Tpy4+O67xUFcHEz/5HbcadvtTuvCGGOjhVtfLugMvHNT\nv95e4MIFIDMT+Mc/gNpaYPVqIDGR57hio0d3N7BvH5CSAoSFAS++CCxcKM69447cadvtTuvCGGOj\nxUhtu910t60e/UcFUwtn5P7vf4Hjx4HUVCAmRjxbFRcHtLQAf/0r0NAg3qPizA7WaK63Ejj38Hl4\nAGvXivcfLl8ObN4MhIQA778P1NcP/j611poxxhhzRy7RycrJycGMGTOg1+uRmprq8DUvvPAC9Ho9\nBEFAUVGRzAlHTnFxsdIRbonU3D09wJUr4gTBaWnAc88Bf/oT4OcHzJghXhLV2AgkJAClpcDly2IH\n649/FL9sKpXb1XBueblC7ttvB9atE+/X+vvfgaIicZCX+fPFz8iPP4pnf61cIbOaDbUf2r9/PwRB\nQHh4OB566CFcvHhRgZTqxwcDpOE6DY1rJA3XSTmKD3zR09OD559/Ht9++y20Wi0iIiIQExNjN4R7\nVlYWysvLUVZWhvz8fCQlJSEvL0/B1M5jNpuVjnBLrLktFvGMU10dUF0tLlVVwM8/i0t1tXh/SXAw\noNeLR+RXrBA7WP7+8t/cr/Z6qw3n/v00GrFjNX8+0NkJ/OtfwOHD4lles1l8/P77gdJSM6qrxc+V\nu15aOFKk7IcCAwNx6tQpeHl5IScnB88++6zb7IfkpNZRMOXGdRoa10garpNyFO9kFRQUICgoyDYp\nZVxcHI4cOWK3czt69CjWrFkDAIiMjITZbMbVq1fh6+urRGRVIRLPJvX0iEe9rYv10lPr7z094r0g\nv/4qfpG7cQP45RegrU38InftGtDUJC4NDcD580BGhnhpn48PoNUC990H3Huv2KF69FFApwOmTROP\nyDPGfr/bbgOWLRMXAKipAf79b/Fs17lzwJw54uc1KEhc7r0XCAgQO14+PuIluZMnA3feCYwdyyMY\nWknZD83tMwpJZGQkamtr5Y7JGGNMRRTvZNXV1SEgIMD2u7+/P/Lz84d8TW1trao6Wf/7H7Bokdi5\nIbrZ0fn550r885/2jwM3f3fE+pz19T094hml7m7x366um4vFIn6R8vAAxowRj3BrNPaL9XEPD7FD\ndPvt4gh+d94JeHmJy5Qp4pcznU681C8joxIffQT4+orvV4v+k1irBeeWl1pyBwSIkxjHxwNXr1Zi\n716gvR0oLxeX6mpxAJm8PPEAybVr4tLeLh5QGTtW/Lzfdhvwhz8Anp7idqDv9mLMGOAvf7nZsXNH\nUvZDfe3evRtLliyRIxpjjDGVUryTpZF4KLX/qB/936fT6ST/LVfT3PzpiP59IrGzZbE49+9qtSOb\ne6R8+innlhPnls9wM3d0iMtQHnvsFgNJoNPpRu6PSzScfceJEyewZ88enDlzZsBzat4Pyen1119X\nOoIqcJ2GxjWShuv020ZqP6R4J0ur1aKmpsb2e01NDfz9/X/zNbW1tdBqtXavKS8vH9mgjDHG3JKU\n/RAAXLx4EevWrUNOTg7uuuuuAc/zfogxxpiV4rdHz5o1C2VlZaisrERXVxe+/PJLxMTE2L0mJiYG\n+/btAwDk5eVh4sSJqrpUkDHGmOuSsh+qrq7GE088gc8//xxBQUEKJWWMMaYWip/J8vDwQHp6Oh55\n5BH09PQgMTERISEh+PDDDwEA69evx5IlS5CVlYWgoCCMGzcOn3zyicKpGWOMuQsp+6GtW7eitbUV\nSUlJAABPT08UFBQoGZsxxpgL0xBPT88YY4wxxhhjTqP45YLDpdYJI4fKfeTIEQiCAJPJhAceeADf\nf/+9AikHkjJRNACcO3cOHh4e+Prrr2VMN7ihcp88eRJeXl4wmUwwmUx48803FUhpT0qtT548CZPJ\nBIPB4DLzXgyV+5133rHVOSwsDB4eHi4xD9VQua9du4ZHH30URqMRBoMBe/fulT+kA0Plbm1txYoV\nKyAIAiIjI1FSUqJASntr166Fr68vwsLCBn2N2iecl7qtdFdTp05FeHg4TCYTZs+eDQBoaWnBokWL\nEBwcjMWLF9t97rdv3w69Xo8ZM2bg+PHjtscLCwsRFhYGvV6PF198Ufb1cCZH7d6ZNens7MTq1auh\n1+sxZ84cVFVVybNiTuSoRikpKfD397ftN7Kzs23PjcYaAeJ9olFRUQgNDYXBYMAHH3wAgNtTX4PV\nSNH2RCrS3d1NOp2OKioqqKuriwRBoNLSUrvX5ObmktlsJiKi7OxsioyMVCKqHSm5Ozo6bD9fvHiR\ndDqd3DEHkJLb+rqoqChaunQpffXVVwokHZhnqNwnTpygxx57TKGEA0nJ3NraSjNnzqSamhoiImpq\nalIiqh2pbcQqMzOTFixYIGNCx6Tkfu2112jLli1EJNba29ubLBaLEnFtpOR+5ZVXaOvWrURE9NNP\nP7lEvU+dOkXnz58ng8Hg8PlvvvmGoqOjiYgoLy/PJbbbwzHcz4E7mjp1KjU3N9s9tnnzZkpNTSUi\noh07dtCrr75KREQlJSUkCAJ1dXVRRUUF6XQ66u3tJSKiiIgIys/PJyKi6Ohoys7OlnEtnMtRu3dm\nTXbt2kVJSUlERHTw4EFavXq1bOvmLI5qlJKSQu++++6A147WGhERNTQ0UFFRERERtbe3U3BwMJWW\nlnJ76mOwGinZnlR1JqvvhJGenp62CSP7mjt3Lry8vAC4zoSRUnKPGzfO9nNHRwcmT54sd8wBpOQG\ngJ07d2LlypWYMmWKAikHkpqbXOhKWSmZDxw4gNjYWNuoZ2pqI1YHDhxAfHy8jAkdk5Lbz88PbW1t\nAIC2tjZMmjQJHh7K3sYqJfelS5cQFRUFAJg+fToqKyvR1NSkRFyb+fPnOxyNz2qwCefVYrifA3fV\nf5va9/91zZo1OHz4MADxyo34+Hh4enpi6tSpCAoKQn5+PhoaGtDe3m47E/bUU0/Z3qNGjtq9M2vS\n92/Fxsbiu+++k2vVnGawbYOj/fNorREA3H333TAajQCA8ePHIyQkBHV1ddye+hisRoBy7UlVnSxH\nE0ZaC+iIq0wYKTX34cOHERISgujoaNtpTiVJyV1XV4cjR47YbgZ3hTlipOTWaDTIzc2FIAhYsmQJ\nSktL5Y5pR0rmsrIytLS0ICoqCrNmzcJnn30md8wBhvOZvHHjBo4dO4bY2Fi54g1KSu5169ahpKQE\n99xzDwRBQFpamtwxB5CSWxAE22W7BQUFqKqqcomDTb9lsAnn1WK4+yZ3pNFosHDhQsyaNQsff/wx\nAODq1au2kYB9fX1tHef6+nq7IfKt9er/uFardbs6OrMmfdudh4cHvLy80NLSIteqjKidO3dCEAQk\nJibaLoHjGokqKytRVFSEyMhIbk+DsNZozpw5AJRrT6rqZN3KhJGucG281NzLly/HpUuXkJmZiYSE\nhBFONTQpuTdt2oQdO3ZAo9GAiFzi7JCU3Pfffz9qampw4cIFbNy4EcuXL5ch2eCkZLZYLDh//jyy\nsrJw7NgxvPHGGygrK5Mh3eCG85nMzMzEvHnzMHHixBFMJI2U3Nu2bYPRaER9fT2Ki4uRnJyM9vZ2\nGdINTkruLVu2wGw2w2QyIT09HSaTCWPGjJEh3e/Tf9vhCgdspFJT1pFy5swZFBUVITs7G7t27cLp\n06ftntdoNFynfrgmjiUlJaGiogLFxcXw8/PDyy+/rHQkl9HR0YHY2FikpaVhwoQJds9xexJ1dHRg\n5cqVSEtLw/jx4xVtT6rqZA13wsijR4/+5iUqcpGa22r+/Pno7u5Gc3OzHPEGJSV3YWEh4uLiMG3a\nNBw6dAjPPfccjh49KndUO1JyT5gwAWPHjgUAREdHw2KxKHrERkrmgIAALF68GHfccQcmTZqEhx9+\nGBcuXJA7qp3htO2DBw+6xKWCgLTcubm5WLVqFQBxNvhp06bh8uXLsubsT2rb3rNnD4qKirBv3z40\nNTUhMDBQ7qjDImXCeVc23G28O/Lz8wMATJkyBStWrEBBQQF8fX3R2NgIAGhoaICPjw8Ax//f/v7+\n0Gq1dmcw1dYOpHBGTaxtS6vVorq6GgDQ3d2NX375Bd7e3nKtyojx8fGxdRieeeYZ21QJo71GFosF\nsbGxSEhIsB0Y5vZkz1qjJ5980lYjRdvT77/VTD4Wi4UCAwOpoqKCOjs7Hd5cXFVVRTqdjs6ePatQ\nyoGk5C4vL7fdcFdYWEiBgYFKRLUjJXdfTz/9NB06dEjGhI5Jyd3Y2Gird35+Pt13330KJL1JSuZL\nly7RggULqLu7m65fv04Gg4FKSkoUSiyS2kbMZjN5e3vTjRs3FEg5kJTcL730EqWkpBCR2F60Wu2A\nG/vlJiW32Wymzs5OIiL66KOPaM2aNQokHaiiokLSwBdnz55V3cAXw91Wupvr169TW1sbEYmDOD34\n4IN07Ngx2rx5M+3YsYOIiLZv3z7gpvzOzk66cuUKBQYG2rbHs2fPpry8POrt7VX9wBdEA9u9M2uy\na9cu2rBhAxERffHFF6obqMCqf43q6+ttP7/33nsUHx9PRKO7Rr29vZSQkECbNm2ye5zb002D1UjJ\n9qSqThYRUVZWFgUHB5NOp6Nt27YREVFGRgZlZGQQEVFiYiJ5e3uT0Wgko9FIERERSsa1GSp3amoq\nhYaGktFopHnz5lFBQYGScW2Gyt2Xq3SyiIbOnZ6eTqGhoSQIAs2dO9clOuVSav3222/TzJkzyWAw\nUFpamlJR7UjJvXfvXtuGzVUMlbupqYmWLVtG4eHhZDAYaP/+/UrGtRkqd25uLgUHB9P06dMpNjbW\nNtqqkuLi4sjPz488PT3J39+fdu/ePaCNJCcnk06no/DwcCosLFQw7a1x9P8yWly5coUEQSBBECg0\nNNS2/s3NzbRgwQLS6/W0aNEiam1ttb3nrbfeIp1OR9OnT6ecnBzb4z/88AMZDAbS6XS0ceNG2dfF\nmfq3+z179ji1Jr/++iutWrWKgoKCKDIykioqKuRcPadwtG1ISEigsLAwCg8Pp8cff5waGxttrx+N\nNSIiOn36NGk0GhIEwfb9Njs7m9tTH45qlJWVpWh74smIGWOMMcYYY8yJVHVPFmOMMcYYY4y5Ou5k\nMcYYY4wxxpgTcSeLMcYYY4wxxpyIO1mMMcYYY4wx5kTcyWKMMcYYY4wxJ+JOFmOMMcYYY4w5EXey\nGGOMMcYYY8yJ/g+4vm3+G+iD0wAAAABJRU5ErkJggg==\n",
+       "text": [
+        "<matplotlib.figure.Figure at 0xe197c50>"
+       ]
+      }
+     ],
+     "prompt_number": 11
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}

--- a/pymc/examples/discrete_find_MAP.ipynb
+++ b/pymc/examples/discrete_find_MAP.ipynb
@@ -56,15 +56,7 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stderr",
-       "text": [
-        "WARNING (theano.gof.compilelock): Overriding existing lock by dead process '25402' (I am process '18668')\n"
-       ]
-      }
-     ],
+     "outputs": [],
      "prompt_number": 2
     },
     {
@@ -531,7 +523,7 @@
       "with model:\n",
       "    for i in range(n+1):\n",
       "        s = {'p':0.5, 'surv_sim':i}\n",
-      "        map_est = mc.find_MAP(start=s, vars=model.vars, fmin=bh, minimizer_kwargs={\"method\": \"Powell\"})\n",
+      "        map_est = mc.find_MAP(start=s, vars=model.vars, fmin=bh, minimizer_kwargs={\"method\": /\"Powell\"})\n",
       "        print('surv_sim: %i->%i, p: %f->%f, LogP:%f'%(s['surv_sim'],\n",
       "                                                      map_est['surv_sim'],\n",
       "                                                      s['p'],\n",
@@ -728,16 +720,7 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stderr",
-       "text": [
-        "/nfs/adaptive/bedwards/anaconda/envs/pymc-dev/lib/python2.7/site-packages/theano/scan_module/scan_perform_ext.py:85: RuntimeWarning: numpy.ndarray size changed, may indicate binary incompatibility\n",
-        "  from scan_perform.scan_perform import *\n"
-       ]
-      }
-     ],
+     "outputs": [],
      "prompt_number": 9
     },
     {

--- a/pymc/examples/discrete_find_MAP.py
+++ b/pymc/examples/discrete_find_MAP.py
@@ -1,0 +1,117 @@
+# Using `find_MAP` on models with discrete variables
+
+# Maximum a posterior(MAP) estimation, can be difficult in models which have
+# discrete stochastic variables. Here we demonstrate the problem with a simple
+# model, and present a few possible work arounds.
+
+import pymc as mc
+
+# We define a simple model of a survey with one data point. We use a $Beta$
+# distribution for the $p$ parameter in a binomial. We would like to know both
+# the posterior distribution for p, as well as the predictive posterior
+# distribution over the survey parameter.
+
+alpha = 4
+beta = 4
+n = 20
+yes = 15
+
+with mc.Model() as model:
+    p = mc.Beta('p', alpha, beta)
+    surv_sim = mc.Binomial('surv_sim', n=n, p=p)
+    surv = mc.Binomial('surv', n=n, p=p, observed=yes)
+
+# First let's try and use `find_MAP`.
+
+with model:
+    print(mc.find_MAP())
+
+# `find_map` defaults to find the MAP for only the continuous variables we have
+# to specify if we would like to use the discrete variables.
+
+with model:
+    print(mc.find_MAP(vars=model.vars, disp=True))
+
+# We set the `disp` variable to display a warning that we are using a
+# non-gradient minimization technique, as discrete variables do not give much
+# gradient information. To demonstrate this, if we use a gradient based
+# minimization, `fmin_bfgs`, with various starting points we see that the map
+# does not converge.
+
+with model:
+    for i in range(n+1):
+        s = {'p':0.5, 'surv_sim':i}
+        map_est = mc.find_MAP(start=s, vars=model.vars,
+                              fmin=mc.starting.optimize.fmin_bfgs)
+        print('surv_sim: %i->%i, p: %f->%f, LogP:%f'%(s['surv_sim'],
+                                                      map_est['surv_sim'],
+                                                      s['p'],
+                                                      map_est['p'],
+                                                      model.logpc(map_est)))
+
+# Once again because the gradient of `surv_sim` provides no information to the
+# `fmin` routine and it is only changed in a few cases, most of which are not
+# correct. Manually, looking at the log proability we can see that the maximum
+# is somewhere around `surv_sim`$=14$ and `p`$=0.7$. If we employ a
+# non-gradient minimization, such as `fmin_powell` (the default when discrete
+# variables are detected), we might be able to get a better estimate.
+
+with model:
+    for i in range(n+1):
+        s = {'p':0.5, 'surv_sim':i}
+        map_est = mc.find_MAP(start=s, vars=model.vars)
+        print('surv_sim: %i->%i, p: %f->%f, LogP:%f'%(s['surv_sim'],
+                                                      map_est['surv_sim'],
+                                                      s['p'],
+                                                      map_est['p'],
+                                                      model.logpc(map_est)))
+
+# For most starting values this converges to the maximum log likelihood of
+# $\approx -3.15$, but for particularly low starting values of `surv_sim`, or
+# values near `surv_sim`$=14$ there is still some noise. The scipy optimize
+# package contains some more general 'global' minimization functions that we
+# can utilize. The `basinhopping` algorithm restarts the optimization at places
+# near found minimums. Because it has a slightly different interface to other
+# minimization schemes we have to define a wrapper function.
+
+def bh(*args,**kwargs):
+    result = mc.starting.optimize.basinhopping(*args, **kwargs)
+    # A `Result` object is returned, the argmin value can be in `x`
+    return result['x']
+
+with model:
+    for i in range(n+1):
+        s = {'p':0.5, 'surv_sim':i}
+        map_est = mc.find_MAP(start=s, vars=model.vars, fmin=bh)
+        print('surv_sim: %i->%i, p: %f->%f, LogP:%f'%(s['surv_sim'],
+                                                      map_est['surv_sim'],
+                                                      s['p'],
+                                                      map_est['p'],
+                                                      model.logpc(map_est)))
+
+# By default `basinhopping` uses a gradient minimization technique,
+# `fmin_bfgs`, resulting in inaccurate predictions many times. If we force
+# `basinhoping` to use a non-gradient technique we get much better results
+
+with model:
+    for i in range(n+1):
+        s = {'p':0.5, 'surv_sim':i}
+        map_est = mc.find_MAP(start=s, vars=model.vars,
+                              fmin=bh, minimizer_kwargs={"method": "Powell"})
+        print('surv_sim: %i->%i, p: %f->%f, LogP:%f'%(s['surv_sim'],
+                                                      map_est['surv_sim'],
+                                                      s['p'],
+                                                      map_est['p'],
+                                                      model.logpc(map_est)))
+
+# Confident in our MAP estimate we can sample from the posterior, making sure
+# we use the `Metropolis` method for our discrete variables.
+
+with model:
+    step1 = mc.step_methods.HamiltonianMC(vars=[p])
+    step2 = mc.step_methods.Metropolis(vars=[surv_sim])
+
+with model:
+    trace = mc.sample(25000,[step1,step2],start=map_est)
+
+mc.traceplot(trace);

--- a/pymc/examples/discrete_find_MAP.py
+++ b/pymc/examples/discrete_find_MAP.py
@@ -40,7 +40,7 @@ with model:
 
 with model:
     for i in range(n+1):
-        s = {'p':0.5, 'surv_sim':i}
+        s = {'p': 0.5, 'surv_sim': i}
         map_est = mc.find_MAP(start=s, vars=model.vars,
                               fmin=mc.starting.optimize.fmin_bfgs)
         print('surv_sim: %i->%i, p: %f->%f, LogP:%f'%(s['surv_sim'],
@@ -58,7 +58,7 @@ with model:
 
 with model:
     for i in range(n+1):
-        s = {'p':0.5, 'surv_sim':i}
+        s = {'p': 0.5, 'surv_sim': i}
         map_est = mc.find_MAP(start=s, vars=model.vars)
         print('surv_sim: %i->%i, p: %f->%f, LogP:%f'%(s['surv_sim'],
                                                       map_est['surv_sim'],
@@ -74,14 +74,15 @@ with model:
 # near found minimums. Because it has a slightly different interface to other
 # minimization schemes we have to define a wrapper function.
 
-def bh(*args,**kwargs):
+
+def bh(*args, **kwargs):
     result = mc.starting.optimize.basinhopping(*args, **kwargs)
     # A `Result` object is returned, the argmin value can be in `x`
     return result['x']
 
 with model:
     for i in range(n+1):
-        s = {'p':0.5, 'surv_sim':i}
+        s = {'p': 0.5, 'surv_sim': i}
         map_est = mc.find_MAP(start=s, vars=model.vars, fmin=bh)
         print('surv_sim: %i->%i, p: %f->%f, LogP:%f'%(s['surv_sim'],
                                                       map_est['surv_sim'],
@@ -95,7 +96,7 @@ with model:
 
 with model:
     for i in range(n+1):
-        s = {'p':0.5, 'surv_sim':i}
+        s = {'p': 0.5, 'surv_sim': i}
         map_est = mc.find_MAP(start=s, vars=model.vars,
                               fmin=bh, minimizer_kwargs={"method": "Powell"})
         print('surv_sim: %i->%i, p: %f->%f, LogP:%f'%(s['surv_sim'],
@@ -112,6 +113,6 @@ with model:
     step2 = mc.step_methods.Metropolis(vars=[surv_sim])
 
 with model:
-    trace = mc.sample(25000,[step1,step2],start=map_est)
+    trace = mc.sample(25000, [step1, step2], start=map_est)
 
 mc.traceplot(trace);

--- a/pymc/tests/test_tuning.py
+++ b/pymc/tests/test_tuning.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy import inf
 from pymc.tuning import scaling
 from pymc.tuning import starting
-from pymc import Model, Uniform, Normal
+from pymc import Model, Uniform, Normal, Beta, Binomial
 from pymc.tests.checks import close_to
 from . import models
 
@@ -21,6 +21,28 @@ def test_guess_scaling():
     a1 = scaling.guess_scaling(start, model=model)
 
     assert all((a1 > 0) & (a1 < 1e200))
+
+
+def test_find_MAP_discrete():
+    tol = 2.0**-11
+    alpha = 4
+    beta = 4
+    n = 20
+    yes = 15
+
+    with Model() as model:
+        p = Beta('p',alpha,beta)
+        ss = Binomial('ss', n=n, p=p)
+        s = Binomial('s', n=n, p=p, observed=yes)
+        
+        map_est1 = starting.find_MAP()
+        map_est2 = starting.find_MAP(vars=model.vars)
+
+    close_to(map_est1['p'], 0.6086956533498806, tol)
+    assert 'ss' not in map_est1
+
+    close_to(map_est2['p'], 0.695642178810167, tol)
+    assert map_est2['ss'] == 14
 
 
 def test_find_MAP():

--- a/pymc/tests/test_tuning.py
+++ b/pymc/tests/test_tuning.py
@@ -31,10 +31,10 @@ def test_find_MAP_discrete():
     yes = 15
 
     with Model() as model:
-        p = Beta('p',alpha,beta)
+        p = Beta('p', alpha, beta)
         ss = Binomial('ss', n=n, p=p)
         s = Binomial('s', n=n, p=p, observed=yes)
-        
+
         map_est1 = starting.find_MAP()
         map_est2 = starting.find_MAP(vars=model.vars)
 

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -27,11 +27,10 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
     vars : list
         List of variables to set to MAP point (Defaults to all continuous).
         If discrete variables are included, estimates are likely to be 
-        inaccurate, and a warning is issued if the default `fmin` is the
-        default.
+        inaccurate, and a warning is issued if `fmin` is not specified.
     fmin : function
         Optimization algorithm (Defaults to `scipy.optimize.fmin_bfgs`) for 
-        continuous variables. If their are discrete variable specified,
+        continuous variables. If there are discrete variable specified,
         defaults to `scipy.optimize.fmin_powell`, which provides slightly
         better performance.
     return_raw : Bool

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -28,8 +28,8 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
         List of variables to set to MAP point (Defaults to all continuous).
     fmin : function
         Optimization algorithm (Defaults to `scipy.optimize.fmin_bfgs` unless
-        discrete variables are specified in `vars`, then 
-        `scipy.optimize.fmin_powell` which will perform better). 
+        discrete variables are specified in `vars`, then
+        `scipy.optimize.fmin_powell` which will perform better).
     return_raw : Bool
         Whether to return extra value returned by fmin (Defaults to `False`)
     disp : Bool
@@ -45,9 +45,9 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
 
     if vars is None:
         vars = model.cont_vars
-    
+ 
     disc_vars = list(typefilter(vars, discrete_types))
-    
+
     if disc_vars and disp:
         print("Warning: vars contains discrete variables. MAP " +
               "estimates may not be accurate for the default " +

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -26,10 +26,10 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
     start : dict of parameter values (Defaults to model.test_point)
     vars : list
         List of variables to set to MAP point (Defaults to all continuous).
-        If discrete variables are included, estimates are likely to be 
+        If discrete variables are included, estimates are likely to be
         inaccurate, and a warning is issued if `fmin` is not specified.
     fmin : function
-        Optimization algorithm (Defaults to `scipy.optimize.fmin_bfgs`) for 
+        Optimization algorithm (Defaults to `scipy.optimize.fmin_bfgs`) for
         continuous variables. If there are discrete variable specified,
         defaults to `scipy.optimize.fmin_powell`, which provides slightly
         better performance.
@@ -45,18 +45,18 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
 
     if vars is None:
         vars = model.cont_vars
-        if fmin is None:
-            fmin = optimize.fmin_bfgs
     else:
-        disc_vars = list(typefilter(vars,discrete_types))
+        disc_vars = list(typefilter(vars, discrete_types))
         if disc_vars:
             if fmin is None:
-                print("Warning: vars contains discrete variables. MAP " +\
-                      "estimates may not be accurate for the default " +\
-                      "parameters. Defaulting to non-gradient minimization " +\
+                print("Warning: vars contains discrete variables. MAP " +
+                      "estimates may not be accurate for the default " +
+                      "parameters. Defaulting to non-gradient minimization " +
                       "fmin_powell.")
-                fmin = optimize.fmin_powell 
+                fmin = optimize.fmin_powell
 
+    if fmin is None:
+        fmin = optimize.fmin_bfgs
 
     allinmodel(vars, model)
 
@@ -71,7 +71,7 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
 
     def grad_logp_o(point):
         return nan_to_num(-dlogp(point))
- 
+
     # Check to see if minimization function actually uses the gradient
     if 'fprime' in getargspec(fmin).args:
         r = fmin(logp_o, bij.map(
@@ -87,19 +87,19 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
     if (not allfinite(mx) or
         not allfinite(logp(mx)) or
             not allfinite(dlogp(mx))):
-            raise ValueError("Optimization error: max, logp or dlogp at " +\
-                             "max have bad values. Some values may be " +\
-                             "outside of distribution support. max: " +\
-                             repr(mx) + " logp: " + repr(logp(mx)) +\
-                             " dlogp: " + repr(dlogp(mx)) + "Check that " +\
-                             "1) you don't have hierarchical parameters, " +\
-                             "these will lead to points with infinite " +\
-                             "density. 2) your distribution logp's are " +\
+            raise ValueError("Optimization error: max, logp or dlogp at " +
+                             "max have bad values. Some values may be " +
+                             "outside of distribution support. max: " +
+                             repr(mx) + " logp: " + repr(logp(mx)) +
+                             " dlogp: " + repr(dlogp(mx)) + "Check that " +
+                             "1) you don't have hierarchical parameters, " +
+                             "these will lead to points with infinite " +
+                             "density. 2) your distribution logp's are " +
                              "properly specified.")
 
     mx = bij.rmap(mx)
-    mx = {v.name:np.floor(mx[v.name]) if v.dtype in discrete_types else
-                 mx[v.name] for v in vars}
+    mx = {v.name: np.floor(mx[v.name]) if v.dtype in discrete_types else
+          mx[v.name] for v in vars}
     if return_raw:
         return mx, r
     else:

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -23,18 +23,18 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
 
     Parameters
     ----------
-    start : dict of parameter values (Defaults to model.test_point)
+    start : `dict` of parameter values (Defaults to `model.test_point`)
     vars : list
         List of variables to set to MAP point (Defaults to all continuous).
-        If discrete variables are included, estimates are likely to be
-        inaccurate, and a warning is issued if `fmin` is not specified.
     fmin : function
-        Optimization algorithm (Defaults to `scipy.optimize.fmin_bfgs`) for
-        continuous variables. If there are discrete variable specified,
-        defaults to `scipy.optimize.fmin_powell`, which provides slightly
-        better performance.
+        Optimization algorithm (Defaults to `scipy.optimize.fmin_bfgs` unless
+        discrete variables are specified in `vars`, then 
+        `scipy.optimize.fmin_powell` which will perform better). 
     return_raw : Bool
-        Whether to return extra value returned by fmin (Defaults to False)
+        Whether to return extra value returned by fmin (Defaults to `False`)
+    disp : Bool
+        Display helpful warnings, and verbose output of `fmin` (Defaults to
+        `False`)
     model : Model (optional if in `with` context)
     *args, **kwargs
         Extra args passed to fmin
@@ -45,17 +45,18 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
 
     if vars is None:
         vars = model.cont_vars
-    else:
-        disc_vars = list(typefilter(vars, discrete_types))
-        if disc_vars:
-            if fmin is None:
-                print("Warning: vars contains discrete variables. MAP " +
-                      "estimates may not be accurate for the default " +
-                      "parameters. Defaulting to non-gradient minimization " +
-                      "fmin_powell.")
-                fmin = optimize.fmin_powell
+    
+    disc_vars = list(typefilter(vars, discrete_types))
+    
+    if disc_vars and disp:
+        print("Warning: vars contains discrete variables. MAP " +
+              "estimates may not be accurate for the default " +
+              "parameters. Defaulting to non-gradient minimization " +
+              "fmin_powell.")
 
-    if fmin is None:
+    if fmin is None and disc_vars:
+        fmin = optimize.fmin_powell
+    else:
         fmin = optimize.fmin_bfgs
 
     allinmodel(vars, model)

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -27,7 +27,8 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
     vars : list
         List of variables to set to MAP point (Defaults to all continuous).
         If discrete variables are included, estimates are likely to be 
-        inaccurate, and a warning is issued.
+        inaccurate, and a warning is issued if the default `fmin` is the
+        default.
     fmin : function
         Optimization algorithm (Defaults to `scipy.optimize.fmin_bfgs`) for 
         continuous variables. If their are discrete variable specified,
@@ -50,10 +51,11 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
     else:
         disc_vars = list(typefilter(vars,discrete_types))
         if disc_vars:
-            print("Warning: vars contains discrete variables. MAP " +\
-                  "estimates may not be accurate for the default parameters."+\
-                  " Defaulting to non-gradient minimization fmin_powell.")
             if fmin is None:
+                print("Warning: vars contains discrete variables. MAP " +\
+                      "estimates may not be accurate for the default " +\
+                      "parameters. Defaulting to non-gradient minimization " +\
+                      "fmin_powell.")
                 fmin = optimize.fmin_powell 
 
 

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -14,7 +14,7 @@ from inspect import getargspec
 __all__ = ['find_MAP', 'scipyminimize']
 
 
-def find_MAP(start=None, vars=None, fmin=optimize.fmin_bfgs, return_raw=False,
+def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
              disp=False, model=None, *args, **kwargs):
     """
     Sets state to the local maximum a posteriori point given a model.
@@ -45,13 +45,16 @@ def find_MAP(start=None, vars=None, fmin=optimize.fmin_bfgs, return_raw=False,
 
     if vars is None:
         vars = model.cont_vars
+        if fmin is None:
+            fmin = optimize.fmin_bfgs
     else:
         disc_vars = list(typefilter(vars,discrete_types))
         if disc_vars:
             print("Warning: vars contains discrete variables. MAP " +\
                   "estimates may not be accurate for the default parameters."+\
                   " Defaulting to non-gradient minimization fmin_powell.")
-            fmin = optimize.fmin_powell 
+            if fmin is None:
+                fmin = optimize.fmin_powell 
 
 
     allinmodel(vars, model)

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -54,10 +54,11 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
               "parameters. Defaulting to non-gradient minimization " +
               "fmin_powell.")
 
-    if fmin is None and disc_vars:
-        fmin = optimize.fmin_powell
-    else:
-        fmin = optimize.fmin_bfgs
+    if fmin is None:
+        if disc_vars:
+            fmin = optimize.fmin_powell
+        else:
+            fmin = optimize.fmin_bfgs
 
     allinmodel(vars, model)
 

--- a/pymc/tuning/starting.py
+++ b/pymc/tuning/starting.py
@@ -45,7 +45,7 @@ def find_MAP(start=None, vars=None, fmin=None, return_raw=False,
 
     if vars is None:
         vars = model.cont_vars
- 
+
     disc_vars = list(typefilter(vars, discrete_types))
 
     if disc_vars and disp:


### PR DESCRIPTION
Addresses #396. This pull request addresses some issues with finding Maximum a Posterior(MAP) estimates when a model contains discrete stochastics.
1. Provides a better performing minimization function (`fmin_powell`) when discrete stochastics are used.
2. If no `fmin` is provided and `vars` contains discrete stochastics, provide a warning, and switch minimization methods
3. Floor discrete stochastic values before they are returned so they match the support of the original distribution
4. Clean up >80 error message for PEP8 compliance.
