### PR TITLE
fix some tests/examples for python 3 or if missing statsmodels

### DIFF
--- a/pymc/examples/glm_linear.py
+++ b/pymc/examples/glm_linear.py
@@ -4,7 +4,7 @@ import sys
 try:
     import statsmodels.api as sm
 except ImportError:
-    print("Example requires statsmodels")
+    print "Example requires statsmodels"
     sys.exit(0)
 
 from pymc import *

--- a/pymc/examples/glm_linear.py
+++ b/pymc/examples/glm_linear.py
@@ -1,10 +1,12 @@
+from __future__ import print_function
+
 import numpy as np
 import sys
 
 try:
     import statsmodels.api as sm
 except ImportError:
-    print "Example requires statsmodels"
+    print("Example requires statsmodels")
     sys.exit(0)
 
 from pymc import *

--- a/pymc/examples/glm_linear.py
+++ b/pymc/examples/glm_linear.py
@@ -1,4 +1,5 @@
 import numpy as np
+import sys
 
 try:
     import statsmodels.api as sm

--- a/pymc/examples/glm_robust.py
+++ b/pymc/examples/glm_robust.py
@@ -1,8 +1,10 @@
 import numpy as np
+import sys
 
 try:
     import statsmodels.api as sm
 except ImportError:
+    print "Example requires statsmodels"
     sys.exit(0)
 
 from pymc import *

--- a/pymc/examples/glm_robust.py
+++ b/pymc/examples/glm_robust.py
@@ -1,10 +1,12 @@
+from __future__ import print_function
+
 import numpy as np
 import sys
 
 try:
     import statsmodels.api as sm
 except ImportError:
-    print "Example requires statsmodels"
+    print("Example requires statsmodels")
     sys.exit(0)
 
 from pymc import *

--- a/pymc/tests/test_glm.py
+++ b/pymc/tests/test_glm.py
@@ -6,7 +6,7 @@ import sys
 try:
     import statsmodels.api as sm
 except ImportError:
-    sys.exit(0)
+    raise SkipTest("Test requires statsmodels.")
 
 from pymc.examples import glm_linear, glm_robust
 


### PR DESCRIPTION
One of the example tests currently fails on python 3 because it uses print statements instead of functions. If we support 2.6+ we can use `__future__` imports to make them pass on both 2.6+ and 3.x. I've added a print statement to the glm_robust.py to explain why it exits if statsmodels is missing.

The glm examples were missing imports for sys in the case that statsmodels is not installed.

There was an unused import of SkipTest in test_glm.py. We should call it instead of exiting if statsmodels is not available.
