### PR TITLE
Make forward sampling functions return `InferenceData`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,6 +8,8 @@
 - The GLM submodule has been removed, please use [Bambi](https://bambinos.github.io/bambi/) instead.
 - The `Distribution` keyword argument `testval` has been deprecated in favor of `initval`. Furthermore `initval` no longer assigns a `tag.test_value` on tensors since the initial values are now kept track of by the model object ([see #4913](https://github.com/pymc-devs/pymc/pull/4913)).
 - `pm.sample` now returns results as `InferenceData` instead of `MultiTrace` by default (see [#4744](https://github.com/pymc-devs/pymc/pull/4744)).
+- `pm.sample_prior_predictive`, `pm.sample_posterior_predictive` and `pm.sample_posterior_predictive_w` now return an `InferenceData` object
+  by default, instead of a dictionary (see [#5073](https://github.com/pymc-devs/pymc/pull/5073)).
 - `pm.sample_prior_predictive` no longer returns transformed variable values by default. Pass them by name in `var_names` if you want to obtain these draws (see [4769](https://github.com/pymc-devs/pymc/pull/4769)).
 - ⚠ `pm.Bound` interface no longer accepts a callable class as argument, instead it requires an instantiated distribution (created via the `.dist()` API) to be passed as an argument. In addition, Bound no longer returns a class instance but works as a normal PyMC distribution. Finally, it is no longer possible to do predictive random sampling from Bounded variables. Please, consult the new documentation for details on how to use Bounded variables (see [4815](https://github.com/pymc-devs/pymc/pull/4815)).
 - `pm.DensityDist` no longer accepts the `logp` as its first position argument. It is now an optional keyword argument. If you pass a callable as the first positional argument, a `TypeError` will be raised (see [5026](https://github.com/pymc-devs/pymc3/pull/5026)).

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -267,7 +267,7 @@ def sample(
     callback=None,
     jitter_max_retries=10,
     *,
-    return_inferencedata=None,
+    return_inferencedata=True,
     idata_kwargs: dict = None,
     mp_ctx=None,
     **kwargs,
@@ -336,7 +336,7 @@ def sample(
         Maximum number of repeated attempts (per chain) at creating an initial matrix with uniform jitter
         that yields a finite probability. This applies to ``jitter+adapt_diag`` and ``jitter+adapt_full``
         init methods.
-    return_inferencedata : bool, default=True
+    return_inferencedata : bool
         Whether to return the trace as an :class:`arviz:arviz.InferenceData` (True) object or a `MultiTrace` (False)
         Defaults to `True`.
     idata_kwargs : dict, optional
@@ -449,9 +449,6 @@ def sample(
 
     if not isinstance(random_seed, abc.Iterable):
         raise TypeError("Invalid value for `random_seed`. Must be tuple, list or int")
-
-    if return_inferencedata is None:
-        return_inferencedata = True
 
     if not discard_tuned_samples and not return_inferencedata:
         warnings.warn(
@@ -1893,7 +1890,7 @@ def sample_prior_predictive(
     var_names: Optional[Iterable[str]] = None,
     random_seed=None,
     mode: Optional[Union[str, Mode]] = None,
-    return_inferencedata=None,
+    return_inferencedata=True,
     idata_kwargs: dict = None,
 ) -> Union[InferenceData, Dict[str, np.ndarray]]:
     """Generate samples from the prior predictive distribution.
@@ -1924,8 +1921,6 @@ def sample_prior_predictive(
         or a dictionary with variable names as keys and samples as numpy arrays.
     """
     model = modelcontext(model)
-    if return_inferencedata is None:
-        return_inferencedata = True
 
     if model.potentials:
         warnings.warn(
@@ -1992,11 +1987,9 @@ def sample_prior_predictive(
 
     if not return_inferencedata:
         return prior
-
     ikwargs = dict(model=model)
     if idata_kwargs:
         ikwargs.update(idata_kwargs)
-
     return pm.to_inference_data(prior=prior, **ikwargs)
 
 

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -1911,9 +1911,9 @@ def sample_prior_predictive(
         Seed for the random number generator.
     mode:
         The mode used by ``aesara.function`` to compile the graph.
-    return_inferencedata : bool, default=True
+    return_inferencedata : bool
         Whether to return an :class:`arviz:arviz.InferenceData` (True) object or a dictionary (False).
-        Defaults to `True`.
+        Defaults to True.
     idata_kwargs : dict, optional
         Keyword arguments for :func:`pymc.to_inference_data`
 

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -1579,7 +1579,7 @@ def sample_posterior_predictive(
     -------
     arviz.InferenceData or Dict
         An ArviZ ``InferenceData`` object containing the posterior predictive samples (default), or
-        a dictionary with variable names as keys, and samples numpy arrays.
+        a dictionary with variable names as keys, and samples as numpy arrays.
     """
 
     _trace: Union[MultiTrace, PointList]
@@ -1743,6 +1743,8 @@ def sample_posterior_predictive_w(
     weights: Optional[ArrayLike] = None,
     random_seed: Optional[int] = None,
     progressbar: bool = True,
+    return_inferencedata=True,
+    idata_kwargs: dict = None,
 ):
     """Generate weighted posterior predictive samples from a list of models and
     a list of traces according to a set of weights.
@@ -1769,12 +1771,18 @@ def sample_posterior_predictive_w(
         Whether or not to display a progress bar in the command line. The bar shows the percentage
         of completion, the sampling speed in samples per second (SPS), and the estimated remaining
         time until completion ("expected time of arrival"; ETA).
+    return_inferencedata : bool
+        Whether to return an :class:`arviz:arviz.InferenceData` (True) object or a dictionary (False).
+        Defaults to True.
+    idata_kwargs : dict, optional
+        Keyword arguments for :func:`pymc.to_inference_data`
 
     Returns
     -------
-    samples : dict
-        Dictionary with the variables as keys. The values corresponding to the
-        posterior predictive samples from the weighted models.
+    arviz.InferenceData or Dict
+        An ArviZ ``InferenceData`` object containing the posterior predictive samples from the
+        weighted models (default), or a dictionary with variable names as keys, and samples as
+        numpy arrays.
     """
     if isinstance(traces[0], InferenceData):
         n_samples = [
@@ -1893,7 +1901,13 @@ def sample_posterior_predictive_w(
     except KeyboardInterrupt:
         pass
     else:
-        return {k: np.asarray(v) for k, v in ppc.items()}
+        ppc = {k: np.asarray(v) for k, v in ppc.items()}
+        if not return_inferencedata:
+            return ppc
+        ikwargs = dict(model=models)
+        if idata_kwargs:
+            ikwargs.update(idata_kwargs)
+        return pm.to_inference_data(posterior_predictive=ppc, **ikwargs)
 
 
 def sample_prior_predictive(

--- a/pymc/smc/smc.py
+++ b/pymc/smc/smc.py
@@ -179,6 +179,7 @@ class SMC_KERNEL(ABC):
             self.draws,
             var_names=[v.name for v in self.model.unobserved_value_vars],
             model=self.model,
+            return_inferencedata=False,
         )
 
     def _initialize_kernel(self):

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -3249,7 +3249,7 @@ def test_distinct_rvs():
         X_rv = pm.Normal("x")
         Y_rv = pm.Normal("y")
 
-        pp_samples = pm.sample_prior_predictive(samples=2)
+        pp_samples = pm.sample_prior_predictive(samples=2, return_inferencedata=False)
 
     assert X_rv.owner.inputs[0] != Y_rv.owner.inputs[0]
 
@@ -3259,7 +3259,7 @@ def test_distinct_rvs():
         X_rv = pm.Normal("x")
         Y_rv = pm.Normal("y")
 
-        pp_samples_2 = pm.sample_prior_predictive(samples=2)
+        pp_samples_2 = pm.sample_prior_predictive(samples=2, return_inferencedata=False)
 
     assert np.array_equal(pp_samples["y"], pp_samples_2["y"])
 

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -102,7 +102,13 @@ def pymc_random(
 
 
 def pymc_random_discrete(
-    dist, paramdomains, valuedomain=Domain([0]), ref_rand=None, size=100000, alpha=0.05, fails=20
+    dist,
+    paramdomains,
+    valuedomain=Domain([0]),
+    ref_rand=None,
+    size=100000,
+    alpha=0.05,
+    fails=20,
 ):
     model, param_vars = build_model(dist, valuedomain, paramdomains)
     model_dist = change_rv_size(model.named_vars["value"], size, expand=True)
@@ -176,7 +182,9 @@ class BaseTestCases:
                             size = shape
                         else:
                             size = shape[:-ndim_supp]
-                        return self.distribution(name, size=size, transform=None, **params)
+                        return self.distribution(
+                            name, size=size, transform=None, **params
+                        )
                 except TypeError:
                     if np.sum(np.atleast_1d(shape)) == 0:
                         pytest.skip("Timeseries must have positive shape")
@@ -194,7 +202,9 @@ class BaseTestCases:
         def test_scalar_distribution_shape(self, shape, size):
             """Draws samples of different [size] from a scalar [shape] RV."""
             rv = self.get_random_variable(shape)
-            exp_shape = self.default_shape if shape is None else tuple(np.atleast_1d(shape))
+            exp_shape = (
+                self.default_shape if shape is None else tuple(np.atleast_1d(shape))
+            )
             exp_size = self.default_size if size is None else tuple(np.atleast_1d(size))
             expected = exp_size + exp_shape
             actual = np.shape(self.sample_random_variable(rv, size))
@@ -214,7 +224,9 @@ class BaseTestCases:
         def test_scalar_sample_shape(self, shape, size):
             """Draws samples of scalar [size] from a [shape] RV."""
             rv = self.get_random_variable(shape)
-            exp_shape = self.default_shape if shape is None else tuple(np.atleast_1d(shape))
+            exp_shape = (
+                self.default_shape if shape is None else tuple(np.atleast_1d(shape))
+            )
             exp_size = self.default_size if size is None else tuple(np.atleast_1d(size))
             expected = exp_size + exp_shape
             actual = np.shape(self.sample_random_variable(rv, size))
@@ -227,7 +239,9 @@ class BaseTestCases:
         def test_vector_params(self, shape, size):
             shape = self.shape
             rv = self.get_random_variable(shape, with_vector_params=True)
-            exp_shape = self.default_shape if shape is None else tuple(np.atleast_1d(shape))
+            exp_shape = (
+                self.default_shape if shape is None else tuple(np.atleast_1d(shape))
+            )
             exp_size = self.default_size if size is None else tuple(np.atleast_1d(size))
             expected = exp_size + exp_shape
             actual = np.shape(self.sample_random_variable(rv, size))
@@ -340,7 +354,9 @@ class BaseTestDistribution(SeededTest):
     def _instantiate_pymc_rv(self, dist_params=None):
         params = dist_params if dist_params else self.pymc_dist_params
         self.pymc_rv = self.pymc_dist.dist(
-            **params, size=self.size, rng=aesara.shared(self.get_random_state(reset=True))
+            **params,
+            size=self.size,
+            rng=aesara.shared(self.get_random_state(reset=True)),
         )
 
     def check_pymc_draws_match_reference(self):
@@ -356,16 +372,36 @@ class BaseTestDistribution(SeededTest):
         for (expected_name, expected_value), actual_variable in zip(
             self.expected_rv_op_params.items(), aesera_dist_inputs
         ):
-            assert_almost_equal(expected_value, actual_variable.eval(), decimal=self.decimal)
+            assert_almost_equal(
+                expected_value, actual_variable.eval(), decimal=self.decimal
+            )
 
     def check_rv_size(self):
         # test sizes
-        sizes_to_check = self.sizes_to_check or [None, (), 1, (1,), 5, (4, 5), (2, 4, 2)]
-        sizes_expected = self.sizes_expected or [(), (), (1,), (1,), (5,), (4, 5), (2, 4, 2)]
+        sizes_to_check = self.sizes_to_check or [
+            None,
+            (),
+            1,
+            (1,),
+            5,
+            (4, 5),
+            (2, 4, 2),
+        ]
+        sizes_expected = self.sizes_expected or [
+            (),
+            (),
+            (1,),
+            (1,),
+            (5,),
+            (4, 5),
+            (2, 4, 2),
+        ]
         for size, expected in zip(sizes_to_check, sizes_expected):
             pymc_rv = self.pymc_dist.dist(**self.pymc_dist_params, size=size)
             actual = tuple(pymc_rv.shape.eval())
-            assert actual == expected, f"size={size}, expected={expected}, actual={actual}"
+            assert (
+                actual == expected
+            ), f"size={size}, expected={expected}, actual={actual}"
 
         # test multi-parameters sampling for univariate distributions (with univariate inputs)
         if (
@@ -374,10 +410,15 @@ class BaseTestDistribution(SeededTest):
             and sum(self.pymc_dist.rv_op.ndims_params) == 0
         ):
             params = {
-                k: p * np.ones(self.repeated_params_shape) for k, p in self.pymc_dist_params.items()
+                k: p * np.ones(self.repeated_params_shape)
+                for k, p in self.pymc_dist_params.items()
             }
             self._instantiate_pymc_rv(params)
-            sizes_to_check = [None, self.repeated_params_shape, (5, self.repeated_params_shape)]
+            sizes_to_check = [
+                None,
+                self.repeated_params_shape,
+                (5, self.repeated_params_shape),
+            ]
             sizes_expected = [
                 (self.repeated_params_shape,),
                 (self.repeated_params_shape,),
@@ -410,7 +451,11 @@ class TestFlat(BaseTestDistribution):
     pymc_dist = pm.Flat
     pymc_dist_params = {}
     expected_rv_op_params = {}
-    tests_to_run = ["check_pymc_params_match_rv_op", "check_rv_size", "check_not_implemented"]
+    tests_to_run = [
+        "check_pymc_params_match_rv_op",
+        "check_rv_size",
+        "check_not_implemented",
+    ]
 
     def check_not_implemented(self):
         with pytest.raises(NotImplementedError):
@@ -421,7 +466,11 @@ class TestHalfFlat(BaseTestDistribution):
     pymc_dist = pm.HalfFlat
     pymc_dist_params = {}
     expected_rv_op_params = {}
-    tests_to_run = ["check_pymc_params_match_rv_op", "check_rv_size", "check_not_implemented"]
+    tests_to_run = [
+        "check_pymc_params_match_rv_op",
+        "check_rv_size",
+        "check_not_implemented",
+    ]
 
     def check_not_implemented(self):
         with pytest.raises(NotImplementedError):
@@ -430,13 +479,20 @@ class TestHalfFlat(BaseTestDistribution):
 
 class TestDiscreteWeibull(BaseTestDistribution):
     def discrete_weibul_rng_fn(self, size, q, beta, uniform_rng_fct):
-        return np.ceil(np.power(np.log(1 - uniform_rng_fct(size=size)) / np.log(q), 1.0 / beta)) - 1
+        return (
+            np.ceil(
+                np.power(np.log(1 - uniform_rng_fct(size=size)) / np.log(q), 1.0 / beta)
+            )
+            - 1
+        )
 
     def seeded_discrete_weibul_rng_fn(self):
         uniform_rng_fct = functools.partial(
             getattr(np.random.RandomState, "uniform"), self.get_random_state()
         )
-        return functools.partial(self.discrete_weibul_rng_fn, uniform_rng_fct=uniform_rng_fct)
+        return functools.partial(
+            self.discrete_weibul_rng_fn, uniform_rng_fct=uniform_rng_fct
+        )
 
     pymc_dist = pm.DiscreteWeibull
     pymc_dist_params = {"q": 0.25, "beta": 2.0}
@@ -489,7 +545,9 @@ class TestAsymmetricLaplace(BaseTestDistribution):
         uniform_rng_fct = functools.partial(
             getattr(np.random.RandomState, "uniform"), self.get_random_state()
         )
-        return functools.partial(self.asymmetriclaplace_rng_fn, uniform_rng_fct=uniform_rng_fct)
+        return functools.partial(
+            self.asymmetriclaplace_rng_fn, uniform_rng_fct=uniform_rng_fct
+        )
 
     pymc_dist = pm.AsymmetricLaplace
 
@@ -505,8 +563,12 @@ class TestAsymmetricLaplace(BaseTestDistribution):
 
 
 class TestExGaussian(BaseTestDistribution):
-    def exgaussian_rng_fn(self, mu, sigma, nu, size, normal_rng_fct, exponential_rng_fct):
-        return normal_rng_fct(mu, sigma, size=size) + exponential_rng_fct(scale=nu, size=size)
+    def exgaussian_rng_fn(
+        self, mu, sigma, nu, size, normal_rng_fct, exponential_rng_fct
+    ):
+        return normal_rng_fct(mu, sigma, size=size) + exponential_rng_fct(
+            scale=nu, size=size
+        )
 
     def seeded_exgaussian_rng_fn(self):
         normal_rng_fct = functools.partial(
@@ -577,7 +639,9 @@ class TestKumaraswamy(BaseTestDistribution):
         uniform_rng_fct = functools.partial(
             getattr(np.random.RandomState, "uniform"), self.get_random_state()
         )
-        return functools.partial(self.kumaraswamy_rng_fn, uniform_rng_fct=uniform_rng_fct)
+        return functools.partial(
+            self.kumaraswamy_rng_fn, uniform_rng_fct=uniform_rng_fct
+        )
 
     pymc_dist = pm.Kumaraswamy
     pymc_dist_params = {"a": 1.0, "b": 1.0}
@@ -678,7 +742,9 @@ class TestWald(BaseTestDistribution):
 
     def check_pymc_draws_match_reference(self):
         assert_array_almost_equal(
-            self.pymc_rv.eval(), self.reference_dist_draws + self.alpha, decimal=self.decimal
+            self.pymc_rv.eval(),
+            self.reference_dist_draws + self.alpha,
+            decimal=self.decimal,
         )
 
 
@@ -915,7 +981,10 @@ class TestInverseGammaMuSigma(BaseTestDistribution):
     pymc_dist = pm.InverseGamma
     pymc_dist_params = {"mu": 0.5, "sigma": 0.25}
     expected_alpha, expected_beta = pm.InverseGamma._get_alpha_beta(
-        alpha=None, beta=None, mu=pymc_dist_params["mu"], sigma=pymc_dist_params["sigma"]
+        alpha=None,
+        beta=None,
+        mu=pymc_dist_params["mu"],
+        sigma=pymc_dist_params["sigma"],
     )
     expected_rv_op_params = {"alpha": expected_alpha, "beta": expected_beta}
     tests_to_run = ["check_pymc_params_match_rv_op"]
@@ -983,8 +1052,14 @@ class TestPoisson(BaseTestDistribution):
 
 class TestMvNormalCov(BaseTestDistribution):
     pymc_dist = pm.MvNormal
-    pymc_dist_params = {"mu": np.array([1.0, 2.0]), "cov": np.array([[2.0, 0.0], [0.0, 3.5]])}
-    expected_rv_op_params = {"mu": np.array([1.0, 2.0]), "cov": np.array([[2.0, 0.0], [0.0, 3.5]])}
+    pymc_dist_params = {
+        "mu": np.array([1.0, 2.0]),
+        "cov": np.array([[2.0, 0.0], [0.0, 3.5]]),
+    }
+    expected_rv_op_params = {
+        "mu": np.array([1.0, 2.0]),
+        "cov": np.array([[2.0, 0.0], [0.0, 3.5]]),
+    }
     sizes_to_check = [None, (1), (2, 3)]
     sizes_expected = [(2,), (1, 2), (2, 3, 2)]
     reference_dist_params = {
@@ -1001,7 +1076,10 @@ class TestMvNormalCov(BaseTestDistribution):
 
 class TestMvNormalChol(BaseTestDistribution):
     pymc_dist = pm.MvNormal
-    pymc_dist_params = {"mu": np.array([1.0, 2.0]), "chol": np.array([[2.0, 0.0], [0.0, 3.5]])}
+    pymc_dist_params = {
+        "mu": np.array([1.0, 2.0]),
+        "chol": np.array([[2.0, 0.0], [0.0, 3.5]]),
+    }
     expected_rv_op_params = {
         "mu": np.array([1.0, 2.0]),
         "cov": quaddist_matrix(chol=pymc_dist_params["chol"]).eval(),
@@ -1011,7 +1089,10 @@ class TestMvNormalChol(BaseTestDistribution):
 
 class TestMvNormalTau(BaseTestDistribution):
     pymc_dist = pm.MvNormal
-    pymc_dist_params = {"mu": np.array([1.0, 2.0]), "tau": np.array([[2.0, 0.0], [0.0, 3.5]])}
+    pymc_dist_params = {
+        "mu": np.array([1.0, 2.0]),
+        "tau": np.array([[2.0, 0.0], [0.0, 3.5]]),
+    }
     expected_rv_op_params = {
         "mu": np.array([1.0, 2.0]),
         "cov": quaddist_matrix(tau=pymc_dist_params["tau"]).eval(),
@@ -1122,7 +1203,11 @@ class TestDirichletMultinomial(BaseTestDistribution):
     sizes_to_check = [None, 1, (4,), (3, 4)]
     sizes_expected = [(4,), (1, 4), (4, 4), (3, 4, 4)]
 
-    tests_to_run = ["check_pymc_params_match_rv_op", "test_random_draws", "check_rv_size"]
+    tests_to_run = [
+        "check_pymc_params_match_rv_op",
+        "test_random_draws",
+        "check_rv_size",
+    ]
 
     def test_random_draws(self):
         draws = pm.DirichletMultinomial.dist(
@@ -1228,7 +1313,9 @@ class TestWeibull(BaseTestDistribution):
         std_weibull_rng_fct = functools.partial(
             getattr(np.random.RandomState, "weibull"), self.get_random_state()
         )
-        return functools.partial(self.weibull_rng_fn, std_weibull_rng_fct=std_weibull_rng_fct)
+        return functools.partial(
+            self.weibull_rng_fn, std_weibull_rng_fct=std_weibull_rng_fct
+        )
 
     pymc_dist = pm.Weibull
     pymc_dist_params = {"alpha": 1.0, "beta": 2.0}
@@ -1256,7 +1343,8 @@ class TestBetaBinomial(BaseTestDistribution):
 
 
 @pytest.mark.skipif(
-    condition=_polyagamma_not_installed, reason="`polyagamma package is not available/installed."
+    condition=_polyagamma_not_installed,
+    reason="`polyagamma package is not available/installed.",
 )
 class TestPolyaGamma(BaseTestDistribution):
     def polyagamma_rng_fn(self, size, h, z, rng):
@@ -1313,7 +1401,9 @@ class TestConstant(BaseTestDistribution):
 
 
 class TestZeroInflatedPoisson(BaseTestDistribution):
-    def zero_inflated_poisson_rng_fn(self, size, psi, theta, poisson_rng_fct, random_rng_fct):
+    def zero_inflated_poisson_rng_fn(
+        self, size, psi, theta, poisson_rng_fct, random_rng_fct
+    ):
         return poisson_rng_fct(theta, size=size) * (random_rng_fct(size=size) < psi)
 
     def seeded_zero_inflated_poisson_rng_fn(self):
@@ -1344,7 +1434,9 @@ class TestZeroInflatedPoisson(BaseTestDistribution):
 
 
 class TestZeroInflatedBinomial(BaseTestDistribution):
-    def zero_inflated_binomial_rng_fn(self, size, psi, n, p, binomial_rng_fct, random_rng_fct):
+    def zero_inflated_binomial_rng_fn(
+        self, size, psi, n, p, binomial_rng_fct, random_rng_fct
+    ):
         return binomial_rng_fct(n, p, size=size) * (random_rng_fct(size=size) < psi)
 
     def seeded_zero_inflated_binomial_rng_fn(self):
@@ -1412,14 +1504,18 @@ class TestZeroInflatedNegativeBinomial(BaseTestDistribution):
 class TestOrderedLogistic(BaseTestDistribution):
     pymc_dist = _OrderedLogistic
     pymc_dist_params = {"eta": 0, "cutpoints": np.array([-2, 0, 2])}
-    expected_rv_op_params = {"p": np.array([0.11920292, 0.38079708, 0.38079708, 0.11920292])}
+    expected_rv_op_params = {
+        "p": np.array([0.11920292, 0.38079708, 0.38079708, 0.11920292])
+    }
     tests_to_run = ["check_pymc_params_match_rv_op", "check_rv_size"]
 
 
 class TestOrderedProbit(BaseTestDistribution):
     pymc_dist = _OrderedProbit
     pymc_dist_params = {"eta": 0, "cutpoints": np.array([-2, 0, 2])}
-    expected_rv_op_params = {"p": np.array([0.02275013, 0.47724987, 0.47724987, 0.02275013])}
+    expected_rv_op_params = {
+        "p": np.array([0.02275013, 0.47724987, 0.47724987, 0.02275013])
+    }
     tests_to_run = ["check_pymc_params_match_rv_op", "check_rv_size"]
 
 
@@ -1469,7 +1565,11 @@ class TestMatrixNormal(BaseTestDistribution):
     pymc_dist_params = {"mu": mu, "rowcov": row_cov, "colcov": col_cov}
     expected_rv_op_params = {"mu": mu, "rowcov": row_cov, "colcov": col_cov}
 
-    tests_to_run = ["check_pymc_params_match_rv_op", "test_matrix_normal", "test_errors"]
+    tests_to_run = [
+        "check_pymc_params_match_rv_op",
+        "test_matrix_normal",
+        "test_errors",
+    ]
 
     def test_matrix_normal(self):
         delta = 0.05  # limit for KS p-value
@@ -1480,11 +1580,16 @@ class TestMatrixNormal(BaseTestDistribution):
 
         with pm.Model(rng_seeder=1):
             matrixnormal = pm.MatrixNormal(
-                "matnormal", mu=np.random.random((3, 3)), rowcov=np.eye(3), colcov=np.eye(3)
+                "matnormal",
+                mu=np.random.random((3, 3)),
+                rowcov=np.eye(3),
+                colcov=np.eye(3),
             )
             check = pm.sample_prior_predictive(n_fails, return_inferencedata=False)
 
-        ref_smp = ref_rand(mu=np.random.random((3, 3)), rowcov=np.eye(3), colcov=np.eye(3))
+        ref_smp = ref_rand(
+            mu=np.random.random((3, 3)), rowcov=np.eye(3), colcov=np.eye(3)
+        )
 
         p, f = delta, n_fails
         while p <= delta and f > 0:
@@ -1493,7 +1598,8 @@ class TestMatrixNormal(BaseTestDistribution):
             p = np.min(
                 [
                     st.ks_2samp(
-                        np.atleast_1d(matrixnormal_smp).flatten(), np.atleast_1d(ref_smp).flatten()
+                        np.atleast_1d(matrixnormal_smp).flatten(),
+                        np.atleast_1d(ref_smp).flatten(),
                     )
                 ]
             )
@@ -1516,7 +1622,10 @@ class TestMatrixNormal(BaseTestDistribution):
         msg = "Value must be two dimensional."
         with pm.Model():
             matrixnormal = pm.MatrixNormal(
-                "matnormal", mu=np.random.random((3, 3)), rowcov=np.eye(3), colcov=np.eye(3)
+                "matnormal",
+                mu=np.random.random((3, 3)),
+                rowcov=np.eye(3),
+                colcov=np.eye(3),
             )
             with pytest.raises(ValueError, match=msg):
                 rvs_to_values = {matrixnormal: aesara.tensor.ones((3, 3, 3))}
@@ -1572,7 +1681,9 @@ class TestInterpolated(BaseTestDistribution):
                     def dist(cls, **kwargs):
                         x_points = np.linspace(mu - 5 * sigma, mu + 5 * sigma, 100)
                         pdf_points = st.norm.pdf(x_points, loc=mu, scale=sigma)
-                        return super().dist(x_points=x_points, pdf_points=pdf_points, **kwargs)
+                        return super().dist(
+                            x_points=x_points, pdf_points=pdf_points, **kwargs
+                        )
 
                 pymc_random(
                     TestedInterpolated,
@@ -1738,7 +1849,9 @@ class TestDensityDist:
             obs = pm.DensityDist(
                 "density_dist",
                 mu,
-                random=lambda mu, rng=None, size=None: rng.normal(loc=mu, scale=1, size=size),
+                random=lambda mu, rng=None, size=None: rng.normal(
+                    loc=mu, scale=1, size=size
+                ),
                 observed=np.random.randn(100, *size),
                 size=size,
             )
@@ -1758,7 +1871,9 @@ class TestDensityDist:
 
         samples = 500
         with pytest.raises(NotImplementedError):
-            pm.sample_posterior_predictive(idata, samples=samples, model=model, size=100)
+            pm.sample_posterior_predictive(
+                idata, samples=samples, model=model, size=100
+            )
 
     @pytest.mark.parametrize("size", [(), (3,), (3, 2)], ids=str)
     def test_density_dist_with_random_multivariate(self, size):
@@ -1791,7 +1906,9 @@ class TestNestedRandom(SeededTest):
                 except ValueError:
                     value, nested_shape, loc = info
                 if value is None:
-                    nested_rvs[rv_name] = pm.Uniform(rv_name, 0 + loc, 1 + loc, shape=nested_shape)
+                    nested_rvs[rv_name] = pm.Uniform(
+                        rv_name, 0 + loc, 1 + loc, shape=nested_shape
+                    )
                 else:
                     nested_rvs[rv_name] = value * np.ones(nested_shape)
             rv = distribution("target", shape=shape, **nested_rvs)
@@ -1866,18 +1983,88 @@ class TestNestedRandom(SeededTest):
     @pytest.mark.parametrize(
         ["prior_samples", "shape", "mu", "sigma", "lower", "upper"],
         [
-            [10, (3,), (None, tuple()), (1.0, tuple()), (None, tuple(), -1), (None, (3,))],
-            [10, (3,), (None, tuple()), (1.0, tuple()), (None, tuple(), -1), (None, (3,))],
-            [10, (3,), (None, tuple()), (1.0, tuple()), (None, (3,), -1), (None, tuple())],
-            [10, (3,), (None, tuple()), (1.0, tuple()), (None, (3,), -1), (None, tuple())],
+            [
+                10,
+                (3,),
+                (None, tuple()),
+                (1.0, tuple()),
+                (None, tuple(), -1),
+                (None, (3,)),
+            ],
+            [
+                10,
+                (3,),
+                (None, tuple()),
+                (1.0, tuple()),
+                (None, tuple(), -1),
+                (None, (3,)),
+            ],
+            [
+                10,
+                (3,),
+                (None, tuple()),
+                (1.0, tuple()),
+                (None, (3,), -1),
+                (None, tuple()),
+            ],
+            [
+                10,
+                (3,),
+                (None, tuple()),
+                (1.0, tuple()),
+                (None, (3,), -1),
+                (None, tuple()),
+            ],
             [10, (4, 3), (None, (3,)), (1.0, tuple()), (None, (3,), -1), (None, (3,))],
-            [10, (4, 3), (None, (3,)), (1.0, tuple()), (None, (3,), -1), (None, (4, 3))],
-            [10, (3,), (0.0, tuple()), (None, tuple()), (None, tuple(), -1), (None, (3,))],
-            [10, (3,), (0.0, tuple()), (None, tuple()), (None, tuple(), -1), (None, (3,))],
-            [10, (3,), (0.0, tuple()), (None, tuple()), (None, (3,), -1), (None, tuple())],
-            [10, (3,), (0.0, tuple()), (None, tuple()), (None, (3,), -1), (None, tuple())],
+            [
+                10,
+                (4, 3),
+                (None, (3,)),
+                (1.0, tuple()),
+                (None, (3,), -1),
+                (None, (4, 3)),
+            ],
+            [
+                10,
+                (3,),
+                (0.0, tuple()),
+                (None, tuple()),
+                (None, tuple(), -1),
+                (None, (3,)),
+            ],
+            [
+                10,
+                (3,),
+                (0.0, tuple()),
+                (None, tuple()),
+                (None, tuple(), -1),
+                (None, (3,)),
+            ],
+            [
+                10,
+                (3,),
+                (0.0, tuple()),
+                (None, tuple()),
+                (None, (3,), -1),
+                (None, tuple()),
+            ],
+            [
+                10,
+                (3,),
+                (0.0, tuple()),
+                (None, tuple()),
+                (None, (3,), -1),
+                (None, tuple()),
+            ],
             [10, (4, 3), (0.0, tuple()), (None, (3,)), (None, (3,), -1), (None, (3,))],
-            [10, (4, 3), (0.0, tuple()), (None, (3,)), (None, (3,), -1), (None, (4, 3))],
+            [
+                10,
+                (4, 3),
+                (0.0, tuple()),
+                (None, (3,)),
+                (None, (3,), -1),
+                (None, (4, 3)),
+            ],
         ],
         ids=str,
     )
@@ -1929,7 +2116,9 @@ def generate_shapes(include_params=False):
     if not include_params:
         del mudim_as_event[-1]
         del mudim_as_dist[-1]
-    data = itertools.chain(itertools.product(*mudim_as_event), itertools.product(*mudim_as_dist))
+    data = itertools.chain(
+        itertools.product(*mudim_as_event), itertools.product(*mudim_as_dist)
+    )
     return data
 
 
@@ -1941,12 +2130,16 @@ class TestMvNormal(SeededTest):
         ids=str,
     )
     def test_with_np_arrays(self, sample_shape, dist_shape, mu_shape, param):
-        dist = pm.MvNormal.dist(mu=np.ones(mu_shape), **{param: np.eye(3)}, shape=dist_shape)
+        dist = pm.MvNormal.dist(
+            mu=np.ones(mu_shape), **{param: np.eye(3)}, shape=dist_shape
+        )
         output_shape = to_tuple(sample_shape) + dist_shape
         assert dist.random(size=sample_shape).shape == output_shape
 
     @pytest.mark.parametrize(
-        ["sample_shape", "dist_shape", "mu_shape"], generate_shapes(include_params=False), ids=str
+        ["sample_shape", "dist_shape", "mu_shape"],
+        generate_shapes(include_params=False),
+        ids=str,
     )
     def test_with_chol_rv(self, sample_shape, dist_shape, mu_shape):
         with pm.Model() as model:
@@ -1961,7 +2154,9 @@ class TestMvNormal(SeededTest):
         assert prior["mv"].shape == to_tuple(sample_shape) + dist_shape
 
     @pytest.mark.parametrize(
-        ["sample_shape", "dist_shape", "mu_shape"], generate_shapes(include_params=False), ids=str
+        ["sample_shape", "dist_shape", "mu_shape"],
+        generate_shapes(include_params=False),
+        ids=str,
     )
     def test_with_cov_rv(self, sample_shape, dist_shape, mu_shape):
         with pm.Model() as model:
@@ -1981,7 +2176,9 @@ class TestMvNormal(SeededTest):
         with pm.Model() as model:
             a = pm.Normal("a", sigma=100, shape=ndim)
             b = pm.Normal("b", mu=a, sigma=1, shape=ndim)
-            c = pm.MvNormal("c", mu=a, chol=np.linalg.cholesky(np.eye(ndim)), shape=ndim)
+            c = pm.MvNormal(
+                "c", mu=a, chol=np.linalg.cholesky(np.eye(ndim)), shape=ndim
+            )
             d = pm.MvNormal("d", mu=a, cov=np.eye(ndim), shape=ndim)
             samples = pm.sample_prior_predictive(1000)
 
@@ -2053,7 +2250,9 @@ class TestMvGaussianRandomWalk(SeededTest):
 
     @pytest.mark.xfail
     @pytest.mark.parametrize(
-        ["sample_shape", "dist_shape", "mu_shape"], generate_shapes(include_params=False), ids=str
+        ["sample_shape", "dist_shape", "mu_shape"],
+        generate_shapes(include_params=False),
+        ids=str,
     )
     def test_with_chol_rv(self, sample_shape, dist_shape, mu_shape):
         with pm.Model() as model:
@@ -2069,7 +2268,9 @@ class TestMvGaussianRandomWalk(SeededTest):
 
     @pytest.mark.xfail
     @pytest.mark.parametrize(
-        ["sample_shape", "dist_shape", "mu_shape"], generate_shapes(include_params=False), ids=str
+        ["sample_shape", "dist_shape", "mu_shape"],
+        generate_shapes(include_params=False),
+        ids=str,
     )
     def test_with_cov_rv(self, sample_shape, dist_shape, mu_shape):
         with pm.Model() as model:
@@ -2078,7 +2279,9 @@ class TestMvGaussianRandomWalk(SeededTest):
             chol, corr, stds = pm.LKJCholeskyCov(
                 "chol_cov", n=3, eta=2, sd_dist=sd_dist, compute_corr=True
             )
-            mv = pm.MvGaussianRandomWalk("mv", mu, cov=pm.math.dot(chol, chol.T), shape=dist_shape)
+            mv = pm.MvGaussianRandomWalk(
+                "mv", mu, cov=pm.math.dot(chol, chol.T), shape=dist_shape
+            )
             prior = pm.sample_prior_predictive(samples=sample_shape)
 
         assert prior["mv"].shape == to_tuple(sample_shape) + dist_shape
@@ -2091,7 +2294,12 @@ def test_car_rng_fn(sparse):
     size = (100,)
 
     W = np.array(
-        [[0.0, 1.0, 1.0, 0.0], [1.0, 0.0, 0.0, 1.0], [1.0, 0.0, 0.0, 1.0], [0.0, 1.0, 1.0, 0.0]]
+        [
+            [0.0, 1.0, 1.0, 0.0],
+            [1.0, 0.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0, 1.0],
+            [0.0, 1.0, 1.0, 0.0],
+        ]
     )
 
     tau = 2

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -102,13 +102,7 @@ def pymc_random(
 
 
 def pymc_random_discrete(
-    dist,
-    paramdomains,
-    valuedomain=Domain([0]),
-    ref_rand=None,
-    size=100000,
-    alpha=0.05,
-    fails=20,
+    dist, paramdomains, valuedomain=Domain([0]), ref_rand=None, size=100000, alpha=0.05, fails=20
 ):
     model, param_vars = build_model(dist, valuedomain, paramdomains)
     model_dist = change_rv_size(model.named_vars["value"], size, expand=True)
@@ -416,11 +410,7 @@ class TestFlat(BaseTestDistribution):
     pymc_dist = pm.Flat
     pymc_dist_params = {}
     expected_rv_op_params = {}
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-        "check_rv_size",
-        "check_not_implemented",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_rv_size", "check_not_implemented"]
 
     def check_not_implemented(self):
         with pytest.raises(NotImplementedError):
@@ -431,11 +421,7 @@ class TestHalfFlat(BaseTestDistribution):
     pymc_dist = pm.HalfFlat
     pymc_dist_params = {}
     expected_rv_op_params = {}
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-        "check_rv_size",
-        "check_not_implemented",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_rv_size", "check_not_implemented"]
 
     def check_not_implemented(self):
         with pytest.raises(NotImplementedError):
@@ -554,10 +540,7 @@ class TestGumbel(BaseTestDistribution):
     expected_rv_op_params = {"mu": 1.5, "beta": 3.0}
     reference_dist_params = {"loc": 1.5, "scale": 3.0}
     reference_dist = seeded_scipy_distribution_builder("gumbel_r")
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-        "check_pymc_draws_match_reference",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_pymc_draws_match_reference"]
 
 
 class TestStudentT(BaseTestDistribution):
@@ -633,9 +616,7 @@ class TestTruncatedNormalTau(BaseTestDistribution):
     tau, sigma = get_tau_sigma(tau=tau, sigma=None)
     pymc_dist_params = {"mu": mu, "tau": tau, "lower": lower, "upper": upper}
     expected_rv_op_params = {"mu": mu, "sigma": sigma, "lower": lower, "upper": upper}
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
 class TestTruncatedNormalLowerTau(BaseTestDistribution):
@@ -644,9 +625,7 @@ class TestTruncatedNormalLowerTau(BaseTestDistribution):
     tau, sigma = get_tau_sigma(tau=tau, sigma=None)
     pymc_dist_params = {"mu": mu, "tau": tau, "lower": lower}
     expected_rv_op_params = {"mu": mu, "sigma": sigma, "lower": lower, "upper": upper}
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
 class TestTruncatedNormalUpperTau(BaseTestDistribution):
@@ -655,9 +634,7 @@ class TestTruncatedNormalUpperTau(BaseTestDistribution):
     tau, sigma = get_tau_sigma(tau=tau, sigma=None)
     pymc_dist_params = {"mu": mu, "tau": tau, "upper": upper}
     expected_rv_op_params = {"mu": mu, "sigma": sigma, "lower": lower, "upper": upper}
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
 class TestTruncatedNormalUpperArray(BaseTestDistribution):
@@ -666,20 +643,13 @@ class TestTruncatedNormalUpperArray(BaseTestDistribution):
         np.array([-np.inf, -np.inf]),
         np.array([3, 2]),
         np.array([0, 0]),
-        np.array(
-            [
-                1,
-                1,
-            ]
-        ),
+        np.array([1, 1]),
     )
     size = (15, 2)
     tau, sigma = get_tau_sigma(tau=tau, sigma=None)
     pymc_dist_params = {"mu": mu, "tau": tau, "upper": upper}
     expected_rv_op_params = {"mu": mu, "sigma": sigma, "lower": lower, "upper": upper}
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
 class TestWald(BaseTestDistribution):
@@ -718,9 +688,7 @@ class TestWaldMuPhi(BaseTestDistribution):
     mu_rv, lam_rv, phi_rv = pm.Wald.get_mu_lam_phi(mu=mu, lam=None, phi=phi)
     pymc_dist_params = {"mu": mu, "phi": phi, "alpha": alpha}
     expected_rv_op_params = {"mu": mu_rv, "lam": lam_rv, "alpha": alpha}
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op"]
 
 
 class TestSkewNormal(BaseTestDistribution):
@@ -844,10 +812,7 @@ class TestHalfNormal(BaseTestDistribution):
     expected_rv_op_params = {"mean": 0, "sigma": 10.0}
     reference_dist_params = {"loc": 0, "scale": 10.0}
     reference_dist = seeded_scipy_distribution_builder("halfnorm")
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-        "check_pymc_draws_match_reference",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_pymc_draws_match_reference"]
 
 
 class TestHalfNormalTau(BaseTestDistribution):
@@ -897,10 +862,7 @@ class TestExponential(BaseTestDistribution):
     expected_rv_op_params = {"mu": 1.0 / pymc_dist_params["lam"]}
     reference_dist_params = {"scale": 1.0 / pymc_dist_params["lam"]}
     reference_dist = seeded_numpy_distribution_builder("exponential")
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-        "check_pymc_draws_match_reference",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_pymc_draws_match_reference"]
 
 
 class TestCauchy(BaseTestDistribution):
@@ -909,10 +871,7 @@ class TestCauchy(BaseTestDistribution):
     expected_rv_op_params = {"alpha": 2.0, "beta": 5.0}
     reference_dist_params = {"loc": 2.0, "scale": 5.0}
     reference_dist = seeded_scipy_distribution_builder("cauchy")
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-        "check_pymc_draws_match_reference",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_pymc_draws_match_reference"]
 
 
 class TestHalfCauchy(BaseTestDistribution):
@@ -921,10 +880,7 @@ class TestHalfCauchy(BaseTestDistribution):
     expected_rv_op_params = {"alpha": 0.0, "beta": 5.0}
     reference_dist_params = {"loc": 0.0, "scale": 5.0}
     reference_dist = seeded_scipy_distribution_builder("halfcauchy")
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-        "check_pymc_draws_match_reference",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_pymc_draws_match_reference"]
 
 
 class TestGamma(BaseTestDistribution):
@@ -933,10 +889,7 @@ class TestGamma(BaseTestDistribution):
     expected_rv_op_params = {"alpha": 2.0, "beta": 1 / 5.0}
     reference_dist_params = {"shape": 2.0, "scale": 1 / 5.0}
     reference_dist = seeded_numpy_distribution_builder("gamma")
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-        "check_pymc_draws_match_reference",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_pymc_draws_match_reference"]
 
 
 class TestGammaMuSigma(BaseTestDistribution):
@@ -955,20 +908,14 @@ class TestInverseGamma(BaseTestDistribution):
     expected_rv_op_params = {"alpha": 2.0, "beta": 5.0}
     reference_dist_params = {"a": 2.0, "scale": 5.0}
     reference_dist = seeded_scipy_distribution_builder("invgamma")
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-        "check_pymc_draws_match_reference",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_pymc_draws_match_reference"]
 
 
 class TestInverseGammaMuSigma(BaseTestDistribution):
     pymc_dist = pm.InverseGamma
     pymc_dist_params = {"mu": 0.5, "sigma": 0.25}
     expected_alpha, expected_beta = pm.InverseGamma._get_alpha_beta(
-        alpha=None,
-        beta=None,
-        mu=pymc_dist_params["mu"],
-        sigma=pymc_dist_params["sigma"],
+        alpha=None, beta=None, mu=pymc_dist_params["mu"], sigma=pymc_dist_params["sigma"]
     )
     expected_rv_op_params = {"alpha": expected_alpha, "beta": expected_beta}
     tests_to_run = ["check_pymc_params_match_rv_op"]
@@ -1005,10 +952,7 @@ class TestNegativeBinomialMuSigma(BaseTestDistribution):
     pymc_dist = pm.NegativeBinomial
     pymc_dist_params = {"mu": 5.0, "alpha": 8.0}
     expected_n, expected_p = pm.NegativeBinomial.get_n_p(
-        mu=pymc_dist_params["mu"],
-        alpha=pymc_dist_params["alpha"],
-        n=None,
-        p=None,
+        mu=pymc_dist_params["mu"], alpha=pymc_dist_params["alpha"], n=None, p=None
     )
     expected_rv_op_params = {"n": expected_n, "p": expected_p}
     tests_to_run = ["check_pymc_params_match_rv_op"]
@@ -1020,10 +964,7 @@ class TestBernoulli(BaseTestDistribution):
     expected_rv_op_params = {"p": 0.33}
     reference_dist_params = {"p": 0.33}
     reference_dist = seeded_scipy_distribution_builder("bernoulli")
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-        "check_pymc_draws_match_reference",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_pymc_draws_match_reference"]
 
 
 class TestBernoulliLogitP(BaseTestDistribution):
@@ -1042,14 +983,8 @@ class TestPoisson(BaseTestDistribution):
 
 class TestMvNormalCov(BaseTestDistribution):
     pymc_dist = pm.MvNormal
-    pymc_dist_params = {
-        "mu": np.array([1.0, 2.0]),
-        "cov": np.array([[2.0, 0.0], [0.0, 3.5]]),
-    }
-    expected_rv_op_params = {
-        "mu": np.array([1.0, 2.0]),
-        "cov": np.array([[2.0, 0.0], [0.0, 3.5]]),
-    }
+    pymc_dist_params = {"mu": np.array([1.0, 2.0]), "cov": np.array([[2.0, 0.0], [0.0, 3.5]])}
+    expected_rv_op_params = {"mu": np.array([1.0, 2.0]), "cov": np.array([[2.0, 0.0], [0.0, 3.5]])}
     sizes_to_check = [None, (1), (2, 3)]
     sizes_expected = [(2,), (1, 2), (2, 3, 2)]
     reference_dist_params = {
@@ -1066,10 +1001,7 @@ class TestMvNormalCov(BaseTestDistribution):
 
 class TestMvNormalChol(BaseTestDistribution):
     pymc_dist = pm.MvNormal
-    pymc_dist_params = {
-        "mu": np.array([1.0, 2.0]),
-        "chol": np.array([[2.0, 0.0], [0.0, 3.5]]),
-    }
+    pymc_dist_params = {"mu": np.array([1.0, 2.0]), "chol": np.array([[2.0, 0.0], [0.0, 3.5]])}
     expected_rv_op_params = {
         "mu": np.array([1.0, 2.0]),
         "cov": quaddist_matrix(chol=pymc_dist_params["chol"]).eval(),
@@ -1079,10 +1011,7 @@ class TestMvNormalChol(BaseTestDistribution):
 
 class TestMvNormalTau(BaseTestDistribution):
     pymc_dist = pm.MvNormal
-    pymc_dist_params = {
-        "mu": np.array([1.0, 2.0]),
-        "tau": np.array([[2.0, 0.0], [0.0, 3.5]]),
-    }
+    pymc_dist_params = {"mu": np.array([1.0, 2.0]), "tau": np.array([[2.0, 0.0], [0.0, 3.5]])}
     expected_rv_op_params = {
         "mu": np.array([1.0, 2.0]),
         "cov": quaddist_matrix(tau=pymc_dist_params["tau"]).eval(),
@@ -1193,11 +1122,7 @@ class TestDirichletMultinomial(BaseTestDistribution):
     sizes_to_check = [None, 1, (4,), (3, 4)]
     sizes_expected = [(4,), (1, 4), (4, 4), (3, 4, 4)]
 
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-        "test_random_draws",
-        "check_rv_size",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op", "test_random_draws", "check_rv_size"]
 
     def test_random_draws(self):
         draws = pm.DirichletMultinomial.dist(
@@ -1227,10 +1152,7 @@ class TestCategorical(BaseTestDistribution):
     pymc_dist = pm.Categorical
     pymc_dist_params = {"p": np.array([0.28, 0.62, 0.10])}
     expected_rv_op_params = {"p": np.array([0.28, 0.62, 0.10])}
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-        "check_rv_size",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_rv_size"]
 
 
 class TestGeometric(BaseTestDistribution):
@@ -1250,10 +1172,7 @@ class TestHyperGeometric(BaseTestDistribution):
     }
     reference_dist_params = expected_rv_op_params
     reference_dist = seeded_numpy_distribution_builder("hypergeometric")
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-        "check_pymc_draws_match_reference",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_pymc_draws_match_reference"]
 
 
 class TestLogistic(BaseTestDistribution):
@@ -1291,10 +1210,7 @@ class TestTriangular(BaseTestDistribution):
     expected_rv_op_params = {"lower": 0, "c": 0.5, "upper": 1}
     reference_dist_params = {"left": 0, "mode": 0.5, "right": 1}
     reference_dist = seeded_numpy_distribution_builder("triangular")
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-        "check_pymc_draws_match_reference",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_pymc_draws_match_reference"]
 
 
 class TestVonMises(BaseTestDistribution):
@@ -1340,8 +1256,7 @@ class TestBetaBinomial(BaseTestDistribution):
 
 
 @pytest.mark.skipif(
-    condition=_polyagamma_not_installed,
-    reason="`polyagamma package is not available/installed.",
+    condition=_polyagamma_not_installed, reason="`polyagamma package is not available/installed."
 )
 class TestPolyaGamma(BaseTestDistribution):
     def polyagamma_rng_fn(self, size, h, z, rng):
@@ -1498,20 +1413,14 @@ class TestOrderedLogistic(BaseTestDistribution):
     pymc_dist = _OrderedLogistic
     pymc_dist_params = {"eta": 0, "cutpoints": np.array([-2, 0, 2])}
     expected_rv_op_params = {"p": np.array([0.11920292, 0.38079708, 0.38079708, 0.11920292])}
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-        "check_rv_size",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_rv_size"]
 
 
 class TestOrderedProbit(BaseTestDistribution):
     pymc_dist = _OrderedProbit
     pymc_dist_params = {"eta": 0, "cutpoints": np.array([-2, 0, 2])}
     expected_rv_op_params = {"p": np.array([0.02275013, 0.47724987, 0.47724987, 0.02275013])}
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-        "check_rv_size",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_rv_size"]
 
 
 class TestOrderedMultinomial(BaseTestDistribution):
@@ -1523,10 +1432,7 @@ class TestOrderedMultinomial(BaseTestDistribution):
         "n": 1000,
         "p": np.array([0.11920292, 0.38079708, 0.38079708, 0.11920292]),
     }
-    tests_to_run = [
-        "check_pymc_params_match_rv_op",
-        "check_rv_size",
-    ]
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_rv_size"]
 
 
 class TestWishart(BaseTestDistribution):
@@ -1540,11 +1446,7 @@ class TestWishart(BaseTestDistribution):
     reference_dist_params = {"nu": 4, "V": V}
     expected_rv_op_params = {"nu": 4, "V": V}
     sizes_to_check = [None, 1, (4, 5)]
-    sizes_expected = [
-        (3, 3),
-        (1, 3, 3),
-        (4, 5, 3, 3),
-    ]
+    sizes_expected = [(3, 3), (1, 3, 3), (4, 5, 3, 3)]
     reference_dist = lambda self: functools.partial(
         self.wishart_rng_fn, rng=self.get_random_state()
     )
@@ -1578,12 +1480,9 @@ class TestMatrixNormal(BaseTestDistribution):
 
         with pm.Model(rng_seeder=1):
             matrixnormal = pm.MatrixNormal(
-                "matnormal",
-                mu=np.random.random((3, 3)),
-                rowcov=np.eye(3),
-                colcov=np.eye(3),
+                "matnormal", mu=np.random.random((3, 3)), rowcov=np.eye(3), colcov=np.eye(3)
             )
-            check = pm.sample_prior_predictive(n_fails)
+            check = pm.sample_prior_predictive(n_fails, return_inferencedata=False)
 
         ref_smp = ref_rand(mu=np.random.random((3, 3)), rowcov=np.eye(3), colcov=np.eye(3))
 
@@ -1594,8 +1493,7 @@ class TestMatrixNormal(BaseTestDistribution):
             p = np.min(
                 [
                     st.ks_2samp(
-                        np.atleast_1d(matrixnormal_smp).flatten(),
-                        np.atleast_1d(ref_smp).flatten(),
+                        np.atleast_1d(matrixnormal_smp).flatten(), np.atleast_1d(ref_smp).flatten()
                     )
                 ]
             )
@@ -1618,10 +1516,7 @@ class TestMatrixNormal(BaseTestDistribution):
         msg = "Value must be two dimensional."
         with pm.Model():
             matrixnormal = pm.MatrixNormal(
-                "matnormal",
-                mu=np.random.random((3, 3)),
-                rowcov=np.eye(3),
-                colcov=np.eye(3),
+                "matnormal", mu=np.random.random((3, 3)), rowcov=np.eye(3), colcov=np.eye(3)
             )
             with pytest.raises(ValueError, match=msg):
                 rvs_to_values = {matrixnormal: aesara.tensor.ones((3, 3, 3))}
@@ -1710,10 +1605,7 @@ class TestKroneckerNormal(BaseTestDistribution):
     reference_dist = lambda self: functools.partial(
         self.kronecker_rng_fn, rng=self.get_random_state()
     )
-    tests_to_run = [
-        "check_pymc_draws_match_reference",
-        "check_rv_size",
-    ]
+    tests_to_run = ["check_pymc_draws_match_reference", "check_rv_size"]
 
 
 class TestScalarParameterSamples(SeededTest):
@@ -1899,63 +1791,28 @@ class TestNestedRandom(SeededTest):
                 except ValueError:
                     value, nested_shape, loc = info
                 if value is None:
-                    nested_rvs[rv_name] = pm.Uniform(
-                        rv_name,
-                        0 + loc,
-                        1 + loc,
-                        shape=nested_shape,
-                    )
+                    nested_rvs[rv_name] = pm.Uniform(rv_name, 0 + loc, 1 + loc, shape=nested_shape)
                 else:
                     nested_rvs[rv_name] = value * np.ones(nested_shape)
-            rv = distribution(
-                "target",
-                shape=shape,
-                **nested_rvs,
-            )
+            rv = distribution("target", shape=shape, **nested_rvs)
         return model, rv, nested_rvs
 
     def sample_prior(self, distribution, shape, nested_rvs_info, prior_samples):
-        model, rv, nested_rvs = self.build_model(
-            distribution,
-            shape,
-            nested_rvs_info,
-        )
+        model, rv, nested_rvs = self.build_model(distribution, shape, nested_rvs_info)
         with model:
-            return pm.sample_prior_predictive(prior_samples)
+            return pm.sample_prior_predictive(prior_samples, return_inferencedata=False)
 
     @pytest.mark.parametrize(
         ["prior_samples", "shape", "mu", "alpha"],
         [
             [10, (3,), (None, tuple()), (None, (3,))],
             [10, (3,), (None, (3,)), (None, tuple())],
-            [
-                10,
-                (
-                    4,
-                    3,
-                ),
-                (None, (3,)),
-                (None, (3,)),
-            ],
-            [
-                10,
-                (
-                    4,
-                    3,
-                ),
-                (None, (3,)),
-                (None, (4, 3)),
-            ],
+            [10, (4, 3), (None, (3,)), (None, (3,))],
+            [10, (4, 3), (None, (3,)), (None, (4, 3))],
         ],
         ids=str,
     )
-    def test_NegativeBinomial(
-        self,
-        prior_samples,
-        shape,
-        mu,
-        alpha,
-    ):
+    def test_NegativeBinomial(self, prior_samples, shape, mu, alpha):
         prior = self.sample_prior(
             distribution=pm.NegativeBinomial,
             shape=shape,
@@ -1971,37 +1828,12 @@ class TestNestedRandom(SeededTest):
             [10, (3,), (0.5, (3,)), (None, tuple()), (None, (3,))],
             [10, (3,), (0.5, tuple()), (None, (3,)), (None, tuple())],
             [10, (3,), (0.5, (3,)), (None, (3,)), (None, tuple())],
-            [
-                10,
-                (
-                    4,
-                    3,
-                ),
-                (0.5, (3,)),
-                (None, (3,)),
-                (None, (3,)),
-            ],
-            [
-                10,
-                (
-                    4,
-                    3,
-                ),
-                (0.5, (3,)),
-                (None, (3,)),
-                (None, (4, 3)),
-            ],
+            [10, (4, 3), (0.5, (3,)), (None, (3,)), (None, (3,))],
+            [10, (4, 3), (0.5, (3,)), (None, (3,)), (None, (4, 3))],
         ],
         ids=str,
     )
-    def test_ZeroInflatedNegativeBinomial(
-        self,
-        prior_samples,
-        shape,
-        psi,
-        mu,
-        alpha,
-    ):
+    def test_ZeroInflatedNegativeBinomial(self, prior_samples, shape, psi, mu, alpha):
         prior = self.sample_prior(
             distribution=pm.ZeroInflatedNegativeBinomial,
             shape=shape,
@@ -2017,34 +1849,12 @@ class TestNestedRandom(SeededTest):
             [10, (3,), (None, tuple()), (None, (3,))],
             [10, (3,), (None, (3,)), (None, tuple())],
             [10, (3,), (None, (3,)), (None, tuple())],
-            [
-                10,
-                (
-                    4,
-                    3,
-                ),
-                (None, (3,)),
-                (None, (3,)),
-            ],
-            [
-                10,
-                (
-                    4,
-                    3,
-                ),
-                (None, (3,)),
-                (None, (4, 3)),
-            ],
+            [10, (4, 3), (None, (3,)), (None, (3,))],
+            [10, (4, 3), (None, (3,)), (None, (4, 3))],
         ],
         ids=str,
     )
-    def test_Rice(
-        self,
-        prior_samples,
-        shape,
-        nu,
-        sigma,
-    ):
+    def test_Rice(self, prior_samples, shape, nu, sigma):
         prior = self.sample_prior(
             distribution=pm.Rice,
             shape=shape,
@@ -2060,66 +1870,18 @@ class TestNestedRandom(SeededTest):
             [10, (3,), (None, tuple()), (1.0, tuple()), (None, tuple(), -1), (None, (3,))],
             [10, (3,), (None, tuple()), (1.0, tuple()), (None, (3,), -1), (None, tuple())],
             [10, (3,), (None, tuple()), (1.0, tuple()), (None, (3,), -1), (None, tuple())],
-            [
-                10,
-                (
-                    4,
-                    3,
-                ),
-                (None, (3,)),
-                (1.0, tuple()),
-                (None, (3,), -1),
-                (None, (3,)),
-            ],
-            [
-                10,
-                (
-                    4,
-                    3,
-                ),
-                (None, (3,)),
-                (1.0, tuple()),
-                (None, (3,), -1),
-                (None, (4, 3)),
-            ],
+            [10, (4, 3), (None, (3,)), (1.0, tuple()), (None, (3,), -1), (None, (3,))],
+            [10, (4, 3), (None, (3,)), (1.0, tuple()), (None, (3,), -1), (None, (4, 3))],
             [10, (3,), (0.0, tuple()), (None, tuple()), (None, tuple(), -1), (None, (3,))],
             [10, (3,), (0.0, tuple()), (None, tuple()), (None, tuple(), -1), (None, (3,))],
             [10, (3,), (0.0, tuple()), (None, tuple()), (None, (3,), -1), (None, tuple())],
             [10, (3,), (0.0, tuple()), (None, tuple()), (None, (3,), -1), (None, tuple())],
-            [
-                10,
-                (
-                    4,
-                    3,
-                ),
-                (0.0, tuple()),
-                (None, (3,)),
-                (None, (3,), -1),
-                (None, (3,)),
-            ],
-            [
-                10,
-                (
-                    4,
-                    3,
-                ),
-                (0.0, tuple()),
-                (None, (3,)),
-                (None, (3,), -1),
-                (None, (4, 3)),
-            ],
+            [10, (4, 3), (0.0, tuple()), (None, (3,)), (None, (3,), -1), (None, (3,))],
+            [10, (4, 3), (0.0, tuple()), (None, (3,)), (None, (3,), -1), (None, (4, 3))],
         ],
         ids=str,
     )
-    def test_TruncatedNormal(
-        self,
-        prior_samples,
-        shape,
-        mu,
-        sigma,
-        lower,
-        upper,
-    ):
+    def test_TruncatedNormal(self, prior_samples, shape, mu, sigma, lower, upper):
         prior = self.sample_prior(
             distribution=pm.TruncatedNormal,
             shape=shape,
@@ -2134,37 +1896,12 @@ class TestNestedRandom(SeededTest):
             [10, (3,), (None, tuple()), (-1.0, (3,)), (2, tuple())],
             [10, (3,), (None, tuple()), (-1.0, tuple()), (None, tuple(), 1)],
             [10, (3,), (None, (3,)), (-1.0, tuple()), (None, tuple(), 1)],
-            [
-                10,
-                (
-                    4,
-                    3,
-                ),
-                (None, (3,)),
-                (-1.0, tuple()),
-                (None, (3,), 1),
-            ],
-            [
-                10,
-                (
-                    4,
-                    3,
-                ),
-                (None, (3,)),
-                (None, tuple(), -1),
-                (None, (3,), 1),
-            ],
+            [10, (4, 3), (None, (3,)), (-1.0, tuple()), (None, (3,), 1)],
+            [10, (4, 3), (None, (3,)), (None, tuple(), -1), (None, (3,), 1)],
         ],
         ids=str,
     )
-    def test_Triangular(
-        self,
-        prior_samples,
-        shape,
-        c,
-        lower,
-        upper,
-    ):
+    def test_Triangular(self, prior_samples, shape, c, lower, upper):
         prior = self.sample_prior(
             distribution=pm.Triangular,
             shape=shape,
@@ -2209,9 +1946,7 @@ class TestMvNormal(SeededTest):
         assert dist.random(size=sample_shape).shape == output_shape
 
     @pytest.mark.parametrize(
-        ["sample_shape", "dist_shape", "mu_shape"],
-        generate_shapes(include_params=False),
-        ids=str,
+        ["sample_shape", "dist_shape", "mu_shape"], generate_shapes(include_params=False), ids=str
     )
     def test_with_chol_rv(self, sample_shape, dist_shape, mu_shape):
         with pm.Model() as model:
@@ -2226,9 +1961,7 @@ class TestMvNormal(SeededTest):
         assert prior["mv"].shape == to_tuple(sample_shape) + dist_shape
 
     @pytest.mark.parametrize(
-        ["sample_shape", "dist_shape", "mu_shape"],
-        generate_shapes(include_params=False),
-        ids=str,
+        ["sample_shape", "dist_shape", "mu_shape"], generate_shapes(include_params=False), ids=str
     )
     def test_with_cov_rv(self, sample_shape, dist_shape, mu_shape):
         with pm.Model() as model:
@@ -2320,9 +2053,7 @@ class TestMvGaussianRandomWalk(SeededTest):
 
     @pytest.mark.xfail
     @pytest.mark.parametrize(
-        ["sample_shape", "dist_shape", "mu_shape"],
-        generate_shapes(include_params=False),
-        ids=str,
+        ["sample_shape", "dist_shape", "mu_shape"], generate_shapes(include_params=False), ids=str
     )
     def test_with_chol_rv(self, sample_shape, dist_shape, mu_shape):
         with pm.Model() as model:
@@ -2338,9 +2069,7 @@ class TestMvGaussianRandomWalk(SeededTest):
 
     @pytest.mark.xfail
     @pytest.mark.parametrize(
-        ["sample_shape", "dist_shape", "mu_shape"],
-        generate_shapes(include_params=False),
-        ids=str,
+        ["sample_shape", "dist_shape", "mu_shape"], generate_shapes(include_params=False), ids=str
     )
     def test_with_cov_rv(self, sample_shape, dist_shape, mu_shape):
         with pm.Model() as model:
@@ -2379,7 +2108,7 @@ def test_car_rng_fn(sparse):
     with pm.Model(rng_seeder=1):
         car = pm.CAR("car", mu, W, alpha, tau, size=size)
         mn = pm.MvNormal("mn", mu, cov, size=size)
-        check = pm.sample_prior_predictive(n_fails)
+        check = pm.sample_prior_predictive(n_fails, return_inferencedata=False)
 
     p, f = delta, n_fails
     while p <= delta and f > 0:

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -1583,7 +1583,7 @@ class TestMatrixNormal(BaseTestDistribution):
                 rowcov=np.eye(3),
                 colcov=np.eye(3),
             )
-            check = pm.sample_prior_predictive(n_fails)
+            check = pm.sample_prior_predictive(n_fails, return_inferencedata=False)
 
         ref_smp = ref_rand(mu=np.random.random((3, 3)), rowcov=np.eye(3), colcov=np.eye(3))
 
@@ -1921,7 +1921,7 @@ class TestNestedRandom(SeededTest):
             nested_rvs_info,
         )
         with model:
-            return pm.sample_prior_predictive(prior_samples)
+            return pm.sample_prior_predictive(prior_samples, return_inferencedata=False)
 
     @pytest.mark.parametrize(
         ["prior_samples", "shape", "mu", "alpha"],
@@ -2379,7 +2379,7 @@ def test_car_rng_fn(sparse):
     with pm.Model(rng_seeder=1):
         car = pm.CAR("car", mu, W, alpha, tau, size=size)
         mn = pm.MvNormal("mn", mu, cov, size=size)
-        check = pm.sample_prior_predictive(n_fails)
+        check = pm.sample_prior_predictive(n_fails, return_inferencedata=False)
 
     p, f = delta, n_fails
     while p <= delta and f > 0:

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -505,6 +505,29 @@ class TestSamplePPC(SeededTest):
             )
             assert ppc["a"].shape == (nchains * ndraws, 5)
 
+    def test_normal_scalar_idata(self):
+        nchains = 2
+        ndraws = 500
+        with pm.Model() as model:
+            mu = pm.Normal("mu", 0.0, 1.0)
+            a = pm.Normal("a", mu=mu, sigma=1, observed=0.0)
+            trace = pm.sample(
+                draws=ndraws,
+                chains=nchains,
+                return_inferencedata=False,
+                discard_tuned_samples=False,
+            )
+
+        assert not isinstance(trace, InferenceData)
+
+        with model:
+            # test keep_size parameter and idata input
+            idata = pm.to_inference_data(trace)
+            assert isinstance(idata, InferenceData)
+
+            ppc = pm.sample_posterior_predictive(idata, keep_size=True, return_inferencedata=False)
+            assert ppc["a"].shape == (nchains, ndraws)
+
     def test_normal_vector(self, caplog):
         with pm.Model() as model:
             mu = pm.Normal("mu", 0.0, 1.0)

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -472,36 +472,38 @@ class TestSamplePPC(SeededTest):
             trace = pm.sample(
                 draws=ndraws,
                 chains=nchains,
+                return_inferencedata=False,
             )
 
         with model:
             # test list input
-            ppc0 = pm.sample_posterior_predictive([model.initial_point], samples=10)
+            ppc0 = pm.sample_posterior_predictive(
+                [model.initial_point], samples=10, return_inferencedata=False
+            )
             # # deprecated argument is not introduced to fast version [2019/08/20:rpg]
-            ppc = pm.sample_posterior_predictive(trace, var_names=["a"])
+            ppc = pm.sample_posterior_predictive(trace, var_names=["a"], return_inferencedata=False)
             # test empty ppc
-            ppc = pm.sample_posterior_predictive(trace, var_names=[])
+            ppc = pm.sample_posterior_predictive(trace, var_names=[], return_inferencedata=False)
             assert len(ppc) == 0
 
             # test keep_size parameter
-            ppc = pm.sample_posterior_predictive(trace, keep_size=True)
-            assert ppc.posterior_predictive["a"].shape == (1, nchains, ndraws)
+            ppc = pm.sample_posterior_predictive(trace, keep_size=True, return_inferencedata=False)
+            assert ppc["a"].shape == (nchains, ndraws)
 
             # test default case
-            ppc = pm.sample_posterior_predictive(trace, var_names=["a"])
-            assert "a" in ppc.posterior_predictive.data_vars
-            assert ppc.posterior_predictive["a"].shape == (1, nchains * ndraws)
+            ppc = pm.sample_posterior_predictive(trace, var_names=["a"], return_inferencedata=False)
+            assert "a" in ppc
+            assert ppc["a"].shape == (nchains * ndraws,)
             # mu's standard deviation may have changed thanks to a's observed
-            _, pval = stats.kstest(
-                ppc.posterior_predictive["a"] - trace.posterior["mu"],
-                stats.norm(loc=0, scale=1).cdf,
-            )
+            _, pval = stats.kstest(ppc["a"] - trace["mu"], stats.norm(loc=0, scale=1).cdf)
             assert pval > 0.001
 
         # size argument not introduced to fast version [2019/08/20:rpg]
         with model:
-            ppc = pm.sample_posterior_predictive(trace, size=5, var_names=["a"])
-            assert ppc.posterior_predictive["a"].shape == (1, nchains * ndraws, 5)
+            ppc = pm.sample_posterior_predictive(
+                trace, size=5, var_names=["a"], return_inferencedata=False
+            )
+            assert ppc["a"].shape == (nchains * ndraws, 5)
 
     def test_normal_vector(self, caplog):
         with pm.Model() as model:

--- a/pymc/tests/test_sampling.py
+++ b/pymc/tests/test_sampling.py
@@ -204,7 +204,7 @@ class TestSample(SeededTest):
             assert len(result._groups_warmup) > 0
 
             # inferencedata without tuning, with idata_kwargs
-            prior = pm.sample_prior_predictive()
+            prior = pm.sample_prior_predictive(return_inferencedata=False)
             result = pm.sample(
                 **kwargs,
                 return_inferencedata=True,
@@ -472,7 +472,6 @@ class TestSamplePPC(SeededTest):
             trace = pm.sample(
                 draws=ndraws,
                 chains=nchains,
-                return_inferencedata=False,
             )
 
         with model:
@@ -486,43 +485,23 @@ class TestSamplePPC(SeededTest):
 
             # test keep_size parameter
             ppc = pm.sample_posterior_predictive(trace, keep_size=True)
-            assert ppc["a"].shape == (nchains, ndraws)
+            assert ppc.posterior_predictive["a"].shape == (1, nchains, ndraws)
 
             # test default case
             ppc = pm.sample_posterior_predictive(trace, var_names=["a"])
-            assert "a" in ppc
-            assert ppc["a"].shape == (nchains * ndraws,)
+            assert "a" in ppc.posterior_predictive.data_vars
+            assert ppc.posterior_predictive["a"].shape == (1, nchains * ndraws)
             # mu's standard deviation may have changed thanks to a's observed
-            _, pval = stats.kstest(ppc["a"] - trace["mu"], stats.norm(loc=0, scale=1).cdf)
+            _, pval = stats.kstest(
+                ppc.posterior_predictive["a"] - trace.posterior["mu"],
+                stats.norm(loc=0, scale=1).cdf,
+            )
             assert pval > 0.001
 
         # size argument not introduced to fast version [2019/08/20:rpg]
         with model:
             ppc = pm.sample_posterior_predictive(trace, size=5, var_names=["a"])
-            assert ppc["a"].shape == (nchains * ndraws, 5)
-
-    def test_normal_scalar_idata(self):
-        nchains = 2
-        ndraws = 500
-        with pm.Model() as model:
-            mu = pm.Normal("mu", 0.0, 1.0)
-            a = pm.Normal("a", mu=mu, sigma=1, observed=0.0)
-            trace = pm.sample(
-                draws=ndraws,
-                chains=nchains,
-                return_inferencedata=False,
-                discard_tuned_samples=False,
-            )
-
-        assert not isinstance(trace, InferenceData)
-
-        with model:
-            # test keep_size parameter and idata input
-            idata = pm.to_inference_data(trace)
-            assert isinstance(idata, InferenceData)
-
-            ppc = pm.sample_posterior_predictive(idata, keep_size=True)
-            assert ppc["a"].shape == (nchains, ndraws)
+            assert ppc.posterior_predictive["a"].shape == (1, nchains * ndraws, 5)
 
     def test_normal_vector(self, caplog):
         with pm.Model() as model:
@@ -532,25 +511,35 @@ class TestSamplePPC(SeededTest):
 
         with model:
             # test list input
-            ppc0 = pm.sample_posterior_predictive([model.initial_point], samples=10)
-            ppc = pm.sample_posterior_predictive(trace, samples=12, var_names=[])
+            ppc0 = pm.sample_posterior_predictive(
+                [model.initial_point], return_inferencedata=False, samples=10
+            )
+            ppc = pm.sample_posterior_predictive(
+                trace, return_inferencedata=False, samples=12, var_names=[]
+            )
             assert len(ppc) == 0
 
             # test keep_size parameter
-            ppc = pm.sample_posterior_predictive(trace, keep_size=True)
+            ppc = pm.sample_posterior_predictive(trace, return_inferencedata=False, keep_size=True)
             assert ppc["a"].shape == (trace.nchains, len(trace), 2)
             with pytest.warns(UserWarning):
-                ppc = pm.sample_posterior_predictive(trace, samples=12, var_names=["a"])
+                ppc = pm.sample_posterior_predictive(
+                    trace, return_inferencedata=False, samples=12, var_names=["a"]
+                )
             assert "a" in ppc
             assert ppc["a"].shape == (12, 2)
 
             with pytest.warns(UserWarning):
-                ppc = pm.sample_posterior_predictive(trace, samples=12, var_names=["a"])
+                ppc = pm.sample_posterior_predictive(
+                    trace, return_inferencedata=False, samples=12, var_names=["a"]
+                )
             assert "a" in ppc
             assert ppc["a"].shape == (12, 2)
 
             # size unsupported by fast_ version  argument. [2019/08/19:rpg]
-            ppc = pm.sample_posterior_predictive(trace, samples=10, var_names=["a"], size=4)
+            ppc = pm.sample_posterior_predictive(
+                trace, return_inferencedata=False, samples=10, var_names=["a"], size=4
+            )
             assert "a" in ppc
             assert ppc["a"].shape == (10, 4, 2)
 
@@ -567,7 +556,7 @@ class TestSamplePPC(SeededTest):
             idata = pm.to_inference_data(trace)
             assert isinstance(idata, InferenceData)
 
-            ppc = pm.sample_posterior_predictive(idata, keep_size=True)
+            ppc = pm.sample_posterior_predictive(idata, return_inferencedata=False, keep_size=True)
             assert ppc["a"].shape == (trace.nchains, len(trace), 2)
 
     def test_exceptions(self, caplog):
@@ -600,11 +589,15 @@ class TestSamplePPC(SeededTest):
             # TODO: Assert something about the output
             # ppc = pm.sample_posterior_predictive(idata, samples=12, var_names=[])
             # assert len(ppc) == 0
-            ppc = pm.sample_posterior_predictive(idata, samples=12, var_names=["a"])
+            ppc = pm.sample_posterior_predictive(
+                idata, return_inferencedata=False, samples=12, var_names=["a"]
+            )
             assert "a" in ppc
             assert ppc["a"].shape == (12, 2)
 
-            ppc = pm.sample_posterior_predictive(idata, samples=10, var_names=["a"], size=4)
+            ppc = pm.sample_posterior_predictive(
+                idata, return_inferencedata=False, samples=10, var_names=["a"], size=4
+            )
             assert "a" in ppc
             assert ppc["a"].shape == (10, 4, 2)
 
@@ -616,9 +609,13 @@ class TestSamplePPC(SeededTest):
 
         with model:
             # test list input
-            ppc0 = pm.sample_posterior_predictive([model.initial_point], samples=10)
+            ppc0 = pm.sample_posterior_predictive(
+                [model.initial_point], return_inferencedata=False, samples=10
+            )
             assert ppc0 == {}
-            ppc = pm.sample_posterior_predictive(idata, samples=1000, var_names=["b"])
+            ppc = pm.sample_posterior_predictive(
+                idata, return_inferencedata=False, samples=1000, var_names=["b"]
+            )
             assert len(ppc) == 1
             assert ppc["b"].shape == (1000,)
             scale = np.sqrt(1 + 0.2 ** 2)
@@ -637,7 +634,7 @@ class TestSamplePPC(SeededTest):
             with pytest.raises(NotImplementedError) as excinfo:
                 pm.sample_prior_predictive(50)
             assert "Cannot sample" in str(excinfo.value)
-            samples = pm.sample_posterior_predictive(idata, 40)
+            samples = pm.sample_posterior_predictive(idata, 40, return_inferencedata=False)
             assert samples["foo"].shape == (40, 200)
 
     def test_model_shared_variable(self):
@@ -660,7 +657,7 @@ class TestSamplePPC(SeededTest):
         samples = 100
         with model:
             post_pred = pm.sample_posterior_predictive(
-                trace, samples=samples, var_names=["p", "obs"]
+                trace, return_inferencedata=False, samples=samples, var_names=["p", "obs"]
             )
 
         expected_p = np.array([logistic.eval({coeff: val}) for val in trace["x"][:samples]])
@@ -694,6 +691,7 @@ class TestSamplePPC(SeededTest):
             rtol = 1e-5 if aesara.config.floatX == "float64" else 1e-4
 
             ppc = pm.sample_posterior_predictive(
+                return_inferencedata=False,
                 model=model,
                 trace=trace,
                 samples=len(trace) * nchains,
@@ -728,6 +726,7 @@ class TestSamplePPC(SeededTest):
                 trace, varnames=[n for n in trace.varnames if n != "out"]
             ).to_dict("records")
             ppc = pm.sample_posterior_predictive(
+                return_inferencedata=False,
                 model=model,
                 trace=ppc_trace,
                 samples=len(ppc_trace),
@@ -745,7 +744,7 @@ class TestSamplePPC(SeededTest):
             trace = pm.sample(compute_convergence_checks=False, return_inferencedata=False)
 
         with model:
-            ppc = pm.sample_posterior_predictive(trace, samples=1)
+            ppc = pm.sample_posterior_predictive(trace, return_inferencedata=False, samples=1)
             assert ppc["a"].dtype.kind == "f"
             assert ppc["b"].dtype.kind == "i"
 
@@ -918,7 +917,7 @@ class TestSamplePriorPredictive(SeededTest):
             positive_mu = pm.Deterministic("positive_mu", np.abs(mu))
             z = -1 - positive_mu
             pm.Normal("x_obs", mu=z, sigma=1, observed=observed_data)
-            prior = pm.sample_prior_predictive()
+            prior = pm.sample_prior_predictive(return_inferencedata=False)
 
         assert "observed_data" not in prior
         assert (prior["mu"] < -90).all()
@@ -932,8 +931,12 @@ class TestSamplePriorPredictive(SeededTest):
             with pm.Model():
                 mu = pm.Gamma("mu", 3, 1, size=1)
                 goals = pm.Poisson("goals", mu, size=shape)
-                trace1 = pm.sample_prior_predictive(10, var_names=["mu", "mu", "goals"])
-                trace2 = pm.sample_prior_predictive(10, var_names=["mu", "goals"])
+                trace1 = pm.sample_prior_predictive(
+                    10, return_inferencedata=False, var_names=["mu", "mu", "goals"]
+                )
+                trace2 = pm.sample_prior_predictive(
+                    10, return_inferencedata=False, var_names=["mu", "goals"]
+                )
             if shape == 2:  # want to test shape as an int
                 shape = (2,)
             assert trace1["goals"].shape == (10,) + shape
@@ -944,7 +947,7 @@ class TestSamplePriorPredictive(SeededTest):
             m = pm.Multinomial("m", n=5, p=np.array([0.25, 0.25, 0.25, 0.25]))
             trace = pm.sample_prior_predictive(10)
 
-        assert trace["m"].shape == (10, 4)
+        assert trace.prior["m"].shape == (1, 10, 4)
 
     def test_multivariate2(self):
         # Added test for issue #3271
@@ -955,8 +958,12 @@ class TestSamplePriorPredictive(SeededTest):
             burned_trace = pm.sample(
                 20, tune=10, cores=1, return_inferencedata=False, compute_convergence_checks=False
             )
-        sim_priors = pm.sample_prior_predictive(samples=20, model=dm_model)
-        sim_ppc = pm.sample_posterior_predictive(burned_trace, samples=20, model=dm_model)
+        sim_priors = pm.sample_prior_predictive(
+            return_inferencedata=False, samples=20, model=dm_model
+        )
+        sim_ppc = pm.sample_posterior_predictive(
+            burned_trace, return_inferencedata=False, samples=20, model=dm_model
+        )
         assert sim_priors["probs"].shape == (20, 6)
         assert sim_priors["obs"].shape == (20,) + mn_data.shape
         assert sim_ppc["obs"].shape == (20,) + mn_data.shape
@@ -987,9 +994,9 @@ class TestSamplePriorPredictive(SeededTest):
             y = pm.Binomial("y", n=at_bats, p=thetas, observed=hits)
             gen = pm.sample_prior_predictive(draws)
 
-        assert gen["phi"].shape == (draws,)
-        assert gen["y"].shape == (draws, n)
-        assert "thetas" in gen
+        assert gen.prior["phi"].shape == (1, draws)
+        assert gen.prior_predictive["y"].shape == (1, draws, n)
+        assert "thetas" in gen.prior.data_vars
 
     def test_shared(self):
         n1 = 10
@@ -1002,16 +1009,16 @@ class TestSamplePriorPredictive(SeededTest):
             o = pm.Deterministic("o", obs)
             gen1 = pm.sample_prior_predictive(draws)
 
-        assert gen1["y"].shape == (draws, n1)
-        assert gen1["o"].shape == (draws, n1)
+        assert gen1.prior["y"].shape == (1, draws, n1)
+        assert gen1.prior["o"].shape == (1, draws, n1)
 
         n2 = 20
         obs.set_value(np.random.rand(n2) < 0.5)
         with m:
             gen2 = pm.sample_prior_predictive(draws)
 
-        assert gen2["y"].shape == (draws, n2)
-        assert gen2["o"].shape == (draws, n2)
+        assert gen2.prior["y"].shape == (1, draws, n2)
+        assert gen2.prior["o"].shape == (1, draws, n2)
 
     def test_density_dist(self):
         obs = np.random.normal(-1, 0.1, size=10)
@@ -1025,7 +1032,7 @@ class TestSamplePriorPredictive(SeededTest):
                 random=lambda mu, sd, rng=None, size=None: rng.normal(loc=mu, scale=sd, size=size),
                 observed=obs,
             )
-            prior = pm.sample_prior_predictive()
+            prior = pm.sample_prior_predictive(return_inferencedata=False)
 
         npt.assert_almost_equal(prior["a"].mean(), 0, decimal=1)
 
@@ -1035,7 +1042,7 @@ class TestSamplePriorPredictive(SeededTest):
             sd = pm.Uniform("sd", lower=2, upper=3)
             x = pm.Normal("x", mu=mu, sigma=sd, size=5)
             prior = pm.sample_prior_predictive(10)
-        assert prior["mu"].shape == (10, 5)
+        assert prior.prior["mu"].shape == (1, 10, 5)
 
     def test_zeroinflatedpoisson(self):
         with pm.Model():
@@ -1043,9 +1050,9 @@ class TestSamplePriorPredictive(SeededTest):
             psi = pm.HalfNormal("psi", sd=1)
             pm.ZeroInflatedPoisson("suppliers", psi=psi, theta=theta, size=20)
             gen_data = pm.sample_prior_predictive(samples=5000)
-            assert gen_data["theta"].shape == (5000,)
-            assert gen_data["psi"].shape == (5000,)
-            assert gen_data["suppliers"].shape == (5000, 20)
+            assert gen_data.prior["theta"].shape == (1, 5000)
+            assert gen_data.prior["psi"].shape == (1, 5000)
+            assert gen_data.prior["suppliers"].shape == (1, 5000, 20)
 
     def test_potentials_warning(self):
         warning_msg = "The effect of Potentials on other parameters is ignored during"
@@ -1075,10 +1082,10 @@ class TestSamplePriorPredictive(SeededTest):
             )
 
         # Check values are correct
-        assert np.allclose(prior["ub_log__"], np.log(prior["ub"]))
+        assert np.allclose(prior.prior["ub_log__"].data, np.log(prior.prior["ub"].data))
         assert np.allclose(
-            prior["x_interval__"],
-            ub_interval_forward(prior["x"], prior["ub"]),
+            prior.prior["x_interval__"].data,
+            ub_interval_forward(prior.prior["x"].data, prior.prior["ub"].data),
         )
 
         # Check that it works when the original RVs are not mentioned in var_names
@@ -1090,9 +1097,16 @@ class TestSamplePriorPredictive(SeededTest):
                 var_names=["ub_log__", "x_interval__"],
                 samples=10,
             )
-        assert "ub" not in prior_transformed_only and "x" not in prior_transformed_only
-        assert np.allclose(prior["ub_log__"], prior_transformed_only["ub_log__"])
-        assert np.allclose(prior["x_interval__"], prior_transformed_only["x_interval__"])
+        assert (
+            "ub" not in prior_transformed_only.prior.data_vars
+            and "x" not in prior_transformed_only.prior.data_vars
+        )
+        assert np.allclose(
+            prior.prior["ub_log__"].data, prior_transformed_only.prior["ub_log__"].data
+        )
+        assert np.allclose(
+            prior.prior["x_interval__"], prior_transformed_only.prior["x_interval__"].data
+        )
 
     def test_issue_4490(self):
         # Test that samples do not depend on var_name order or, more fundamentally,
@@ -1112,27 +1126,34 @@ class TestSamplePriorPredictive(SeededTest):
             d = pm.Normal("d")
             prior2 = pm.sample_prior_predictive(samples=1, var_names=["b", "a", "d", "c"])
 
-        assert prior1["a"] == prior2["a"]
-        assert prior1["b"] == prior2["b"]
-        assert prior1["c"] == prior2["c"]
-        assert prior1["d"] == prior2["d"]
+        assert prior1.prior["a"] == prior2.prior["a"]
+        assert prior1.prior["b"] == prior2.prior["b"]
+        assert prior1.prior["c"] == prior2.prior["c"]
+        assert prior1.prior["d"] == prior2.prior["d"]
 
 
 class TestSamplePosteriorPredictive:
     def test_point_list_arg_bug_spp(self, point_list_arg_bug_fixture):
         pmodel, trace = point_list_arg_bug_fixture
         with pmodel:
-            pp = pm.sample_posterior_predictive([trace[15]], var_names=["d"])
+            pp = pm.sample_posterior_predictive(
+                [trace[15]], return_inferencedata=False, var_names=["d"]
+            )
 
     def test_sample_from_xarray_prior(self, point_list_arg_bug_fixture):
         pmodel, trace = point_list_arg_bug_fixture
 
         with pmodel:
-            prior = pm.sample_prior_predictive(samples=20)
+            prior = pm.sample_prior_predictive(
+                samples=20,
+                return_inferencedata=False,
+            )
             idat = pm.to_inference_data(trace, prior=prior)
 
         with pmodel:
-            pp = pm.sample_posterior_predictive(idat.prior, var_names=["d"])
+            pp = pm.sample_posterior_predictive(
+                idat.prior, return_inferencedata=False, var_names=["d"]
+            )
 
     def test_sample_from_xarray_posterior(self, point_list_arg_bug_fixture):
         pmodel, trace = point_list_arg_bug_fixture

--- a/pymc/tests/test_shared.py
+++ b/pymc/tests/test_shared.py
@@ -48,10 +48,14 @@ class TestShared(SeededTest):
             prior_trace1 = pm.sample_prior_predictive(1000)
             pp_trace1 = pm.sample_posterior_predictive(idata, 1000)
 
-        assert prior_trace0["b"].shape == (1000,)
-        assert prior_trace0["obs"].shape == (1000, 100)
-        np.testing.assert_allclose(x, pp_trace0["obs"].mean(axis=0), atol=1e-1)
+        assert prior_trace0.prior["b"].shape == (1, 1000)
+        assert prior_trace0.prior_predictive["obs"].shape == (1, 1000, 100)
+        np.testing.assert_allclose(
+            x, pp_trace0.posterior_predictive["obs"].mean(("chain", "draw")), atol=1e-1
+        )
 
-        assert prior_trace1["b"].shape == (1000,)
-        assert prior_trace1["obs"].shape == (1000, 200)
-        np.testing.assert_allclose(x_pred, pp_trace1["obs"].mean(axis=0), atol=1e-1)
+        assert prior_trace1.prior["b"].shape == (1, 1000)
+        assert prior_trace1.prior_predictive["obs"].shape == (1, 1000, 200)
+        np.testing.assert_allclose(
+            x_pred, pp_trace1.posterior_predictive["obs"].mean(("chain", "draw")), atol=1e-1
+        )

--- a/pymc/tests/test_smc.py
+++ b/pymc/tests/test_smc.py
@@ -293,8 +293,8 @@ class TestSimulator(SeededTest):
 
         with self.SMABC_test:
             trace = pm.sample_smc(draws=1000, return_inferencedata=False)
-            pr_p = pm.sample_prior_predictive(1000)
-            po_p = pm.sample_posterior_predictive(trace, 1000)
+            pr_p = pm.sample_prior_predictive(1000, return_inferencedata=False)
+            po_p = pm.sample_posterior_predictive(trace, 1000, return_inferencedata=False)
 
         assert abs(self.data.mean() - trace["a"].mean()) < 0.05
         assert abs(self.data.std() - trace["b"].mean()) < 0.05

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 minversion = "6.0"
 xfail_strict=true
 
+[tool.black]
+line-length = 100
+
 [tool.coverage.report]
 exclude_lines = [
   "pragma: nocover",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,6 @@
 minversion = "6.0"
 xfail_strict=true
 
-[tool.black]
-line-length = 100
-
 [tool.coverage.report]
 exclude_lines = [
   "pragma: nocover",


### PR DESCRIPTION
This PR adds the possibility to return foward samples directly as an `InferenceData` objects, and sets this behavior as the default. These objects then just need to be extended to the original trace (which is already an `InferenceData` object by default in 4.0), which simplifies the workflow.

I implemented this for `sample_prior_predictive` and you can already review -- I would like to get your approval on the logic before going to `sample_posterior_predictive` and `sample_posterior_predictive_w`, as the implementation will be very similar.

+ [x] Refactor `sample_prior_predictive`
+ [x] Refactor `sample_posterior_predictive`
+ [x] Refactor `sample_posterior_predictive_w`
+ [x] Breaking changes: forward sampling functions now return an `InferenceData` object by default.
+ [x] Mention in the RELEASE-NOTES.md