### PR TITLE
Rename pymc3 to pymc in conda test envs

### DIFF
--- a/conda-envs/environment-test-py37.yml
+++ b/conda-envs/environment-test-py37.yml
@@ -1,4 +1,4 @@
-name: pymc3-test-py37
+name: pymc-test-py37
 channels:
 - conda-forge
 - defaults

--- a/conda-envs/environment-test-py38.yml
+++ b/conda-envs/environment-test-py38.yml
@@ -1,4 +1,4 @@
-name: pymc3-test-py38
+name: pymc-test-py38
 channels:
 - conda-forge
 - defaults

--- a/conda-envs/environment-test-py39.yml
+++ b/conda-envs/environment-test-py39.yml
@@ -1,4 +1,4 @@
-name: pymc3-test-py39
+name: pymc-test-py39
 channels:
 - conda-forge
 - defaults

--- a/conda-envs/windows-environment-test-py38.yml
+++ b/conda-envs/windows-environment-test-py38.yml
@@ -1,4 +1,4 @@
-name: pymc3-test-py38
+name: pymc-test-py38
 channels:
 - conda-forge
 - defaults


### PR DESCRIPTION
Somehow, the test environments still had `pymc3` in their name, instead of `pymc`. So here is a quick (arguably _extremely_ complex) PR to fix this