### PR TITLE
Fix coords in constant_data issue #5046

### DIFF
--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -131,9 +131,9 @@ def dict_to_dataset(
         for name, vals in data.items():
             vals = np.atleast_1d(vals)
             val_dims = dims.get(name)
-            val_dims, coords = generate_dims_coords(vals.shape, name, dims=val_dims, coords=coords)
-            coords = {key: xr.IndexVariable((key,), data=coords[key]) for key in val_dims}
-            out_data[name] = xr.DataArray(vals, dims=val_dims, coords=coords)
+            val_dims, crds = generate_dims_coords(vals.shape, name, dims=val_dims, coords=coords)
+            crds = {key: xr.IndexVariable((key,), data=crds[key]) for key in val_dims}
+            out_data[name] = xr.DataArray(vals, dims=val_dims, coords=crds)
         return xr.Dataset(data_vars=out_data, attrs=make_attrs(attrs=attrs, library=library))
 
 

--- a/pymc/tests/test_idata_conversion.py
+++ b/pymc/tests/test_idata_conversion.py
@@ -568,6 +568,37 @@ class TestDataPyMC:
         assert "direction" not in idata.log_likelihood.dims
         assert "direction" in idata.observed_data.dims
 
+    @pytest.mark.xfail(reason="Critical bug in dataset conversion.")
+    def test_constant_data_coords_issue_5046(self):
+        # For some reason only the first entry of the `dims` ends up in the dataset.
+        dims = {
+            "alpha": ["backwards"],
+            "bravo": ["letters", "yesno"],
+        }
+        coords = {
+            "backwards": np.arange(17)[::-1],
+            "letters": list("ABCDEFGHIJK"),
+            "yesno": ["yes", "no"],
+        }
+        data = {
+            name: np.random.uniform(size=[len(coords[dn]) for dn in dnames])
+            for name, dnames in dims.items()
+        }
+
+        for k in data:
+            assert len(data[k].shape) == len(dims[k])
+
+        ds = pm.backends.arviz.dict_to_dataset(
+            data=data,
+            library=pm,
+            coords=coords,
+            dims=dims,
+            default_dims=[],
+            index_origin=0,
+        )
+        for dname, cvals in coords.items():
+            np.testing.assert_array_equal(ds[dname].values, cvals)
+
 
 class TestPyMCWarmupHandling:
     @pytest.mark.parametrize("save_warmup", [False, True])

--- a/pymc/tests/test_idata_conversion.py
+++ b/pymc/tests/test_idata_conversion.py
@@ -568,9 +568,8 @@ class TestDataPyMC:
         assert "direction" not in idata.log_likelihood.dims
         assert "direction" in idata.observed_data.dims
 
-    @pytest.mark.xfail(reason="Critical bug in dataset conversion.")
     def test_constant_data_coords_issue_5046(self):
-        # For some reason only the first entry of the `dims` ends up in the dataset.
+        """This is a regression test against a bug where a local coords variable was overwritten."""
         dims = {
             "alpha": ["backwards"],
             "bravo": ["letters", "yesno"],


### PR DESCRIPTION
I got a minimum example to reproduce the problem.

@OriolAbril it looks like ArviZ `0.11.4` also has a bug there. This is the traceback when passing to `dict_to_dataset` from ArviZ:

```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _  

shape = (1, 17)
coords = {'backwards': <xarray.IndexVariable 'backwards' (backwards: 17)>
array([16, 15, 14, 13, 12, 11, 10,  9,  8,  7,  6,  5...: <xarray.IndexVariable 'draw' (draw: 17)>
array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16])}
dims = ['chain', 'draw', 'backwards']

    def _infer_coords_and_dims(
        shape, coords, dims
    ) -> "Tuple[Dict[Any, Variable], Tuple[Hashable, ...]]":
        """All the logic for creating a new DataArray"""

        if (
            coords is not None
            and not utils.is_dict_like(coords)
            and len(coords) != len(shape)
        ):
            raise ValueError(
                f"coords is not dict-like, but it has {len(coords)} items, "
                f"which does not match the {len(shape)} dimensions of the "
                "data"
            )

        if isinstance(dims, str):
            dims = (dims,)

        if dims is None:
            dims = [f"dim_{n}" for n in range(len(shape))]
            if coords is not None and len(coords) == len(shape):
                # try to infer dimensions from coords
                if utils.is_dict_like(coords):
                    # deprecated in GH993, removed in GH1539
                    raise ValueError(
                        "inferring DataArray dimensions from "
                        "dictionary like ``coords`` is no longer "
                        "supported. Use an explicit list of "
                        "``dims`` instead."
                    )
                for n, (dim, coord) in enumerate(zip(dims, coords)):
                    coord = as_variable(coord, name=dims[n]).to_index_variable()
                    dims[n] = coord.name
            dims = tuple(dims)
        elif len(dims) != len(shape):
>           raise ValueError(
                "different number of dimensions on data "
                f"and dims: {len(shape)} vs {len(dims)}"
            )
E           ValueError: different number of dimensions on data and dims: 2 vs 3

..\..\appdata\local\continuum\miniconda3\envs\pm3v4\lib\site-packages\xarray\core\dataarray.py:126: ValueError
================================================================================================== warnings summary ================================================================================================== 
..\..\appdata\local\continuum\miniconda3\envs\pm3v4\lib\site-packages\win32\lib\pywintypes.py:2
  c:\users\osthege\appdata\local\continuum\miniconda3\envs\pm3v4\lib\site-packages\win32\lib\pywintypes.py:2: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp, sys, os

pymc/tests/test_idata_conversion.py::TestDataPyMC::test_constant_data_coords_issue_5046
  c:\users\osthege\appdata\local\continuum\miniconda3\envs\pm3v4\lib\site-packages\arviz\data\base.py:130: UserWarning: In variable alpha, there are more dims (1) given than exist (0). Passed array should have shape (chain,draw, *shape)
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================================================================================== short test summary info =============================================================================================== 
FAILED pymc/tests/test_idata_conversion.py::TestDataPyMC::test_constant_data_coords_issue_5046 - ValueError: different number of dimensions on data and dims: 2 vs 3
```