### PR TITLE
Specify python versions in Trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,10 @@ VERSION = "3.0"
 
 classifiers = ['Development Status :: 3 - Alpha',
                'Programming Language :: Python',
+               'Programming Language :: Python :: 2',
+               'Programming Language :: Python :: 3',
+               'Programming Language :: Python :: 2.7',
+               'Programming Language :: Python :: 3.3',
                'License :: OSI Approved :: Apache Software License',
                'Intended Audience :: Science/Research',
                'Topic :: Scientific/Engineering',


### PR DESCRIPTION
This adds more specific Trove classifiers for Python (only 2.7 and 3.3 are specified given the discussion in #412).
