### PR TITLE
Remove deprecated join_axes argument in pd.concat

### DIFF
--- a/pymc3/stats.py
+++ b/pymc3/stats.py
@@ -987,8 +987,9 @@ def summary(trace, var_names=None, transform=lambda x: x, stat_funcs=None,
                                varnames=var_names,
                                include_transformed=include_transformed)
         rhat_pd = dict2pd(rhat, 'Rhat')
-        return pd.concat([dforg, n_eff_pd, rhat_pd],
-                         axis=1, join_axes=[dforg.index])
+        return pd.concat(
+            [dforg, n_eff_pd, rhat_pd], axis=1
+        ).reindex(dforg.index)
 
 
 def _calculate_stats(sample, batches, alpha):


### PR DESCRIPTION
Fixes #3606.

I ran the tests for `pymc3/stats.py`, which all passed with 9 fewer warnings. I re-ran the notebooks [Diagonising biased inferences with divergences](https://docs.pymc.io/notebooks/Diagnosing_biased_Inference_with_Divergences.html) and [GLM: negative binomial regression](https://docs.pymc.io/notebooks/GLM-negative-binomial-regression.html) to verify that the summaries there still rendered. And I tested the minimal example in the original issue body.

This is my first PR to PyMC3, so let me know what else I need to do :)