### PR TITLE
Use np prefix for numpy calls in tutorial

### DIFF
--- a/_sources/tutorial.txt
+++ b/_sources/tutorial.txt
@@ -99,7 +99,7 @@ acceptable.
 Next, we enter the actual data values into an array::
    
    disasters_array =   \
-        numpy.array([ 4, 5, 4, 0, 1, 4, 3, 4, 0, 6, 3, 3, 4, 0, 2, 6,
+        np.array([ 4, 5, 4, 0, 1, 4, 3, 4, 0, 6, 3, 3, 4, 0, 2, 6,
                       3, 3, 5, 4, 5, 3, 1, 4, 4, 1, 5, 5, 3, 4, 2, 5,
                       2, 2, 3, 4, 2, 1, 3, 2, 2, 1, 1, 1, 1, 3, 0, 0,
                       1, 0, 1, 1, 0, 0, 3, 1, 0, 3, 2, 2, 0, 1, 1, 1,
@@ -514,7 +514,7 @@ Consider the coal mining disasters data introduced previously. Assume that two
 years of data are missing from the time series; we indicate this in the data 
 array by the use of an arbitrary placeholder value, None.::
 
-    x = numpy.array([ 4, 5, 4, 0, 1, 4, 3, 4, 0, 6, 3, 3, 4, 0, 2, 6,
+    x = np.array([ 4, 5, 4, 0, 1, 4, 3, 4, 0, 6, 3, 3, 4, 0, 2, 6,
     3, 3, 5, 4, 5, 3, 1, 4, 4, 1, 5, 5, 3, 4, 2, 5,
     2, 2, 3, 4, 2, 1, 3, None, 2, 1, 1, 1, 1, 3, 0, 0,
     1, 0, 1, 1, 0, 0, 3, 1, 0, 3, 2, 2, 0, 1, 1, 1,
@@ -527,7 +527,7 @@ specialised NumPy arrays that contain a matching True or False value for each
 element to indicate if that value should be excluded from any computation. 
 Masked arrays can be generated using NumPy's ``ma.masked_equal`` function::
     
-    >>> masked_values = numpy.ma.masked_equal(x, value=None)
+    >>> masked_values = np.ma.masked_equal(x, value=None)
     >>> masked_values
     masked_array(data = [4 5 4 0 1 4 3 4 0 6 3 3 4 0 2 6 3 3 5 4 5 3 1 4 4 1 5 5 3
      4 2 5 2 2 3 4 2 1 3 -- 2 1 1 1 1 3 0 0 1 0 1 1 0 0 3 1 0 3 2 2 0 1 1 1 0 1 0


### PR DESCRIPTION
The tutorial begins by importing numpy with the prefix np.
Subsequent numpy calls in the tutorial now use the np
prefix.

Corrects later calls to numpy.a_thing that would result in
errors:

NameError: name 'numpy' is not defined
