### PR TITLE
Fix for 3354

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,6 +11,7 @@
 - Added the `broadcast_distribution_samples` function that helps broadcasting arrays of drawn samples, taking into account the requested `size` and the inferred distribution shape. This sometimes is needed by distributions that call several `rvs` separately within their `random` method, such as the `ZeroInflatedPoisson` (Fix issue #3310).
 - The `Wald`, `Kumaraswamy`, `LogNormal`, `Pareto`, `Cauchy`, `HalfCauchy`, `Weibull` and `ExGaussian` distributions `random` method used a hidden `_random` function that was written with scalars in mind. This could potentially lead to artificial correlations between random draws. Added shape guards and broadcasting of the distribution samples to prevent this (Similar to issue #3310).
 - Added a fix to allow the imputation of single missing values of observed data, which previously would fail (Fix issue #3122).
+- Fix for #3354. `draw_values` now adds the theano graph descendants of `TensorConstant` or `SharedVariables` to the named relationship nodes stack, only if these descendants are `ObservedRV` or `MultiObservedRV` instances.
 
 ### Deprecations
 

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -366,6 +366,10 @@ def draw_values(params, point=None, size=None):
                 # ('Constants not allowed in param list', ...)` for
                 # TensorConstant, and a `TypeError: Cannot use a shared
                 # variable (...) as explicit input` for SharedVariable.
+                # ObservedRV and MultiObservedRV instances are ViewOPs
+                # of TensorConstants or SharedVariables, we must add them
+                # to the stack or risk evaluating deterministics with the
+                # wrong values (issue #3354)
                 stack.extend([node for node in named_nodes_parents[next_]
                               if isinstance(node, (ObservedRV,
                                                    MultiObservedRV))

--- a/pymc3/distributions/distribution.py
+++ b/pymc3/distributions/distribution.py
@@ -366,6 +366,10 @@ def draw_values(params, point=None, size=None):
                 # ('Constants not allowed in param list', ...)` for
                 # TensorConstant, and a `TypeError: Cannot use a shared
                 # variable (...) as explicit input` for SharedVariable.
+                stack.extend([node for node in named_nodes_parents[next_]
+                              if isinstance(node, (ObservedRV,
+                                                   MultiObservedRV))
+                              and (node, size) not in drawn])
                 continue
             else:
                 # If the node does not have a givens value, try to draw it.

--- a/pymc3/tests/test_sampling.py
+++ b/pymc3/tests/test_sampling.py
@@ -303,8 +303,8 @@ class TestSamplePPC(SeededTest):
             assert samples['foo'].shape == (50, 200)
 
     def test_deterministic_of_observed(self):
-        meas_in_1 = 2 + 4 * np.random.randn(100)
-        meas_in_2 = 5 + 4 * np.random.randn(100)
+        meas_in_1 = pm.theanof.floatX(2 + 4 * np.random.randn(100))
+        meas_in_2 = pm.theanof.floatX(5 + 4 * np.random.randn(100))
         with pm.Model() as model:
             mu_in_1 = pm.Normal('mu_in_1', 0, 1)
             sigma_in_1 = pm.HalfNormal('sd_in_1', 1)
@@ -327,7 +327,11 @@ class TestSamplePPC(SeededTest):
                                                  samples=len(ppc_trace),
                                                  vars=(model.deterministics +
                                                        model.basic_RVs))
-            assert np.allclose(ppc['out'], ppc['in_1'] + ppc['in_2'])
+
+            rtol = 1e-5 if theano.config.floatX == 'float64' else 1e-3
+            assert np.allclose(ppc['in_1'] + ppc['in_2'],
+                               ppc['out'],
+                               rtol=rtol)
 
 
 class TestSamplePPCW(SeededTest):


### PR DESCRIPTION
Fix for #3354. The only change is that `draw_values` now checks whether to add `ObservedRV` and `MultiObservedRV` instances to the `stack` of named nodes that may have to be drawn from to get the future `_draw_value` calls right later on.