### PR TITLE
Made all import statements use relative paths

### DIFF
--- a/pymc/backends/__init__.py
+++ b/pymc/backends/__init__.py
@@ -109,9 +109,9 @@ defined that returns a MultiTrace object.
 
 For specific examples, see pymc.backends.{ndarray,text,sqlite}.py.
 """
-from pymc.backends.ndarray import NDArray
-from pymc.backends.text import Text
-from pymc.backends.sqlite import SQLite
+from ..backends.ndarray import NDArray
+from ..backends.text import Text
+from ..backends.sqlite import SQLite
 
 _shortcuts = {'text': {'backend': Text,
                        'name': 'mcmc'},

--- a/pymc/backends/base.py
+++ b/pymc/backends/base.py
@@ -4,7 +4,7 @@ See the docstring for pymc.backends for more information (includng
 creating custom backends).
 """
 import numpy as np
-from pymc.model import modelcontext
+from ..model import modelcontext
 
 
 class BaseTrace(object):

--- a/pymc/backends/ndarray.py
+++ b/pymc/backends/ndarray.py
@@ -3,7 +3,7 @@
 Store sampling values in memory as a NumPy array.
 """
 import numpy as np
-from pymc.backends import base
+from ..backends import base
 
 
 class NDArray(base.BaseTrace):

--- a/pymc/backends/sqlite.py
+++ b/pymc/backends/sqlite.py
@@ -20,7 +20,7 @@ import numpy as np
 import sqlite3
 import warnings
 
-from pymc.backends import base
+from ..backends import base
 
 TEMPLATES = {
     'table':            ('CREATE TABLE IF NOT EXISTS [{table}] '

--- a/pymc/backends/text.py
+++ b/pymc/backends/text.py
@@ -31,8 +31,8 @@ import glob
 import json
 import numpy as np
 
-from pymc.backends import base
-from pymc.backends.ndarray import NDArray
+from ..backends import base
+from ..backends.ndarray import NDArray
 
 
 class Text(NDArray):

--- a/pymc/glm/families.py
+++ b/pymc/glm/families.py
@@ -9,7 +9,8 @@ except ImportError:
     Poisson = None
 
 from .links import *
-import pymc
+from ..model import modelcontext
+from ..distributions import Normal, T, Uniform, Bernoulli, Poisson
 
 __all__ = ['Normal', 'T', 'Binomial', 'Poisson']
 
@@ -38,7 +39,7 @@ class Family(object):
         -------
         dict : mapping name -> pymc distribution
         """
-        model = pymc.modelcontext(model)
+        model = modelcontext(model)
         priors = {}
         for key, val in self.priors.items():
             if isinstance(val, numbers.Number):
@@ -81,29 +82,29 @@ class Family(object):
 class Normal(Family):
     sm_family = Gaussian
     link = Identity
-    likelihood = pymc.Normal
+    likelihood = Normal
     parent = 'mu'
-    priors = {'sd': ('sigma', pymc.Uniform.dist(0, 100))}
+    priors = {'sd': ('sigma', Uniform.dist(0, 100))}
 
 
 class T(Family):
     sm_family = Gaussian
     link = Identity
-    likelihood = pymc.T
+    likelihood = T
     parent = 'mu'
-    priors = {'lam': ('sigma', pymc.Uniform.dist(0, 100)),
+    priors = {'lam': ('sigma', Uniform.dist(0, 100)),
               'nu': 1}
 
 
 class Binomial(Family):
     link = Logit
     sm_family = Binomial
-    likelihood = pymc.Bernoulli
+    likelihood = Bernoulli
     parent = 'p'
 
 
 class Poisson(Family):
     link = Log
     sm_family = Poisson
-    likelihood = pymc.Poisson
+    likelihood = Poisson
     parent = ''

--- a/pymc/glm/glm.py
+++ b/pymc/glm/glm.py
@@ -1,5 +1,6 @@
 import numpy as np
-from pymc import *
+from ..core import *
+from ..distributions import *
 import patsy
 import theano
 import pandas as pd

--- a/pymc/glm/glm.py
+++ b/pymc/glm/glm.py
@@ -1,6 +1,7 @@
 import numpy as np
 from ..core import *
 from ..distributions import *
+from ..tuning.starting import find_MAP
 import patsy
 import theano
 import pandas as pd

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -1,6 +1,6 @@
-from pymc import backends
-from pymc.backends.base import merge_traces, BaseTrace, MultiTrace
-from pymc.backends.ndarray import NDArray
+from . import backends
+from .backends.base import merge_traces, BaseTrace, MultiTrace
+from .backends.ndarray import NDArray
 import multiprocessing as mp
 from time import time
 from .core import *


### PR DESCRIPTION
Remove explicit `pymc` import statements and replaced them with relative import statements using the dot notation. This will make it easier to load both PyMC 2 and PyMC 3 in the same session.
