### PR TITLE
Simplified Wishart arguments

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -176,4 +176,4 @@ class Wishart(Continuous):
              n * p * log(
              2) - n * log(IVI) - 2 * multigammaln(p, n / 2)) / 2,
 
-            all(n > p - 1))
+             n > (p - 1))

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -146,8 +146,6 @@ class Wishart(Continuous):
     :Parameters:
       n : int
         Degrees of freedom, > 0.
-      p : int
-        Dimensionality, > 0
       V : ndarray
         p x p positive definite matrix
 
@@ -156,10 +154,10 @@ class Wishart(Continuous):
       X : matrix
         Symmetric, positive definite.
     """
-    def __init__(self, n, p, V, *args, **kwargs):
+    def __init__(self, n, V, *args, **kwargs):
         super(Wishart, self).__init__(*args, **kwargs)
         self.n = n
-        self.p = p
+        self.p = V.shape[0]
         self.V = V
         self.mean = n * V
         self.mode = switch(1*(n >= p + 1),

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -157,7 +157,7 @@ class Wishart(Continuous):
     def __init__(self, n, V, *args, **kwargs):
         super(Wishart, self).__init__(*args, **kwargs)
         self.n = n
-        self.p = V.shape[0]
+        self.p = p = V.shape[0]
         self.V = V
         self.mean = n * V
         self.mode = switch(1*(n >= p + 1),

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -317,7 +317,7 @@ def test_wishart():
         yield check_wishart,n
 
 def check_wishart(n):
-    checkd(Wishart, PdMatrix(n), {'n': Domain([2, 3, 4, 2000]) , 'V': PdMatrix(n) }, checks = [check_dlogp], extra_args={'p' : n})
+    checkd(Wishart, PdMatrix(n), {'n': Domain([2, 3, 4, 2000]) , 'V': PdMatrix(n) }, checks = [check_dlogp])
 
 def betafn(a):
     return scipy.special.gammaln(a).sum() - scipy.special.gammaln(a.sum())


### PR DESCRIPTION
This eliminates the need to specify the dimension of the Wishart, which can be inferred from the dimension of the matrix V.
