### PR TITLE
Fix for r-hat calculation on multidimensional variables

### DIFF
--- a/pymc/diagnostics.py
+++ b/pymc/diagnostics.py
@@ -134,6 +134,8 @@ def gelman_rubin(mtrace):
     def calc_rhat(x):
 
         try:
+            # When the variable is multidimensional, this assignment will fail, triggering
+            # a ValueError that will handle the multidimensional case
             m, n = x.shape
 
             # Calculate between-chain variance
@@ -149,7 +151,9 @@ def gelman_rubin(mtrace):
 
         except ValueError:
 
+            # Tricky transpose here, shifting the last dimension to the first
             rotated_indices = np.roll(np.arange(x.ndim), 1)
+            # Now iterate over the dimension of the variable
             return np.squeeze([calc_rhat(xi) for xi in x.transpose(rotated_indices)])
 
     Rhat = {}

--- a/pymc/diagnostics.py
+++ b/pymc/diagnostics.py
@@ -133,18 +133,24 @@ def gelman_rubin(mtrace):
 
     def calc_rhat(x):
 
-        m, n = x.shape
+        try:
+            m, n = x.shape
 
-        # Calculate between-chain variance
-        B = n * np.var(np.mean(x, axis=1), ddof=1)
+            # Calculate between-chain variance
+            B = n * np.var(np.mean(x, axis=1), ddof=1)
 
-        # Calculate within-chain variance
-        W = np.mean(np.var(x, axis=1, ddof=1))
+            # Calculate within-chain variance
+            W = np.mean(np.var(x, axis=1, ddof=1))
 
-        # Estimate of marginal posterior variance
-        Vhat = W*(n - 1)/n + B/n
+            # Estimate of marginal posterior variance
+            Vhat = W*(n - 1)/n + B/n
 
-        return np.sqrt(Vhat/W)
+            return np.sqrt(Vhat/W)
+
+        except ValueError:
+
+            rotated_indices = np.roll(np.arange(x.ndim), 1)
+            return np.squeeze([calc_rhat(xi) for xi in x.transpose(rotated_indices)])
 
     Rhat = {}
     for var in mtrace.varnames:


### PR DESCRIPTION
Found a bug in `forestplot` related to calculating R-hat for multidimensional variables. This seems to fix it.
