### PR TITLE
Add support for alternative parameterization of beta and gamma

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -185,18 +185,39 @@ class Beta(Continuous):
     beta : float
         beta > 0
 
+    Alternative parameterization:
+    mu : float
+        1 > mu > 0
+    sd : float
+        sd > 0
+    .. math::
+        alpha = mu * sd
+        beta = (1 - mu) * sd
+
     .. note::
     - :math:`E(X)=\frac{\alpha}{\alpha+\beta}`
     - :math:`Var(X)=\frac{\alpha \beta}{(\alpha+\beta)^2(\alpha+\beta+1)}`
 
     """
-    def __init__(self, alpha, beta, *args, **kwargs):
+    def __init__(self, alpha=None, beta=None, mu=None, sd=None, *args, **kwargs):
         super(Beta, self).__init__(*args, **kwargs)
+        alpha, beta = self.get_alpha_beta(alpha, beta, mu, sd)
         self.alpha = alpha
         self.beta = beta
         self.mean = alpha / (alpha + beta)
         self.variance = alpha * beta / (
             (alpha + beta) ** 2 * (alpha + beta + 1))
+
+    def get_alpha_beta(self, alpha=None, beta=None, mu=None, sd=None):
+        if (alpha is not None) and (beta is not None):
+            pass
+        elif (mu is not None) and (sd is not None):
+            alpha = mu * sd
+            beta = (1 - mu) * sd
+        else:
+            raise ValueError('Incompatible parameterization. Either use alpha and beta, or mu and sd to specify distribution. ')
+
+        return alpha, beta
 
     def logp(self, value):
         alpha = self.alpha
@@ -467,18 +488,39 @@ class Gamma(Continuous):
     beta : float
         Rate parameter (beta > 0).
 
+    Alternative parameterization:
+    mu : float
+        mu > 0
+    sd : float
+        sd > 0
+    .. math::
+        alpha =  \frac{mu^2}{sd^2}
+        beta = \frac{mu}{sd^2}
+
     .. note::
     - :math:`E(X) = \frac{\alpha}{\beta}`
     - :math:`Var(X) = \frac{\alpha}{\beta^2}`
 
     """
-    def __init__(self, alpha, beta, *args, **kwargs):
+    def __init__(self, alpha=None, beta=None, mu=None, sd=None, *args, **kwargs):
         super(Gamma, self).__init__(*args, **kwargs)
+        alpha, beta = self.get_alpha_beta(alpha, beta, mu, sd)
         self.alpha = alpha
         self.beta = beta
         self.mean = alpha / beta
         self.mode = maximum((alpha - 1) / beta, 0)
         self.variance = alpha / beta ** 2
+
+    def get_alpha_beta(self, alpha=None, beta=None, mu=None, sd=None):
+        if (alpha is not None) and (beta is not None):
+            pass
+        elif (mu is not None) and (sd is not None):
+            alpha = mu ** 2 / sd ** 2
+            beta = mu / sd ** 2
+        else:
+            raise ValueError('Incompatible parameterization. Either use alpha and beta, or mu and sd to specify distribution. ')
+
+        return alpha, beta
 
     def logp(self, value):
         alpha = self.alpha

--- a/pymc/plots.py
+++ b/pymc/plots.py
@@ -89,7 +89,7 @@ def kdeplot_op(ax, data):
 
         ax.plot(x, density(x))
 
-def make_2d(a): 
+def make_2d(a):
     """Ravel the dimensions after the first.
     """
     a = np.atleast_2d(a.T).T

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -168,6 +168,10 @@ def test_beta():
             Beta, Unit, {'alpha': Rplus, 'beta': Rplus},
             lambda value, alpha, beta: sp.beta.logpdf(value, alpha, beta)
             )
+    pymc_matches_scipy(
+            Beta, Unit, {'mu': Unit, 'sd': Rplus},
+            lambda value, mu, sd: sp.beta.logpdf(value, mu * sd, (1 - mu) * sd)
+            )
 
 
 def test_exponential():
@@ -226,6 +230,10 @@ def test_gamma():
     pymc_matches_scipy(
             Gamma, Rplus, {'alpha': Rplusbig, 'beta': Rplusbig},
             lambda value, alpha, beta: sp.gamma.logpdf(value, alpha, scale=1.0/beta)
+            )
+    pymc_matches_scipy(
+            Gamma, Rplus, {'mu': Rplusbig, 'sd': Rplusbig},
+            lambda value, mu, sd: sp.gamma.logpdf(value, mu**2 / sd**2, scale=1.0/(mu / sd**2))
             )
 
 def test_inverse_gamma():


### PR DESCRIPTION
Kruschke often defines the priors for `Beta` and `Gamma` in terms of mean and sd. There's a simple transformation to move to `alpha` and `beta`. Instead of requiring to do this in model code, this PR allows to alternatively submit `mu` and `sd` to `Beta` and `Gamma` which then does the transformation under the hood.

We do something similar for `Normal` where we allow to either specify precision `tau` or standard deviation `sd`. I think this has worked out quite well and makes the model specification much easier on the eyes.
