### PR TITLE
Fix NameError in stochastic_volatility.ipynb

### DIFF
--- a/pymc/examples/stochastic_volatility.ipynb
+++ b/pymc/examples/stochastic_volatility.ipynb
@@ -138,8 +138,8 @@
      "input": [
       "model = pm.Model()\n",
       "with model:\n",
-      "    sigma, log_sigma = model.TransformedVar('sigma', Exponential.dist(1./.02, testval=.1),\n",
-      "                                            logtransform)\n",
+      "    sigma, log_sigma = model.TransformedVar('sigma', pm.Exponential.dist(1./.02, testval=.1),\n",
+      "                                            pm.logtransform)\n",
       "\n",
       "    nu = pm.Exponential('nu', 1./10)\n",
       "    s = GaussianRandomWalk('s', sigma**-2, shape=n)\n",
@@ -172,7 +172,7 @@
      "collapsed": false,
      "input": [
       "with model:\n",
-      "    start = find_MAP(vars=[s], fmin=optimize.fmin_l_bfgs_b)"
+      "    start = pm.find_MAP(vars=[s], fmin=optimize.fmin_l_bfgs_b)"
      ],
      "language": "python",
      "metadata": {},
@@ -208,7 +208,7 @@
      "collapsed": false,
      "input": [
       "figsize(12,6)\n",
-      "traceplot(trace, model.vars[:-1]);"
+      "pm.traceplot(trace, model.vars[:-1]);"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
When this notebook was added back in 85a017b (after being deleted in
138e145), a few names did not get updated to reflect the change of
`from pymc import *` to `import pymc as pm`.
