### PR TITLE
Fix dependencies in requirements-dev.txt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
     - id: pip-from-conda
       additional_dependencies: [pyyaml]
       entry: python scripts/generate_pip_deps_from_conda.py
-      files: ^conda-envs/
+      files: ^conda-envs/environment-dev-py.+.yml$
       language: python
       name: Generate pip dependency from conda
     - id: no-relative-imports

--- a/conda-envs/environment-dev-py37.yml
+++ b/conda-envs/environment-dev-py37.yml
@@ -1,3 +1,4 @@
+# "dev" conda envs are to be used by devs in setting their local environments
 name: pymc-dev-py37
 channels:
 - conda-forge
@@ -8,7 +9,7 @@ dependencies:
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0
-- h5py
+- h5py>=2.7
 - ipython
 - myst-nb
 - numpy>=1.15
@@ -20,13 +21,11 @@ dependencies:
 - pytest>=3.0
 - python-graphviz
 - python=3.7
-- recommonmark>=0.4
 - scipy>1.4.1
 - sphinx-autobuild>=0.7
 - sphinx-notfound-page
 - sphinx-panels
 - sphinx>=1.5
 - typing-extensions
-- watermark
 - pip:
   - sphinx-design

--- a/conda-envs/environment-dev-py38.yml
+++ b/conda-envs/environment-dev-py38.yml
@@ -1,3 +1,4 @@
+# "dev" conda envs are to be used by devs in setting their local environments
 name: pymc-dev-py38
 channels:
 - conda-forge
@@ -8,7 +9,7 @@ dependencies:
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0
-- h5py
+- h5py>=2.7
 - ipython
 - myst-nb
 - numpy>=1.15.0
@@ -20,13 +21,11 @@ dependencies:
 - pytest>=3.0
 - python-graphviz
 - python=3.8
-- recommonmark>=0.4
 - scipy>1.4.1
 - sphinx-autobuild>=0.7
 - sphinx-notfound-page
 - sphinx-panels
 - sphinx>=1.5
 - typing-extensions>=3.7.4
-- watermark
 - pip:
   - sphinx-design

--- a/conda-envs/environment-dev-py39.yml
+++ b/conda-envs/environment-dev-py39.yml
@@ -1,3 +1,4 @@
+# "dev" conda envs are to be used by devs in setting their local environments
 name: pymc-dev-py39
 channels:
 - conda-forge
@@ -20,13 +21,11 @@ dependencies:
 - pytest>=3.0
 - python-graphviz
 - python=3.9
-- recommonmark>=0.4
 - scipy>1.4.1
 - sphinx-autobuild>=0.7
 - sphinx-notfound-page
 - sphinx-panels
 - sphinx>=1.5
 - typing-extensions>=3.7.4
-- watermark
 - pip:
   - sphinx-design

--- a/conda-envs/environment-test-py37.yml
+++ b/conda-envs/environment-test-py37.yml
@@ -14,7 +14,7 @@ dependencies:
 - libblas=*=*mkl
 - mkl-service
 - numpy>=1.15.0
-- pandas=0.24
+- pandas>=0.24
 - pre-commit>=2.8.0
 - pytest-cov>=2.5
 - pytest>=3.0

--- a/conda-envs/environment-test-py37.yml
+++ b/conda-envs/environment-test-py37.yml
@@ -1,3 +1,4 @@
+# "test" conda envs are used to set up our CI environment in GitHub actions
 name: pymc-test-py37
 channels:
 - conda-forge
@@ -12,23 +13,12 @@ dependencies:
 - ipython
 - libblas=*=*mkl
 - mkl-service
-- myst-nb
 - numpy>=1.15.0
-- numpydoc>=0.9
 - pandas=0.24
 - pre-commit>=2.8.0
-- pydata-sphinx-theme
 - pytest-cov>=2.5
 - pytest>=3.0
 - python-graphviz
 - python=3.7
-- recommonmark>=0.4
 - scipy>1.4.1
-- sphinx-autobuild>=0.7
-- sphinx-notfound-page
-- sphinx-panels
-- sphinx>=1.5
 - typing-extensions
-- watermark
-- pip:
-  - sphinx-design

--- a/conda-envs/environment-test-py37.yml
+++ b/conda-envs/environment-test-py37.yml
@@ -4,7 +4,7 @@ channels:
 - defaults
 dependencies:
 - aesara>=2.1.0
-- arviz>=0.11.2
+- arviz>=0.11.4
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0
@@ -25,7 +25,10 @@ dependencies:
 - recommonmark>=0.4
 - scipy>1.4.1
 - sphinx-autobuild>=0.7
+- sphinx-notfound-page
 - sphinx-panels
 - sphinx>=1.5
 - typing-extensions
 - watermark
+- pip:
+  - sphinx-design

--- a/conda-envs/environment-test-py38.yml
+++ b/conda-envs/environment-test-py38.yml
@@ -1,3 +1,4 @@
+# "test" conda envs are used to set up our CI environment in GitHub actions
 name: pymc-test-py38
 channels:
 - conda-forge
@@ -12,24 +13,12 @@ dependencies:
 - ipython
 - libblas=*=*mkl
 - mkl-service
-- myst-nb
-- nbsphinx>=0.4
 - numpy>=1.15.0
-- numpydoc>=0.9
 - pandas
 - pre-commit>=2.8.0
-- pydata-sphinx-theme
 - pytest-cov>=2.5
 - pytest>=3.0
 - python-graphviz
 - python=3.8
-- recommonmark>=0.4
 - scipy>1.4.1
-- sphinx-autobuild>=0.7
-- sphinx-notfound-page
-- sphinx-panels
-- sphinx>=1.5
 - typing-extensions>=3.7.4
-- watermark
-- pip:
-  - sphinx-design

--- a/conda-envs/environment-test-py38.yml
+++ b/conda-envs/environment-test-py38.yml
@@ -4,7 +4,7 @@ channels:
 - defaults
 dependencies:
 - aesara>=2.1.0
-- arviz>=0.11.2
+- arviz>=0.11.4
 - cachetools>=4.2.1
 - cloudpickle
 - fastprogress>=0.2.0
@@ -26,7 +26,10 @@ dependencies:
 - recommonmark>=0.4
 - scipy>1.4.1
 - sphinx-autobuild>=0.7
+- sphinx-notfound-page
 - sphinx-panels
 - sphinx>=1.5
 - typing-extensions>=3.7.4
 - watermark
+- pip:
+  - sphinx-design

--- a/conda-envs/environment-test-py39.yml
+++ b/conda-envs/environment-test-py39.yml
@@ -4,7 +4,7 @@ channels:
 - defaults
 dependencies:
 - aesara>=2.1.0
-- arviz>=0.11.2
+- arviz>=0.11.4
 - cachetools
 - cloudpickle
 - fastprogress>=0.2.0
@@ -26,7 +26,10 @@ dependencies:
 - recommonmark>=0.4
 - scipy>1.4.1
 - sphinx-autobuild>=0.7
+- sphinx-notfound-page
 - sphinx-panels
 - sphinx>=1.5
 - typing-extensions>=3.7.4
 - watermark
+- pip:
+  - sphinx-design

--- a/conda-envs/environment-test-py39.yml
+++ b/conda-envs/environment-test-py39.yml
@@ -1,3 +1,4 @@
+# "test" conda envs are used to set up our CI environment in GitHub actions
 name: pymc-test-py39
 channels:
 - conda-forge
@@ -12,24 +13,12 @@ dependencies:
 - ipython>=7.16
 - libblas=*=*mkl
 - mkl-service
-- myst-nb
-- nbsphinx>=0.4
 - numpy>=1.15.0
-- numpydoc>=0.9
 - pandas
 - pre-commit>=2.8.0
-- pydata-sphinx-theme
 - pytest-cov>=2.5
 - pytest>=3.0
 - python-graphviz
 - python=3.9
-- recommonmark>=0.4
 - scipy>1.4.1
-- sphinx-autobuild>=0.7
-- sphinx-notfound-page
-- sphinx-panels
-- sphinx>=1.5
 - typing-extensions>=3.7.4
-- watermark
-- pip:
-  - sphinx-design

--- a/conda-envs/windows-environment-dev-py38.yml
+++ b/conda-envs/windows-environment-dev-py38.yml
@@ -25,7 +25,6 @@ dependencies:
 - pydata-sphinx-theme
 - pytest-cov>=2.5
 - pytest>=3.0
-- recommonmark>=0.4
 - sphinx-autobuild>=0.7
 - sphinx-notfound-page
 - sphinx-panels

--- a/conda-envs/windows-environment-test-py38.yml
+++ b/conda-envs/windows-environment-test-py38.yml
@@ -20,17 +20,8 @@ dependencies:
 - python-graphviz
 - scipy>1.4.1
 - typing-extensions>=3.7.4
-# Extra stuff for dev, testing and docs build
+# Extra stuff for testing
 - ipython>=7.16
-- myst-nb
-- nbsphinx>=0.4
-- numpydoc>=0.9
 - pre-commit>=2.8.0
-- pydata-sphinx-theme
 - pytest-cov>=2.5
 - pytest>=3.0
-- recommonmark>=0.4
-- sphinx-autobuild>=0.7
-- sphinx-panels
-- sphinx>=1.5
-- watermark

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,13 +3,12 @@
 
 aesara>=2.1.0
 arviz>=0.11.4
-cachetools
+cachetools>=4.2.1
 cloudpickle
 fastprogress>=0.2.0
 h5py
-ipython>=7.16
+ipython
 myst-nb
-nbsphinx>=0.4
 numpy>=1.15.0
 numpydoc>=0.9
 pandas

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ arviz>=0.11.4
 cachetools>=4.2.1
 cloudpickle
 fastprogress>=0.2.0
-h5py
+h5py>=2.7
 ipython
 myst-nb
 numpy>=1.15.0
@@ -16,7 +16,6 @@ pre-commit>=2.8.0
 pydata-sphinx-theme
 pytest-cov>=2.5
 pytest>=3.0
-recommonmark>=0.4
 scipy>1.4.1
 sphinx-autobuild>=0.7
 sphinx-design
@@ -24,4 +23,3 @@ sphinx-notfound-page
 sphinx-panels
 sphinx>=1.5
 typing-extensions>=3.7.4
-watermark

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,14 +2,13 @@
 # See that file for comments about the need/usage of each dependency.
 
 aesara>=2.1.0
-arviz>=0.11.2
+arviz>=0.11.4
 cachetools
 cloudpickle
 fastprogress>=0.2.0
 h5py>=2.7
 ipython>=7.16
 myst-nb
-nbsphinx>=0.4
 numpy>=1.15.0
 numpydoc>=0.9
 pandas
@@ -20,6 +19,8 @@ pytest>=3.0
 recommonmark>=0.4
 scipy>1.4.1
 sphinx-autobuild>=0.7
+sphinx-design
+sphinx-notfound-page
 sphinx-panels
 sphinx>=1.5
 typing-extensions>=3.7.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,9 +6,10 @@ arviz>=0.11.4
 cachetools
 cloudpickle
 fastprogress>=0.2.0
-h5py>=2.7
+h5py
 ipython>=7.16
 myst-nb
+nbsphinx>=0.4
 numpy>=1.15.0
 numpydoc>=0.9
 pandas


### PR DESCRIPTION
The requirements-dev were updated in PR - https://github.com/pymc-devs/pymc/pull/4932. After the merge, RTD could not build docs because of missing dependencies. So, this PR reverts the changes in requirements-dev.txt.

I am not sure of the differences between `environment-dev-py37.yml` and `environment-test-py37.yml`. But `sphinx_design` and `sphinx-notfound-page` are not present in environment-test* yml files. So, is there a way to generate these yml files from requirements-dev.txt?
