### PR TITLE
Removed unneeded Matplot import

### DIFF
--- a/pymc/tests/test_missing.py
+++ b/pymc/tests/test_missing.py
@@ -1,4 +1,4 @@
-from pymc import rnormal, Normal, MCMC, Uniform, Matplot, Metropolis
+from pymc import rnormal, Normal, MCMC, Uniform, Metropolis
 from numpy import ma, shape, ravel
 from numpy.testing import *
 


### PR DESCRIPTION
This import resulted in unnecessary failure of the test suite if
matplotlib is not installed.

Now the test suite passes wether or not matplotlib cab be found.
