### PR TITLE
Implement non-blocked sampling for array based samplers.

### DIFF
--- a/pymc/examples/ARM12_6.py
+++ b/pymc/examples/ARM12_6.py
@@ -63,6 +63,6 @@ def run(n=3000):
         step = HamiltonianMC(model.vars, h)
 
         trace = sample(n, step, start)
-        
+
 if __name__ == '__main__':
     run()

--- a/pymc/examples/ARM12_6uranium.py
+++ b/pymc/examples/ARM12_6uranium.py
@@ -69,4 +69,4 @@ def run(n=3000):
 
         trace = sample(n, step, start)
 if __name__ == '__main__':
-    run()      
+    run()

--- a/pymc/examples/arbitrary_stochastic.py
+++ b/pymc/examples/arbitrary_stochastic.py
@@ -19,9 +19,8 @@ def run (n=3000):
 
         start = model.test_point
         h = find_hessian(start)
-        step = Metropolis(model.vars, h)
+        step = Metropolis(model.vars, h, blocked=True)
         trace = sample(n, step, start)
 
 if __name__ == "__main__":
     run()
-

--- a/pymc/examples/banana.py
+++ b/pymc/examples/banana.py
@@ -63,5 +63,3 @@ def run(n = 3000):
         pl.figure()
         extent = np.min(xs), np.max(xs), np.min(ys), np.max(ys)
         pl.imshow(post, extent=extent)
-
-

--- a/pymc/examples/disaster_model.py
+++ b/pymc/examples/disaster_model.py
@@ -61,5 +61,3 @@ def run(n=1000):
 
 if __name__ == '__main__':
     run()
-
-

--- a/pymc/examples/factor_potential.py
+++ b/pymc/examples/factor_potential.py
@@ -13,7 +13,6 @@ def run(n = 3000):
         n = 50
     with model:
         trace = sample(n, step, start)
+
 if __name__ == '__main__':
     run()
-
-

--- a/pymc/examples/glm_linear.py
+++ b/pymc/examples/glm_linear.py
@@ -31,7 +31,7 @@ def run(n=2000):
     import matplotlib.pyplot as plt
 
     with model:
-        trace = sample(n, Slice(model.vars))
+        trace = sample(n, Slice())
 
     plt.plot(x, y, 'x')
     glm.plot_posterior_predictive(trace)

--- a/pymc/examples/glm_robust.py
+++ b/pymc/examples/glm_robust.py
@@ -37,7 +37,7 @@ def run(n=2000):
     import matplotlib.pyplot as plt
 
     with model:
-        trace = sample(n, Slice(model.vars))
+        trace = sample(n, Slice())
 
     plt.plot(x, y, 'x')
     glm.plot_posterior_predictive(trace)

--- a/pymc/examples/lasso_block_update.py
+++ b/pymc/examples/lasso_block_update.py
@@ -43,7 +43,7 @@ with Model() as model:
 # <codecell>
 
 with model:
-    step1 = Metropolis([m1, m2])
+    step1 = Metropolis([m1, m2], blocked=True)
 
     step2 = Metropolis([s], proposal_dist=LaplaceProposal)
 
@@ -67,5 +67,3 @@ def run(n=5000):
 # <codecell>
 if __name__ == '__main__':
     run()
-
-

--- a/pymc/examples/latent_occupancy.py
+++ b/pymc/examples/latent_occupancy.py
@@ -85,6 +85,6 @@ def run(n=5000):
         step2 = BinaryMetropolis([z])
 
         trace = sample(n, [step1, step2], start)
-        
+
 if __name__ == '__main__':
     run()

--- a/pymc/examples/stochastic_volatility.py
+++ b/pymc/examples/stochastic_volatility.py
@@ -112,9 +112,9 @@ with model:
 
 with model:
     step = NUTS(model.vars, hessian(start, 6))
-    
-    
-    
+
+
+
 def run(n=2000):
     if n == "short":
         n = 50
@@ -136,7 +136,7 @@ def run(n=2000):
 
     # figsize(12,6)
     traceplot(trace, model.vars[:-1])
-    
+
 if __name__ == '__main__':
     run()
 

--- a/pymc/step_methods/hmc.py
+++ b/pymc/step_methods/hmc.py
@@ -26,7 +26,9 @@ def unif(step_size, elow=.85, ehigh=1.15):
 
 
 class HamiltonianMC(ArrayStep):
-    def __init__(self, vars=None, scaling=None, step_scale=.25, path_length=2., is_cov=False, step_rand=unif, state=None, model=None):
+    default_blocked = True
+
+    def __init__(self, vars=None, scaling=None, step_scale=.25, path_length=2., is_cov=False, step_rand=unif, state=None, model=None, **kwargs):
         """
         Parameters
         ----------
@@ -69,7 +71,7 @@ class HamiltonianMC(ArrayStep):
             state = SamplerHist()
         self.state = state
 
-        super(HamiltonianMC, self).__init__(vars, [model.fastlogp, model.fastdlogp(vars)])
+        super(HamiltonianMC, self).__init__(vars, [model.fastlogp, model.fastdlogp(vars)], **kwargs)
 
     def astep(self, q0, logp, dlogp):
         H = Hamiltonian(logp, dlogp, self.potential)

--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -65,8 +65,10 @@ class Metropolis(ArrayStep):
         Optional model for sampling step. Defaults to None (taken from context).
 
     """
+    default_blocked = False
+
     def __init__(self, vars=None, S=None, proposal_dist=NormalProposal, scaling=1.,
-                 tune=True, tune_interval=100, model=None):
+                 tune=True, tune_interval=100, model=None, **kwargs):
 
         model = modelcontext(model)
 
@@ -84,7 +86,7 @@ class Metropolis(ArrayStep):
         # Determine type of variables
         self.discrete = np.array([v.dtype in discrete_types for v in vars])
 
-        super(Metropolis, self).__init__(vars, [model.fastlogp])
+        super(Metropolis, self).__init__(vars, [model.fastlogp], **kwargs)
 
     def astep(self, q0, logp):
 

--- a/pymc/step_methods/nuts.py
+++ b/pymc/step_methods/nuts.py
@@ -17,13 +17,14 @@ class NUTS(ArrayStep):
     Hoffman, Matthew D., & Gelman, Andrew. (2011).
     The No-U-Turn Sampler: Adaptively Setting Path Lengths in Hamiltonian Monte Carlo.
     """
+    default_blocked = True
     def __init__(self, vars=None, scaling=None, step_scale=0.25, is_cov=False, state=None,
                  Emax=1000,
                  target_accept=0.65,
                  gamma=0.05,
                  k=0.75,
                  t0=10,
-                 model=None):
+                 model=None, **kwargs):
         """
         Parameters
         ----------
@@ -83,7 +84,7 @@ class NUTS(ArrayStep):
 
 
 
-        super(NUTS, self).__init__(vars, [model.fastlogp, model.fastdlogp(vars)])
+        super(NUTS, self).__init__(vars, [model.fastlogp, model.fastdlogp(vars)], **kwargs)
 
     def astep(self, q0, logp, dlogp):
         H = Hamiltonian(logp, dlogp, self.potential)

--- a/pymc/step_methods/slicer.py
+++ b/pymc/step_methods/slicer.py
@@ -9,9 +9,9 @@ __all__ = ['Slice']
 
 
 class Slice(ArrayStep):
-
     """Slice sampler"""
-    def __init__(self, vars=None, w=1, tune=True, model=None):
+    default_blocked = False
+    def __init__(self, vars=None, w=1, tune=True, model=None, **kwargs):
 
         model = modelcontext(model)
 
@@ -23,7 +23,7 @@ class Slice(ArrayStep):
         self.w_tune = []
         self.model = model
 
-        super(Slice, self).__init__(vars, [model.fastlogp])
+        super(Slice, self).__init__(vars, [model.fastlogp], **kwargs)
 
     def astep(self, q0, logp):
 

--- a/pymc/tests/test_plots.py
+++ b/pymc/tests/test_plots.py
@@ -1,7 +1,7 @@
 import matplotlib
 matplotlib.use('Agg', warn=False)
 
-import numpy as np 
+import numpy as np
 from .checks import close_to
 
 import pymc.plots
@@ -58,7 +58,7 @@ def test_multichain_plots():
 
     autocorrplot(ptrace, vars=['switchpoint'])
 
-def test_make_2d(): 
+def test_make_2d():
 
     a = np.arange(4)
     close_to(pymc.plots.make_2d(a), a[:,None], 0)

--- a/pymc/tests/test_stats.py
+++ b/pymc/tests/test_stats.py
@@ -56,7 +56,7 @@ def test_summary_0d_variable_model():
     tau = 1.3
     with Model() as model:
         x = Normal('x', mu, tau, testval=.1)
-        step = Metropolis(model.vars, np.diag([1.]))
+        step = Metropolis(model.vars, np.diag([1.]), blocked=True)
         trace = pm.sample(100, step=step)
     pm.summary(trace)
 
@@ -66,7 +66,7 @@ def test_summary_1d_variable_model():
     tau = 1.3
     with Model() as model:
         x = Normal('x', mu, tau, shape=2, testval=[.1, .1])
-        step = Metropolis(model.vars, np.diag([1.]))
+        step = Metropolis(model.vars, np.diag([1.]), blocked=True)
         trace = pm.sample(100, step=step)
     pm.summary(trace)
 
@@ -77,7 +77,7 @@ def test_summary_2d_variable_model():
     with Model() as model:
         x = Normal('x', mu, tau, shape=(2, 2),
                    testval=np.tile(.1, (2, 2)))
-        step = Metropolis(model.vars, np.diag([1.]))
+        step = Metropolis(model.vars, np.diag([1.]), blocked=True)
         trace = pm.sample(100, step=step)
     pm.summary(trace)
 


### PR DESCRIPTION
Before, all our samplers operated in the joint space (i.e. blocked) by default. This often leads to bad convergence for metropolis or slice.

This adds functionality to set `blocked=False` when instantiating any sampler which will instead create a step-method for each RV and append them to a `CompoundStep`.

Samplers like metropolis and slice default to not being blocked (as was the case in pymc2 and is what people assume). HMC and NUTS however default to being blocked as they are specifically designed to operate in the joint space.

Unfortunately because of all the configurations `ArrayStep` could be called there's quite some code to determine the configuration it was called in but it's fully backwards compatible that way.

This supersedes https://github.com/pymc-devs/pymc/pull/450 which took a different approach.
