### PR TITLE
Change NUTS average acceptance ratio to 0.8

### DIFF
--- a/pymc/step_methods/nuts.py
+++ b/pymc/step_methods/nuts.py
@@ -20,7 +20,7 @@ class NUTS(ArrayStep):
     default_blocked = True
     def __init__(self, vars=None, scaling=None, step_scale=0.25, is_cov=False, state=None,
                  Emax=1000,
-                 target_accept=0.65,
+                 target_accept=0.8,
                  gamma=0.05,
                  k=0.75,
                  t0=10,


### PR DESCRIPTION
Stan recently changed their target acceptance ratio of the NUTS sampler to 0.8:
https://twitter.com/betanalpha/status/537574485302714368
because of strong theoretical considerations:
http://arxiv.org/abs/1411.6669
