### PR TITLE
Remove workaround in InferenceData conversion; require ArviZ >=0.11.4

### DIFF
--- a/conda-envs/environment-dev-py37.yml
+++ b/conda-envs/environment-dev-py37.yml
@@ -4,7 +4,7 @@ channels:
 - defaults
 dependencies:
 - aesara>=2.1.0
-- arviz>=0.11.2
+- arviz>=0.11.4
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0

--- a/conda-envs/environment-dev-py38.yml
+++ b/conda-envs/environment-dev-py38.yml
@@ -4,7 +4,7 @@ channels:
 - defaults
 dependencies:
 - aesara>=2.1.0
-- arviz>=0.11.2
+- arviz>=0.11.4
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0

--- a/conda-envs/environment-dev-py39.yml
+++ b/conda-envs/environment-dev-py39.yml
@@ -4,7 +4,7 @@ channels:
 - defaults
 dependencies:
 - aesara>=2.1.0
-- arviz>=0.11.2
+- arviz>=0.11.4
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0

--- a/conda-envs/windows-environment-dev-py38.yml
+++ b/conda-envs/windows-environment-dev-py38.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
  # base dependencies (see install guide for Windows)
 - aesara>=2.1.0
-- arviz>=0.11.2
+- arviz>=0.11.4
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -1114,10 +1114,6 @@ class TestMatchesScipy:
             decimal=select_by_precision(float64=6, float32=1),
         )
 
-    @pytest.mark.xfail(
-        condition=(aesara.config.floatX == "float32"),
-        reason="Poor CDF in SciPy. See scipy/scipy#869 for details.",
-    )
     def test_wald_logcdf(self):
         self.check_logcdf(
             Wald,
@@ -1273,6 +1269,10 @@ class TestMatchesScipy:
             {"N": NatSmall, "k": NatSmall, "n": NatSmall},
         )
 
+    @pytest.mark.xfail(
+        condition=(aesara.config.floatX == "float32"),
+        reason="SciPy log CDF stopped working after un-pinning NumPy version.",
+    )
     def test_negative_binomial(self):
         def scipy_mu_alpha_logpmf(value, mu, alpha):
             return sp.nbinom.logpmf(value, alpha, 1 - mu / (mu + alpha))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 # See that file for comments about the need/usage of each dependency.
 
 aesara>=2.1.0
-arviz>=0.11.2
+arviz>=0.11.4
 cachetools>=4.2.1
 cloudpickle
 fastprogress>=0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aesara>=2.1.0
-arviz>=0.11.2
+arviz>=0.11.4
 cachetools>=4.2.1
 cloudpickle
 fastprogress>=0.2.0


### PR DESCRIPTION
This PR removes a workaround in the InferenceData conversion and at the same time fixes a bug that was present in the workaround.

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] what are the (breaking) changes that this PR makes? → possibly ArviZ API changes
+ [x] important background, or details about the implementation → 
+ [x] are the changes—especially new features—covered by tests and docstrings? → yup
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style) → aye
