### PR TITLE
Show non-KeyboardInterrupt errors when sampling

### DIFF
--- a/pymc/sample.py
+++ b/pymc/sample.py
@@ -83,8 +83,7 @@ def sample(draws, step, start=None, trace=None, tune=None, progressbar=True, mod
                 progress.update(i)
     except KeyboardInterrupt:
         pass
-    finally:
-        return trace
+    return trace
 
 def stop_tuning(step):
     """ stop tuning the current step method """


### PR DESCRIPTION
If the function returns in the finally block, any errors that happen in
the try block are masked. Returning the function outside of the finally
retains the same KeyboardInterrupt behavior but won't mask any other
errors that occur.
