### PR TITLE
Manage coordinates as tuples

### DIFF
--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -222,10 +222,12 @@ class InferenceDataConverter:  # pylint: disable=too-many-instance-attributes
             aelem = arbitrary_element(get_from)
             self.ndraws = aelem.shape[0]
 
-        self.coords = {} if coords is None else coords
-        if hasattr(self.model, "coords"):
-            self.coords = {**self.model.coords, **self.coords}
-        self.coords = {key: value for key, value in self.coords.items() if value is not None}
+        self.coords = {**self.model.coords, **(coords or {})}
+        self.coords = {
+            cname: np.array(cvals) if isinstance(cvals, tuple) else cvals
+            for cname, cvals in self.coords.items()
+            if cvals is not None
+        }
 
         self.dims = {} if dims is None else dims
         if hasattr(self.model, "RV_dims"):

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -871,7 +871,7 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
         return self._RV_dims
 
     @property
-    def coords(self) -> Dict[str, Union[Sequence, None]]:
+    def coords(self) -> Dict[str, Union[Tuple, None]]:
         """Coordinate values for model dimensions."""
         return self._coords
 
@@ -1096,8 +1096,12 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
             raise ValueError(
                 f"The `length` passed for the '{name}' coord must be an Aesara Variable or None."
             )
+        if values is not None:
+            # Conversion to a tuple ensures that the coordinate values are immutable.
+            # Also unlike numpy arrays the's tuple.index(...) which is handy to work with.
+            values = tuple(values)
         if name in self.coords:
-            if not values.equals(self.coords[name]):
+            if not np.array_equal(values, self.coords[name]):
                 raise ValueError(f"Duplicate and incompatible coordinate: {name}.")
         else:
             self._coords[name] = values

--- a/pymc/tests/test_data_container.py
+++ b/pymc/tests/test_data_container.py
@@ -287,12 +287,12 @@ class TestData(SeededTest):
             pm.Data("observations", data, dims=("rows", "columns"))
 
         assert "rows" in pmodel.coords
-        assert pmodel.coords["rows"] == ["R1", "R2", "R3", "R4", "R5"]
+        assert pmodel.coords["rows"] == ("R1", "R2", "R3", "R4", "R5")
         assert "rows" in pmodel.dim_lengths
         assert isinstance(pmodel.dim_lengths["rows"], ScalarSharedVariable)
         assert pmodel.dim_lengths["rows"].eval() == 5
         assert "columns" in pmodel.coords
-        assert pmodel.coords["columns"] == ["C1", "C2", "C3", "C4", "C5", "C6", "C7"]
+        assert pmodel.coords["columns"] == ("C1", "C2", "C3", "C4", "C5", "C6", "C7")
         assert pmodel.RV_dims == {"observations": ("rows", "columns")}
         assert "columns" in pmodel.dim_lengths
         assert isinstance(pmodel.dim_lengths["columns"], ScalarSharedVariable)


### PR DESCRIPTION
Model coordinates should be immutable objects, so tuples are prime candidates for that.

Unfortunately tuples cause problems when passed to xarray (#5043) which happens _after_ the compute-intensive MCMC.

This PR modifies the `Model.coords` such that all coordinate values become tuples.
This way they're immutable and one can do `model.coords["city"].index("London")` to obtain indices that can be used for slicing tensors.

In the `InferenceData` conversion tuples are then automatically converted to NumPy arrays to avoid the problems with xarray.

Note that while this PR restricts the `Model.coords` to tuples, the user may still manually pass other types such as `MultiIndex` for the conversion.

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] what are the (breaking) changes that this PR makes? → above
+ [x] important background, or details about the implementation → above
+ [x] are the changes—especially new features—covered by tests and docstrings? → yes
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style) → yes