### PR TITLE
Avoid SettingWithCopyWarning in ARM5_4 example

### DIFF
--- a/pymc/examples/ARM5_4.py
+++ b/pymc/examples/ARM5_4.py
@@ -13,11 +13,12 @@ wells = get_data_file('pymc.examples', 'data/wells.dat')
 data = pd.read_csv(wells, delimiter=u' ', index_col=u'id',
                    dtype={u'switch': np.int8})
 
+data.dist /= 100
+data.educ /= 4
+
 col = data.columns
 
 P = data[col[1:]]
-P.dist /= 100
-P.educ /= 4
 
 P = P - P.mean()
 P['1'] = 1


### PR DESCRIPTION
These changes fix the following warning from Pandas
(v0.13.1-63-gcc6ee40).

```
pandas/core/generic.py:1826: SettingWithCopyWarning:

A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_index,col_indexer] = value instead self[name] =
value
```
