### PR TITLE
DOC Add in hpd docstring the function assumes an unimodal distribution

### DIFF
--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -698,6 +698,9 @@ def hpd(x, alpha=0.05, transform=lambda x: x):
     """Calculate highest posterior density (HPD) of array for given alpha. The HPD is the
     minimum width Bayesian credible interval (BCI).
 
+    This function assumes the posterior distribution is unimodal:
+    it always returns one interval per variable.
+
     :Arguments:
       x : Numpy array
           An array containing MCMC samples


### PR DESCRIPTION
The HPD region is usually defined as
{θ ; p(θ | x) > k},
as in *Robert - The Bayesian Choice* p25 and *Kruschke - Doing Bayesian Data Analysis* §4.3.4.

The HPD region can therefore be an union of intervals for univariate multimodal distributions.
However, `pymc.stats.hpd` always return one interval. To my understanding, this function assumes an univariate unimodal distribution, but this is not documented. This PR adds in hpd's docstring that a unimodal distribution is assumed.