### PR TITLE
add support for variables > 1d in traceplot

### DIFF
--- a/pymc/plots.py
+++ b/pymc/plots.py
@@ -55,7 +55,7 @@ def traceplot(trace, vars=None, figsize=None,
 
     for trace in traces:
         for i, v in enumerate(vars):
-            d = np.squeeze(trace[v])
+            d = make_2d(trace[v])
 
             if trace[v].dtype.kind == 'i':
                 histplot_op(ax[i, 0], d)
@@ -80,7 +80,6 @@ def traceplot(trace, vars=None, figsize=None,
     return fig
 
 def histplot_op(ax, data):
-    data = np.atleast_2d(data.T).T
     for i in range(data.shape[1]):
         d = data[:, i]
 
@@ -90,7 +89,6 @@ def histplot_op(ax, data):
         ax.set_xlim(mind - .5, maxd + .5)
 
 def kdeplot_op(ax, data):
-    data = np.atleast_2d(data.T).T
     for i in range(data.shape[1]):
         d = data[:, i]
         density = kde.gaussian_kde(d)
@@ -99,6 +97,16 @@ def kdeplot_op(ax, data):
         x = np.linspace(0, 1, 100) * (u - l) + l
 
         ax.plot(x, density(x))
+
+def make_2d(a): 
+    """Ravel the dimensions after the first.
+    """
+    a = np.atleast_2d(a.T).T
+    #flatten out dimensions beyond the first
+    n = a.shape[0]
+    newshape = np.product(a.shape[1:]).astype(int)
+    a = a.reshape((n, newshape), order='F')
+    return a
 
 
 def kde2plot_op(ax, x, y, grid=200):

--- a/pymc/tests/models.py
+++ b/pymc/tests/models.py
@@ -11,6 +11,13 @@ def simple_model():
 
     return model.test_point, model, (mu, tau ** -1)
 
+def multidimensional_model():
+    mu = -2.1
+    tau = 1.3
+    with Model() as model:
+        x = Normal('x', mu, tau, shape=(3,2), testval=.1*np.ones((3,2)) )
+
+    return model.test_point, model, (mu, tau ** -1)
 
 def simple_init():
     start, model, moments = simple_model()

--- a/pymc/tests/test_plots.py
+++ b/pymc/tests/test_plots.py
@@ -1,6 +1,10 @@
 import matplotlib
 matplotlib.use('Agg', warn=False)
 
+import numpy as np 
+from checks import close_to
+
+import pymc.plots
 from pymc.plots import *
 from pymc import psample, Slice, Metropolis, find_hessian, sample
 
@@ -17,9 +21,26 @@ def test_plots():
         step = Metropolis(model.vars, h)
         trace = sample(3000, step, start)
 
+        traceplot(trace)
         forestplot(trace)
 
         autocorrplot(trace)
+
+def test_plots_multidimensional():
+
+    # Test single trace
+    from models import multidimensional_model
+
+
+    start, model, _ = multidimensional_model()
+    with model as model:
+        h = np.diag(find_hessian(start))
+        step = Metropolis(model.vars, h)
+        trace = sample(3000, step, start)
+
+        traceplot(trace)
+        #forestplot(trace)
+        #autocorrplot(trace)
 
 
 def test_multichain_plots():
@@ -36,3 +57,16 @@ def test_multichain_plots():
     forestplot(ptrace, vars=['early_mean', 'late_mean'])
 
     autocorrplot(ptrace, vars=['switchpoint'])
+
+def test_make_2d(): 
+
+    a = np.arange(4)
+    close_to(pymc.plots.make_2d(a), a[:,None], 0)
+
+    n = 7
+    a = np.arange(n*4*5).reshape((n,4,5))
+    res = pymc.plots.make_2d(a)
+
+    assert res.shape == (n,20)
+    close_to(a[:,0,0], res[:,0], 0)
+    close_to(a[:,3,2], res[:,2*4+3], 0)


### PR DESCRIPTION
traceplot would generate an error if a trace of a more than 1-d
variable was.

Now we ravel the dimensions after the first.

We should support for this in forestplot and autocorrplot.

Adresses https://github.com/pymc-devs/pymc/issues/512
