### PR TITLE
Changed conda recipe to match the official one int he conda-recipes repository

### DIFF
--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
+
 if [ "$(uname)" == "Darwin" ]; then
+    export CFLAGS="-arch x86_64"
+    export FFLAGS="-static -ff2c -arch x86_64"
     export LDFLAGS="-Wall -undefined dynamic_lookup -bundle -arch x86_64"
 fi
 


### PR DESCRIPTION
This adds the build flags for OSX that are in the conda-recipes
repository. 

I must admit, that I'm not completely sure about what the build fags do. But I think the recipe here should match the one that is in conda/conda-recipes because that will most likely be the one people will use for building.
