### PR TITLE
Fix TypeError: can only concatenate list (not "dict_keys") to list on Py3

### DIFF
--- a/pymc/database/hdf5.py
+++ b/pymc/database/hdf5.py
@@ -327,7 +327,7 @@ class Database(pickle.Database):
                 if k.__class__ not in [tables.Table, tables.Group]:
                     setattr(db, k.name, k)
 
-            varnames = db._tables[-1].colnames + objects.keys()
+            varnames = db._tables[-1].colnames + list(objects.keys())
             db.trace_names = db.chains * [varnames, ]
 
     def connect_model(self, model):


### PR DESCRIPTION
This fixes 7 errors during `pymc.test()` on win-amd64-py33.
