### PR TITLE
Misc: add back nose-timer, support multidimensional variables in traceplot, test discrete step methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ install:
   - pip install git+https://github.com/mahmoudimus/nose-timer.git
 
 env:
-  - TESTCMD="nosetests -vv --with-timer --timer-verbose -e test_glm -e test_examples -e test_distributions"
-  - TESTCMD="nosetests -vv --with-timer --timer-verbose pymc.tests.test_distributions"
-  - TESTCMD="nosetests -vv --with-timer --timer-verbose pymc.tests.test_examples:test_examples0"
-  - TESTCMD="nosetests -vv --with-timer --timer-verbose pymc.tests.test_examples:test_examples1"
-  - TESTCMD="nosetests -vv --with-timer --timer-verbose pymc.tests.test_examples:test_examples2"
+  - TESTCMD="nosetests -vv --with-timer -e test_glm -e test_examples -e test_distributions"
+  - TESTCMD="nosetests -vv --with-timer pymc.tests.test_distributions"
+  - TESTCMD="nosetests -vv --with-timer pymc.tests.test_examples:test_examples0"
+  - TESTCMD="nosetests -vv --with-timer pymc.tests.test_examples:test_examples1"
+  - TESTCMD="nosetests -vv --with-timer pymc.tests.test_examples:test_examples2"
 
 script: "$TESTCMD"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,13 @@ install:
   - pip install --no-deps numdifftools
   - pip install git+https://github.com/Theano/Theano.git
   - python setup.py build_ext --inplace
+  - pip install git+https://github.com/mahmoudimus/nose-timer.git
 
 env:
-  - TESTCMD="nosetests -vv -e test_glm -e test_examples -e test_distributions"
-  - TESTCMD="nosetests -vv pymc.tests.test_distributions"
-  - TESTCMD="nosetests -vv pymc.tests.test_examples:test_examples0"
-  - TESTCMD="nosetests -vv pymc.tests.test_examples:test_examples1"
-  - TESTCMD="nosetests -vv pymc.tests.test_examples:test_examples2"
+  - TESTCMD="nosetests -vv --with-timer --timer-verbose -e test_glm -e test_examples -e test_distributions"
+  - TESTCMD="nosetests -vv --with-timer --timer-verbose pymc.tests.test_distributions"
+  - TESTCMD="nosetests -vv --with-timer --timer-verbose pymc.tests.test_examples:test_examples0"
+  - TESTCMD="nosetests -vv --with-timer --timer-verbose pymc.tests.test_examples:test_examples1"
+  - TESTCMD="nosetests -vv --with-timer --timer-verbose pymc.tests.test_examples:test_examples2"
 
 script: "$TESTCMD"

--- a/pymc/plots.py
+++ b/pymc/plots.py
@@ -55,7 +55,7 @@ def traceplot(trace, vars=None, figsize=None,
 
     for trace in traces:
         for i, v in enumerate(vars):
-            d = np.squeeze(trace[v])
+            d = make_2d(trace[v])
 
             if trace[v].dtype.kind == 'i':
                 histplot_op(ax[i, 0], d)
@@ -80,7 +80,6 @@ def traceplot(trace, vars=None, figsize=None,
     return fig
 
 def histplot_op(ax, data):
-    data = np.atleast_2d(data.T).T
     for i in range(data.shape[1]):
         d = data[:, i]
 
@@ -90,7 +89,6 @@ def histplot_op(ax, data):
         ax.set_xlim(mind - .5, maxd + .5)
 
 def kdeplot_op(ax, data):
-    data = np.atleast_2d(data.T).T
     for i in range(data.shape[1]):
         d = data[:, i]
         density = kde.gaussian_kde(d)
@@ -99,6 +97,16 @@ def kdeplot_op(ax, data):
         x = np.linspace(0, 1, 100) * (u - l) + l
 
         ax.plot(x, density(x))
+
+def make_2d(a): 
+    """Ravel the dimensions after the first.
+    """
+    a = np.atleast_2d(a.T).T
+    #flatten out dimensions beyond the first
+    n = a.shape[0]
+    newshape = np.product(a.shape[1:]).astype(int)
+    a = a.reshape((n, newshape), order='F')
+    return a
 
 
 def kde2plot_op(ax, x, y, grid=200):

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -71,7 +71,7 @@ class Metropolis(ArrayStep):
         model = modelcontext(model)
 
         if vars is None:
-            vars = model.cont_vars
+            vars = model.vars
         if S is None:
             S = np.ones(sum(v.dsize for v in vars))
         self.proposal_dist = proposal_dist(S)

--- a/pymc/step_methods/nuts.py
+++ b/pymc/step_methods/nuts.py
@@ -56,7 +56,7 @@ class NUTS(ArrayStep):
             scaling = model.test_point
 
         if isinstance(scaling, dict):
-            scaling = guess_scaling(Point(scaling, model=model), model=model)
+            scaling = guess_scaling(Point(scaling, model=model), model=model, vars = vars)
 
 
 

--- a/pymc/tests/models.py
+++ b/pymc/tests/models.py
@@ -12,6 +12,13 @@ def simple_model():
 
     return model.test_point, model, (mu, tau ** -1)
 
+def multidimensional_model():
+    mu = -2.1
+    tau = 1.3
+    with Model() as model:
+        x = Normal('x', mu, tau, shape=(3,2), testval=.1*np.ones((3,2)) )
+
+    return model.test_point, model, (mu, tau ** -1)
 
 def simple_init():
     start, model, moments = simple_model()

--- a/pymc/tests/models.py
+++ b/pymc/tests/models.py
@@ -48,6 +48,17 @@ def mv_simple():
 
     return model.test_point, model, (mu, C)
 
+def simple_discrete():
+    p = np.array([.1,..5,.4])
+
+    with pm.Model() as model:
+        x = pm.Multinomial('x', 5, pm.constant(p), shape=3, testval=np.array([1,2,2]))
+
+                H = tau
+          C = np.linalg.inv(H)
+
+return model.test_point, model, (mu, C)
+
 def non_normal(n=2):
     with pm.Model() as model:
         x = pm.Beta('x', 3, 3, shape=n)

--- a/pymc/tests/models.py
+++ b/pymc/tests/models.py
@@ -1,6 +1,7 @@
 from pymc import Model, Normal, Metropolis, MvNormal
 import numpy as np
 import pymc as pm
+from itertools import product
 
 
 def simple_model():
@@ -48,16 +49,24 @@ def mv_simple():
 
     return model.test_point, model, (mu, C)
 
-def simple_discrete():
-    p = np.array([.1,..5,.4])
+def mv_simple_discrete():
+    d= 2
+    n = 5
+    p = np.array([.15,.85])
 
     with pm.Model() as model:
-        x = pm.Multinomial('x', 5, pm.constant(p), shape=3, testval=np.array([1,2,2]))
+        x = pm.Multinomial('x', n, pm.constant(p), shape=d, testval=np.array([1,4]))
+        mu = n * p
+        
+        #covariance matrix
+        C = np.zeros((d,d))
+        for (i, j) in product(range(d), range(d)): 
+            if i == j:
+                C[i,i] = n * p[i]*(1-p[i])
+            else:
+                C[i,j] = -n*p[i]*p[j]
 
-                H = tau
-          C = np.linalg.inv(H)
-
-return model.test_point, model, (mu, C)
+    return model.test_point, model, (mu, C)
 
 def non_normal(n=2):
     with pm.Model() as model:

--- a/pymc/tests/test_plots.py
+++ b/pymc/tests/test_plots.py
@@ -1,6 +1,10 @@
 import matplotlib
 matplotlib.use('Agg', warn=False)
 
+import numpy as np 
+from checks import close_to
+
+import pymc.plots
 from pymc.plots import *
 from pymc import psample, Slice, Metropolis, find_hessian, sample
 
@@ -17,9 +21,26 @@ def test_plots():
         step = Metropolis(model.vars, h)
         trace = sample(3000, step, start)
 
+        traceplot(trace)
         forestplot(trace)
 
         autocorrplot(trace)
+
+def test_plots_multidimensional():
+
+    # Test single trace
+    from models import multidimensional_model
+
+
+    start, model, _ = multidimensional_model()
+    with model as model:
+        h = np.diag(find_hessian(start))
+        step = Metropolis(model.vars, h)
+        trace = sample(3000, step, start)
+
+        traceplot(trace)
+        #forestplot(trace)
+        #autocorrplot(trace)
 
 
 def test_multichain_plots():
@@ -36,3 +57,16 @@ def test_multichain_plots():
     forestplot(ptrace, vars=['early_mean', 'late_mean'])
 
     autocorrplot(ptrace, vars=['switchpoint'])
+
+def test_make_2d(): 
+
+    a = np.arange(4)
+    close_to(pymc.plots.make_2d(a), a[:,None], 0)
+
+    n = 7
+    a = np.arange(n*4*5).reshape((n,4,5))
+    res = pymc.plots.make_2d(a)
+
+    assert res.shape == (n,20)
+    close_to(a[:,0,0], res[:,0], 0)
+    close_to(a[:,3,2], res[:,2*4+3], 0)

--- a/pymc/tests/test_plots.py
+++ b/pymc/tests/test_plots.py
@@ -29,7 +29,7 @@ def test_plots():
 def test_plots_multidimensional():
 
     # Test single trace
-    from models import multidimensional_model
+    from .models import multidimensional_model
 
 
     start, model, _ = multidimensional_model()

--- a/pymc/tests/test_plots.py
+++ b/pymc/tests/test_plots.py
@@ -2,7 +2,7 @@ import matplotlib
 matplotlib.use('Agg', warn=False)
 
 import numpy as np 
-from checks import close_to
+from .checks import close_to
 
 import pymc.plots
 from pymc.plots import *

--- a/pymc/tests/test_step.py
+++ b/pymc/tests/test_step.py
@@ -1,11 +1,11 @@
 from .checks import *
-from .models import simple_model, mv_simple
+from .models import simple_model, mv_simple, mv_simple_discrete
 from theano.tensor import constant
 from scipy.stats.mstats import moment
 
 
 def check_stat(name, trace, var, stat, value, bound):
-    s = stat(trace[var][4000:], axis=0)
+    s = stat(trace[var][2000:], axis=0)
     close_to(s, value, bound)
 
 
@@ -38,15 +38,17 @@ def test_step_discrete():
     with model:
         mh = pm.Metropolis(S=C,
                            proposal_dist=pm.MultivariateNormalProposal)
+        slicer = pm.Slice()
 
 
-    steps = [mh, hmc, slicer, nuts, compound]
+    steps = [mh]
 
     unc = np.diag(C) ** .5
     check = [('x', np.mean, mu, unc / 10.),
              ('x', np.std, unc, unc / 10.)]
 
     for st in steps:
-        h = sample(8000, st, start, model=model, random_seed=1)
+        h = sample(20000, st, start, model=model, random_seed=1)
+
         for (var, stat, val, bound) in check:
             yield check_stat, repr(st), h, var, stat, val, bound

--- a/pymc/tests/test_step.py
+++ b/pymc/tests/test_step.py
@@ -20,6 +20,26 @@ def test_step_continuous():
         nuts = pm.NUTS(scaling=C, is_cov=True)
         compound = pm.CompoundStep([hmc, mh])
 
+
+    steps = [mh, hmc, slicer, nuts, compound]
+
+    unc = np.diag(C) ** .5
+    check = [('x', np.mean, mu, unc / 10.),
+             ('x', np.std, unc, unc / 10.)]
+
+    for st in steps:
+        h = sample(8000, st, start, model=model, random_seed=1)
+        for (var, stat, val, bound) in check:
+            yield check_stat, repr(st), h, var, stat, val, bound
+
+def test_step_discrete():
+    start, model, (mu, C) = mv_simple_discrete()
+
+    with model:
+        mh = pm.Metropolis(S=C,
+                           proposal_dist=pm.MultivariateNormalProposal)
+
+
     steps = [mh, hmc, slicer, nuts, compound]
 
     unc = np.diag(C) ** .5


### PR DESCRIPTION
Couple different improvements. I could split this up into different reviews if need be. 
1. Add back nose-timer so we can keep an eye on what takes time to run
2. Support multidimensional variables in traceplot fixing https://github.com/pymc-devs/pymc/issues/512
3. Add a test for discrete Metropolis step method
