### PR TITLE
Use `KeyError` instead of `exceptions.KeyError`

### DIFF
--- a/pymc/plots.py
+++ b/pymc/plots.py
@@ -73,7 +73,7 @@ def traceplot(trace, vars=None, figsize=None,
                 try:
                     ax[i, 0].axvline(x=lines[v], color="r", lw=1.5)
                     ax[i, 1].axhline(y=lines[v], color="r", lw=1.5, alpha=.35)
-                except exceptions.KeyError:
+                except KeyError:
                     pass
 
     plt.tight_layout()


### PR DESCRIPTION
Using `exceptions.KeyError` will lead to a `NameError`. `KeyError`
should be used instead because `KeyError` is already in builtins
namespace and because the exceptions module is not present in Python 3.

This fixes #483.
