### PR TITLE
Add `Model.eval_rv_shapes` for fast shape evaluation

### DIFF
--- a/pymc/model.py
+++ b/pymc/model.py
@@ -62,7 +62,14 @@ from pymc.distributions import logp_transform, logpt, logpt_sum
 from pymc.distributions.transforms import Transform
 from pymc.exceptions import ImputationWarning, SamplingError, ShapeError
 from pymc.math import flatten_list
-from pymc.util import UNSET, WithMemoization, get_var_name, treedict, treelist
+from pymc.util import (
+    UNSET,
+    WithMemoization,
+    get_transformed_name,
+    get_var_name,
+    treedict,
+    treelist,
+)
 from pymc.vartypes import continuous_types, discrete_types, typefilter
 
 __all__ = [
@@ -1602,6 +1609,33 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
                     b[value_var.name] = rv_var_value
 
         a.update({k: v for k, v in b.items() if k not in a})
+
+    def eval_rv_shapes(self) -> Dict[str, Tuple[int, ...]]:
+        """Evaluates shapes of untransformed AND transformed free variables.
+
+        Returns
+        -------
+        shapes : dict
+            Maps untransformed and transformed variable names to shape tuples.
+        """
+        names = []
+        outputs = []
+        for rv in self.free_RVs:
+            rv_var = self.rvs_to_values[rv]
+            transform = getattr(rv_var.tag, "transform", None)
+            if transform is not None:
+                names.append(get_transformed_name(rv.name, transform))
+                outputs.append(transform.forward(rv, rv).shape)
+            names.append(rv.name)
+            outputs.append(rv.shape)
+        f = aesara.function(
+            inputs=[],
+            outputs=outputs,
+            givens=[(obs, obs.tag.observations) for obs in self.observed_RVs],
+            mode=aesara.compile.mode.FAST_COMPILE,
+            on_unused_input="ignore",
+        )
+        return {name: tuple(shape) for name, shape in zip(names, f())}
 
     def check_start_vals(self, start):
         r"""Check that the starting values for MCMC do not cause the relevant log probability

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -667,33 +667,18 @@ def _check_start_shape(model, start: PointType):
         The complete dictionary mapping (transformed) variable names to numeric initial values.
     """
     e = ""
-    for var in model.basic_RVs:
-        try:
-            var_shape = model.fastfn(var.shape)(start)
-            if var.name in start.keys():
-                start_var_shape = np.shape(start[var.name])
-                if start_var_shape:
-                    if not np.array_equal(var_shape, start_var_shape):
-                        e += "\nExpected shape {} for var '{}', got: {}".format(
-                            tuple(var_shape), var.name, start_var_shape
-                        )
-                # if start var has no shape
-                else:
-                    # if model var has a specified shape
-                    if var_shape.size > 0:
-                        e += "\nExpected shape {} for var " "'{}', got scalar {}".format(
-                            tuple(var_shape), var.name, start[var.name]
-                        )
-        except NotImplementedError as ex:
-            if ex.args[0].startswith("Cannot sample"):
-                _log.warning(
-                    f"Unable to check start shape of {var} because the RV does not implement random sampling."
-                )
-            else:
-                raise
-
+    try:
+        actual_shapes = model.eval_rv_shapes()
+    except NotImplementedError as ex:
+        warnings.warn(f"Unable to validate shapes: {ex.args[0]}", UserWarning)
+        return
+    for name, sval in start.items():
+        ashape = actual_shapes.get(name)
+        sshape = np.shape(sval)
+        if ashape != tuple(sshape):
+            e += f"\nExpected shape {ashape} for var '{name}', got: {sshape}"
     if e != "":
-        raise ValueError(f"Bad shape for start argument:{e}")
+        raise ValueError(f"Bad shape in start point:{e}")
 
 
 def _sample_many(

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -235,10 +235,9 @@ class TestSample(SeededTest):
     @pytest.mark.parametrize(
         "start, error",
         [
-            ([1, 2], TypeError),
-            ({"x": 1}, TypeError),
+            ({"x": 1}, ValueError),
             ({"x": [1, 2, 3]}, ValueError),
-            ({"x": np.array([[1, 1], [1, 1]])}, TypeError),
+            ({"x": np.array([[1, 1], [1, 1]])}, ValueError),
         ],
     )
     def test_sample_start_bad_shape(self, start, error):

--- a/pymc/tests/test_step.py
+++ b/pymc/tests/test_step.py
@@ -983,12 +983,11 @@ class TestNutsCheckTrace:
                 sample(init=None, cores=2, random_seed=1)
             error.match("Initial evaluation")
 
-    @pytest.mark.xfail(reason="Start shape checks that were previously skipped run into ValueError")
     def test_linalg(self, caplog):
         with Model():
             a = Normal("a", size=2, initval=floatX(np.zeros(2)))
             a = at.switch(a > 0, np.inf, a)
-            b = at.slinalg.solve(floatX(np.eye(2)), a)
+            b = at.slinalg.solve(floatX(np.eye(2)), a, check_finite=False)
             Normal("c", mu=b, size=2, initval=floatX(np.r_[0.0, 0.0]))
             caplog.clear()
             trace = sample(20, init=None, tune=5, chains=2, return_inferencedata=False)


### PR DESCRIPTION
This PR adds a `Model.eval_rv_shapes` method that can be used to evaluate the shapes of all free untransformed and transformed RVs at the same time.

Consequently the `_check_start_shapes` function that's applied at the start of every sampling became much simpler.

Even though the new shape checks only evaluate the `.shape` of tensors, the `TestNutsCheckTrace.test_linalg` still errored from a finite-check.
Apparently the `at.slinalg.solve` Op also applies the finite-check in shape inference (on purpose? cc @brandonwillard).

Depending on what your PR does, here are a few things you might want to address in the description:
+ [x] what are the (breaking) changes that this PR makes? → no breaking changes 🎉
+ [x] important background, or details about the implementation → above
+ [x] are the changes—especially new features—covered by tests and docstrings? → ✔️ 
+ [x] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
