### PR TITLE
Fix short test runs for several examples

### DIFF
--- a/pymc/examples/GHME_2013.py
+++ b/pymc/examples/GHME_2013.py
@@ -89,9 +89,9 @@ with model:
     
 def run(n=3000):
     if n == "short":
-        n = 50
+        n = 150
     with model:
-        trace = sample(1500, step, s)
+        trace = sample(n, step, s)
 
 
     # <codecell>

--- a/pymc/examples/disaster_model.py
+++ b/pymc/examples/disaster_model.py
@@ -57,7 +57,7 @@ def run(n=1000):
         # Use Metropolis for switchpoint, since it accomodates discrete variables
         step2 = Metropolis([switchpoint])
 
-        tr = sample(1000, tune=500, start=start, step=[step1, step2])
+        tr = sample(n, tune=500, start=start, step=[step1, step2])
 
 if __name__ == '__main__':
     run()

--- a/pymc/examples/hierarchical.py
+++ b/pymc/examples/hierarchical.py
@@ -56,7 +56,7 @@ def run(n=3000):
     if n == "short":
         n = 50
     with model:
-        trace = sample(3e3, step, start)
+        trace = sample(n, step, start)
         
 if __name__ == '__main__':
     run()

--- a/pymc/examples/nutstest.py
+++ b/pymc/examples/nutstest.py
@@ -18,11 +18,11 @@ with Model() as model:
 
     step = NUTS()
 
-def run(n=10):
+def run(n=5000):
     if n == "short":
         n = 50
     with model:
-        trace = sample(10, step)
+        trace = sample(n, step)
         
  
 

--- a/pymc/examples/simpletest.py
+++ b/pymc/examples/simpletest.py
@@ -25,7 +25,7 @@ def run(n=1000):
     if n == "short":
         n = 50
     with model:
-        trace = sample(1e3, step)
+        trace = sample(n, step)
 
     plt.subplot(2, 2, 1)
     plt.plot(trace[x][:, 0, 0])

--- a/pymc/examples/stochastic_volatility.py
+++ b/pymc/examples/stochastic_volatility.py
@@ -124,7 +124,7 @@ def run(n=2000):
         # Start next run at the last sampled position.
         start2 = trace.point(-1)
         step2 = HamiltonianMC(model.vars, hessian(start2, 6), path_length=4.)
-        trace = sample(2000, step2, trace=trace)
+        trace = sample(n, step2, trace=trace)
 
     # <codecell>
 


### PR DESCRIPTION
This fixes examples where passing `short` to `run` didn't have an effect
because the number of iterations was hardcoded in the `sample` call.

The length of the short run in GHME_2013.py is increased so that slicing
the trace object to burn the first 100 iterations does not lead to an
error when it is passed to `traceplot`.
