### PR TITLE
Fix a forgotten rename to exclude tests from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [run]
 omit =
     # exclude tests files from coverage calculation
-    pymc3/tests/test_*.py
+    pymc/tests/test_*.py


### PR DESCRIPTION
A small diff for a commit, a giant leap for our coverage badge. 
