### PR TITLE
Eliminate Theano warning

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -1,6 +1,6 @@
 from .dist_math import *
 
-from theano.sandbox.linalg import det, solve, matrix_inverse, trace
+from theano.tensor.nlinalg import det, solve, matrix_inverse, trace
 from theano.tensor import dot, cast
 from theano.printing import Print
 

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -1,6 +1,6 @@
 from .dist_math import *
 
-from theano.tensor.nlinalg import det, solve, matrix_inverse, trace
+from theano.tensor.nlinalg import det, matrix_inverse, trace
 from theano.tensor import dot, cast
 from theano.printing import Print
 

--- a/pymc/math.py
+++ b/pymc/math.py
@@ -4,6 +4,6 @@ from theano.tensor import constant, flatten, zeros_like, ones_like, stack, conca
 from theano.tensor import exp, log, cos, sin, tan, cosh, sinh, tanh, sqr, sqrt, erf, erfinv, dot
 from theano.tensor import maximum, minimum, sgn, ceil, floor
 
-from theano.sandbox.linalg.ops import det, matrix_inverse, extract_diag, matrix_dot, trace
+from theano.tensor.nlinalg import det, matrix_inverse, extract_diag, matrix_dot, trace
 from theano.tensor.nnet import sigmoid
 import theano


### PR DESCRIPTION
Removes all imports from Theano.sandbox. See #615 for details.
