### PR TITLE
Add LBS podcast to resources

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ If you already know about Bayesian statistics:
 -  The `PyMC tutorial <https://docs.pymc.io/en/stable/pymc-examples/examples/getting_started.html>`__
 -  `PyMC examples <https://docs.pymc.io/nb_examples/index.html>`__ and the `API reference <https://docs.pymc.io/en/stable/api.html>`__
 
-Learn Bayesian statistics with a book together with PyMC:
+Learn Bayesian statistics with a book together with PyMC
 ---------------------------------------------------------
 
 -  `Probabilistic Programming and Bayesian Methods for Hackers <https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers>`__: Fantastic book with many applied code examples.
@@ -53,11 +53,12 @@ Learn Bayesian statistics with a book together with PyMC:
 -  `PyMC port of the book "Bayesian Cognitive Modeling" by Michael Lee and EJ Wagenmakers <https://github.com/pymc-devs/resources/tree/master/BCM>`__: Focused on using Bayesian statistics in cognitive modeling.
 -  `Bayesian Analysis with Python  <https://www.packtpub.com/big-data-and-business-intelligence/bayesian-analysis-python-second-edition>`__ (second edition) by Osvaldo Martin: Great introductory book. (`code <https://github.com/aloctavodia/BAP>`__ and errata).
 
-PyMC talks
+Audio & Video
 ----------
 
-There are also several talks on PyMC which are gathered in this `YouTube playlist <https://www.youtube.com/playlist?list=PL1Ma_1DBbE82OVW8Fz_6Ts1oOeyOAiovy>`__
-and as part of `PyMCon 2020 <https://discourse.pymc.io/c/pymcon/2020talks/15>`__
+- The `"Learning Bayesian Statistics" podcast <https://www.learnbayesstats.com/>`__ helps you discover and stay up-to-date with the vast Bayesian community. Bonus: it's hosted by Alex Andorra, one of the PyMC core devs!
+- Here is a `YouTube playlist <https://www.youtube.com/playlist?list=PL1Ma_1DBbE82OVW8Fz_6Ts1oOeyOAiovy>`__ gathering several talks on PyMC.
+- You can also find all the talks given at **PyMCon 2020** `here <https://discourse.pymc.io/c/pymcon/2020talks/15>`__.
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ If you already know about Bayesian statistics:
 -  `PyMC examples <https://docs.pymc.io/nb_examples/index.html>`__ and the `API reference <https://docs.pymc.io/en/stable/api.html>`__
 
 Learn Bayesian statistics with a book together with PyMC
----------------------------------------------------------
+--------------------------------------------------------
 
 -  `Probabilistic Programming and Bayesian Methods for Hackers <https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers>`__: Fantastic book with many applied code examples.
 -  `PyMC port of the book "Doing Bayesian Data Analysis" by John Kruschke <https://github.com/aloctavodia/Doing_bayesian_data_analysis>`__ as well as the `second edition <https://github.com/JWarmenhoven/DBDA-python>`__: Principled introduction to Bayesian data analysis.

--- a/README.rst
+++ b/README.rst
@@ -56,9 +56,9 @@ Learn Bayesian statistics with a book together with PyMC
 Audio & Video
 ----------
 
-- The `"Learning Bayesian Statistics" podcast <https://www.learnbayesstats.com/>`__ helps you discover and stay up-to-date with the vast Bayesian community. Bonus: it's hosted by Alex Andorra, one of the PyMC core devs!
 - Here is a `YouTube playlist <https://www.youtube.com/playlist?list=PL1Ma_1DBbE82OVW8Fz_6Ts1oOeyOAiovy>`__ gathering several talks on PyMC.
 - You can also find all the talks given at **PyMCon 2020** `here <https://discourse.pymc.io/c/pymcon/2020talks/15>`__.
+- The `"Learning Bayesian Statistics" podcast <https://www.learnbayesstats.com/>`__ helps you discover and stay up-to-date with the vast Bayesian community. Bonus: it's hosted by Alex Andorra, one of the PyMC core devs!
 
 Installation
 ============


### PR DESCRIPTION
As discussed on Slack, here is a quick PR to add the "Learn Bayes Stats" podcast to the "Getting Started" section of the README.
I also fixed some typos