### PR TITLE
ENH: use super call instead of directly calling __init__ on parent class

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -41,7 +41,7 @@ class Uniform(Continuous):
         Upper limit (defaults to 1)
     """
     def __init__(self, lower=0, upper=1, *args, **kwargs):
-        Continuous.__init__(self, *args, **kwargs)
+        super(Uniform, self).__init__(*args, **kwargs)
         self.lower = lower
         self.upper = upper
         self.mean = (upper + lower) / 2.
@@ -65,7 +65,7 @@ class Flat(Continuous):
     the passed value.
     """
     def __init__(self, *args, **kwargs):
-        Continuous.__init__(self, *args, **kwargs)
+        super(Flat, self).__init__(*args, **kwargs)
         self.median = 0
 
     def logp(self, value):
@@ -95,7 +95,7 @@ class Normal(Continuous):
 
     """
     def __init__(self, mu=0.0, tau=None, sd=None, *args, **kwargs):
-        Continuous.__init__(self, *args, **kwargs)
+        super(Normal, self).__init__(*args, **kwargs)
         self.mean = self.median = self.mode = self.mu = mu
         self.tau = get_tau(tau=tau, sd=sd)
         self.variance = 1. / self.tau
@@ -130,7 +130,7 @@ class Beta(Continuous):
 
     """
     def __init__(self, alpha, beta, *args, **kwargs):
-        Continuous.__init__(self, *args, **kwargs)
+        super(Beta, self).__init__(*args, **kwargs)
         self.alpha = alpha
         self.beta = beta
         self.mean = alpha / (alpha + beta)
@@ -161,7 +161,7 @@ class Exponential(Continuous):
         rate or inverse scale
     """
     def __init__(self, lam, *args, **kwargs):
-        Continuous.__init__(self, *args, **kwargs)
+        super(Exponential, self).__init__(*args, **kwargs)
         self.lam = lam
         self.mean = 1. / lam
         self.median = self.mean * log(2)
@@ -189,7 +189,7 @@ class Laplace(Continuous):
     """
 
     def __init__(self, mu, b, *args, **kwargs):
-        Continuous.__init__(self, *args, **kwargs)
+        super(Laplace, self).__init__(*args, **kwargs)
         self.b = b
         self.mean = self.median = self.mode = self.mu = mu
 
@@ -227,7 +227,7 @@ class Lognormal(Continuous):
 
     """
     def __init__(self, mu=0, tau=1, *args, **kwargs):
-        Continuous.__init__(self, *args, **kwargs)
+        super(Lognormal, self).__init__(*args, **kwargs)
         self.mu = mu
         self.tau = tau
         self.mean = exp(mu + 1./(2*tau))
@@ -269,7 +269,7 @@ class T(Continuous):
         Scale parameter (defaults to 1)
     """
     def __init__(self, nu, mu=0, lam=1, *args, **kwargs):
-        Continuous.__init__(self, *args, **kwargs)
+        super(T, self).__init__(*args, **kwargs)
         self.nu = nu
         self.lam = lam
         self.mean = self.median = self.mode = self.mu = mu
@@ -308,7 +308,7 @@ class Cauchy(Continuous):
     """
 
     def __init__(self, alpha, beta, *args, **kwargs):
-        Continuous.__init__(self, *args, **kwargs)
+        super(Cauchy, self).__init__(*args, **kwargs)
         self.median = self.mode = self.alpha = alpha
         self.beta = beta
 
@@ -345,7 +345,7 @@ class Gamma(Continuous):
 
     """
     def __init__(self, alpha, beta, *args, **kwargs):
-        Continuous.__init__(self, *args, **kwargs)
+        super(Gamma, self).__init__(*args, **kwargs)
         self.alpha = alpha
         self.beta = beta
         self.mean = alpha / beta

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -27,7 +27,7 @@ class Binomial(Discrete):
 
     """
     def __init__(self, n, p, *args, **kwargs):
-        Discrete.__init__(self, *args, **kwargs)
+        super(Binomial, self).__init__(*args, **kwargs)
         self.n = n
         self.p = p
         self.mode = cast(round(n * p), 'int8')
@@ -70,7 +70,7 @@ class BetaBin(Discrete):
 
     """
     def __init__(self, alpha, beta, n, *args, **kwargs):
-        Discrete.__init__(self, *args, **kwargs)
+        super(Binomial, self).__init__(*args, **kwargs)
         self.alpha = alpha
         self.beta = beta
         self.n = n
@@ -109,7 +109,7 @@ class Bernoulli(Discrete):
 
     """
     def __init__(self, p, *args, **kwargs):
-        Discrete.__init__(self, *args, **kwargs)
+        super(Binomial, self).__init__(*args, **kwargs)
         self.p = p
         self.mode = cast(round(p), 'int8')
 
@@ -144,7 +144,7 @@ class Poisson(Discrete):
 
     """
     def __init__(self, mu, *args, **kwargs):
-        Discrete.__init__(self, *args, **kwargs)
+        super(Binomial, self).__init__(*args, **kwargs)
         self.mu = mu
         self.mode = floor(mu).astype('int32')
 
@@ -177,7 +177,7 @@ class NegativeBinomial(Discrete):
 
     """
     def __init__(self, mu, alpha, *args, **kwargs):
-        Discrete.__init__(self, *args, **kwargs)
+        super(Binomial, self).__init__(*args, **kwargs)
         self.mu = mu
         self.alpha = alpha
         self.mode = floor(mu).astype('int32')
@@ -216,7 +216,7 @@ class Geometric(Discrete):
 
     """
     def __init__(self, p, *args, **kwargs):
-        Discrete.__init__(self, *args, **kwargs)
+        super(Binomial, self).__init__(*args, **kwargs)
         self.p = p
         self.mode = 1
 
@@ -239,7 +239,7 @@ class DiscreteUniform(Discrete):
 
     """
     def __init__(self, lower, upper, *args, **kwargs):
-        Discrete.__init__(self, *args, **kwargs)
+        super(Binomial, self).__init__(*args, **kwargs)
         self.lower, self.upper = floor(lower).astype('int32'), floor(upper).astype('int32')
         self.mode = floor((upper - lower) / 2.).astype('int32')
 
@@ -266,7 +266,7 @@ class Categorical(Discrete):
 
     """
     def __init__(self, p, *args, **kwargs):
-        Discrete.__init__(self, *args, **kwargs)
+        super(Binomial, self).__init__(*args, **kwargs)
         self.k = p.shape[0]
         self.p = p
         self.mode = argmax(p)
@@ -292,7 +292,7 @@ class ConstantDist(Discrete):
     """
 
     def __init__(self, c, *args, **kwargs):
-        Discrete.__init__(self, *args, **kwargs)
+        super(Binomial, self).__init__(*args, **kwargs)
         self.mean = self.median = self.mode = self.c = c
 
     def logp(self, value):
@@ -302,7 +302,7 @@ class ConstantDist(Discrete):
 
 class ZeroInflatedPoisson(Discrete):
     def __init__(self, theta, z, *args, **kwargs):
-        Discrete.__init__(self, *args, **kwargs)
+        super(Binomial, self).__init__(*args, **kwargs)
         self.theta = theta
         self.z = z
         self.pois = Poisson.dist(theta)

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -27,6 +27,7 @@ class Distribution(object):
 
     @classmethod
     def dist(cls, *args, **kwargs):
+        #super(Distribution, cls).__new__(
         dist = object.__new__(cls)
         dist.__init__(*args, **kwargs)
         return dist
@@ -67,15 +68,15 @@ def TensorType(dtype, shape):
 class Discrete(Distribution): 
     """Base class for discrete distributions"""
     def __init__(self, shape=(), dtype='int64', *args, **kwargs):
-        Distribution.__init__(self, shape, dtype, defaults=['mode'], *args, **kwargs)
+        super(Discrete, self).__init__(shape, dtype, defaults=['mode'], *args, **kwargs)
 
 class Continuous(Distribution): 
     """Base class for continuous distributions"""
     def __init__(self, shape=(), dtype='float64', *args, **kwargs):
-        Distribution.__init__(self, shape, dtype, defaults=['median', 'mean', 'mode'], *args, **kwargs)
+        super(Continuous, self).__init__(shape, dtype, defaults=['median', 'mean', 'mode'], *args, **kwargs)
 
 class DensityDist(Distribution):
     """Distribution based on a given log density function."""
     def __init__(self, logp, shape=(), dtype='float64',testval=0, *args, **kwargs):
-        Distribution.__init__(self, shape, dtype, testval, *args, **kwargs)
+        super(DensityDist, self).__init__(shape, dtype, testval, *args, **kwargs)
         self.logp = logp

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -21,7 +21,7 @@ class MvNormal(Continuous):
         2 array of floats
     """
     def __init__(self, mu, tau, *args, **kwargs):
-        Continuous.__init__(self, *args, **kwargs)
+        super(MvNormal, self).__init__(*args, **kwargs)
         self.mean = self.median = self.mode = self.mu = mu
         self.tau = tau
 
@@ -60,7 +60,7 @@ class Dirichlet(Continuous):
         as a parent of Multinomial and Categorical nevertheless.
     """
     def __init__(self, a, *args, **kwargs):
-        Continuous.__init__(self, *args, **kwargs)
+        super(Dirichlet, self).__init__(*args, **kwargs)
         self.a = a
         self.k = a.shape[0]
         self.mean = a / sum(a)
@@ -111,7 +111,7 @@ class Multinomial(Discrete):
         - :math:`Cov(X_i,X_j) = -n p_i p_j`
     """
     def __init__(self, n, p, *args, **kwargs):
-        Discrete.__init__(self, *args, **kwargs)
+        super(Multinomial, self).__init__(*args, **kwargs)
         self.n = n
         self.p = p
         self.mean = n * p
@@ -157,7 +157,7 @@ class Wishart(Continuous):
         Symmetric, positive definite.
     """
     def __init__(self, n, p, V, *args, **kwargs):
-        Continuous.__init__(self, *args, **kwargs)
+        super(Continuous, self).__init__(*args, **kwargs)
         self.n = n
         self.p = p
         self.V = V

--- a/pymc/distributions/timeseries.py
+++ b/pymc/distributions/timeseries.py
@@ -17,7 +17,7 @@ class AR1(Continuous):
        precision for innovations
     """
     def __init__(self, k, tau_e, *args, **kwargs):
-        Continuous.__init__(self, *args, **kwargs)
+        super(AR1, self).__init__(*args, **kwargs)
         self.k = k
         self.tau_e = tau_e
         self.tau = tau_e * (1 - k ** 2)
@@ -47,7 +47,7 @@ class GaussianRandomWalk(Continuous):
         distribution for initial value (Defaults to Flat())
     """
     def __init__(self, tau=None, init=Flat.dist(), sd=None, *args, **kwargs):
-        Continuous.__init__(self, *args, **kwargs)
+        super(GaussianRandomWalk, self).__init__(*args, **kwargs)
         self.tau = tau
         self.sd = sd
         self.init = init

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -50,8 +50,7 @@ class TransformedDistribution(Distribution):
         v = forward(FreeRV(name='v', distribution=dist))
         self.type = v.type
 
-        Distribution.__init__(self,
-                v.shape.tag.test_value, 
+        super(TransformedDistribution, self).__init__(v.shape.tag.test_value,
                 v.dtype, 
                 testval, dist.defaults, 
                 *args, **kwargs)

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -318,7 +318,7 @@ class FreeRV(Factor, TensorVariable):
         model : Model"""
         if type is None:
             type = distribution.type
-        TensorVariable.__init__(self, type, owner, index, name)
+        super(TensorVariable, self).__init__(type, owner, index, name)
 
         if distribution is not None:
             self.dshape = tuple(distribution.shape)

--- a/pymc/progressbar.py
+++ b/pymc/progressbar.py
@@ -43,7 +43,7 @@ class TextProgressBar(ProgressBar):
         self.width = 40
         self.printer = printer
 
-        ProgressBar.__init__(self, iterations)
+        super(TextProgressBar, self).__init__(iterations)
         self.update(0)
 
     def animate(self, i, elapsed):
@@ -94,7 +94,7 @@ class IPythonNotebookPB(ProgressBar):
             """ % (self.divid, self.sec_id))
         display(pb)
 
-        ProgressBar.__init__(self, iterations)
+        super(IPythonNotebookPB, self).__init__(iterations)
 
     def animate(self, i, elapsed):
         percentage = int(self.fraction(i))

--- a/pymc/step_methods/gibbs.py
+++ b/pymc/step_methods/gibbs.py
@@ -29,7 +29,7 @@ class ElemwiseCategoricalStep(ArrayStep):
         self.values = values
         self.var = var
 
-        ArrayStep.__init__(self, [var], [elemwise_logp(model, var)])
+        super(ElemwiseCategoricalStep, self).__init__([var], [elemwise_logp(model, var)])
 
     def astep(self, q, logp):
         p = array([logp(v * self.sh) for v in self.values])

--- a/pymc/step_methods/hmc.py
+++ b/pymc/step_methods/hmc.py
@@ -69,9 +69,7 @@ class HamiltonianMC(ArrayStep):
             state = SamplerHist()
         self.state = state
 
-        ArrayStep.__init__(self,
-                           vars, [model.fastlogp, model.fastdlogp(vars)]
-                           )
+        super(HamiltonianMC, self).__init__(vars, [model.fastlogp, model.fastdlogp(vars)])
 
     def astep(self, q0, logp, dlogp):
         H = Hamiltonian(logp, dlogp, self.potential)

--- a/pymc/step_methods/nuts.py
+++ b/pymc/step_methods/nuts.py
@@ -83,9 +83,7 @@ class NUTS(ArrayStep):
 
 
 
-        ArrayStep.__init__(self,
-                vars, [model.fastlogp, model.fastdlogp(vars)]
-                )
+        super(NUTS, self).__init__(vars, [model.fastlogp, model.fastdlogp(vars)])
 
     def astep(self, q0, logp, dlogp):
         H = Hamiltonian(logp, dlogp, self.potential)


### PR DESCRIPTION
This resolves Issue #448 by replacing `__init__` calls on parent class with `super(parent, self).__init__(...)` tests run as far as they do on Master but neither completed.
