### PR TITLE
BART: make linear response more robust and fix bug with predictions

### DIFF
--- a/pymc/bart/bart.py
+++ b/pymc/bart/bart.py
@@ -15,6 +15,7 @@
 import numpy as np
 
 from aesara.tensor.random.op import RandomVariable, default_shape_from_params
+from pandas import DataFrame, Series
 
 from pymc.distributions.distribution import NoDistribution
 
@@ -93,8 +94,8 @@ class BART(NoDistribution):
         Scale parameter for the values of the leaf nodes. Defaults to 2. Recomended to be between 1
         and 3.
     response : str
-        How the leaf_node values are computed. Available options are ``constant``, ``linear`` or
-        ``mix`` (default).
+        How the leaf_node values are computed. Available options are ``constant`` (default),
+        ``linear`` or ``mix``.
     split_prior : array-like
         Each element of split_prior should be in the [0, 1] interval and the elements should sum to
         1. Otherwise they will be normalized.
@@ -109,12 +110,13 @@ class BART(NoDistribution):
         m=50,
         alpha=0.25,
         k=2,
-        response="mix",
+        response="constant",
         split_prior=None,
         **kwargs,
     ):
 
         cls.all_trees = []
+        X, Y = preprocess_XY(X, Y)
 
         bart_op = type(
             f"BART_{name}",
@@ -143,3 +145,14 @@ class BART(NoDistribution):
     @classmethod
     def dist(cls, *params, **kwargs):
         return super().dist(params, **kwargs)
+
+
+def preprocess_XY(X, Y):
+    if isinstance(Y, (Series, DataFrame)):
+        Y = Y.to_numpy()
+    if isinstance(X, (Series, DataFrame)):
+        X = X.to_numpy()
+        # X = np.random.normal(X, X.std(0)/100)
+    Y = Y.astype(float)
+    X = X.astype(float)
+    return X, Y

--- a/pymc/bart/tree.py
+++ b/pymc/bart/tree.py
@@ -111,12 +111,13 @@ class Tree:
             Value of the leaf value where the unobserved point lies.
         """
         leaf_node, split_variable = self._traverse_tree(X, node_index=0)
-        if leaf_node.linear_params is None:
+        linear_params = leaf_node.linear_params
+        if linear_params is None:
             return leaf_node.value
         else:
             x = X[split_variable].item()
-            y_x = leaf_node.linear_params[0] + leaf_node.linear_params[1] * x
-            return y_x / m
+            y_x = (linear_params[0] + linear_params[1] * x) / m
+            return y_x + linear_params[2]
 
     def _traverse_tree(self, x, node_index=0, split_variable=None):
         """
@@ -136,10 +137,10 @@ class Tree:
             split_variable = current_node.idx_split_variable
             if x[split_variable] <= current_node.split_value:
                 left_child = current_node.get_idx_left_child()
-                current_node, _ = self._traverse_tree(x, left_child, split_variable)
+                current_node, split_variable = self._traverse_tree(x, left_child, split_variable)
             else:
                 right_child = current_node.get_idx_right_child()
-                current_node, _ = self._traverse_tree(x, right_child, split_variable)
+                current_node, split_variable = self._traverse_tree(x, right_child, split_variable)
         return current_node, split_variable
 
     def grow_tree(self, index_leaf_node, new_split_node, new_left_node, new_right_node):

--- a/pymc/tests/test_bart.py
+++ b/pymc/tests/test_bart.py
@@ -44,7 +44,7 @@ def test_bart_vi():
         )
         var_imp /= var_imp.sum()
         assert var_imp[0] > var_imp[1:].sum()
-        np.testing.assert_almost_equal(var_imp.sum(), 1)
+        assert_almost_equal(var_imp.sum(), 1)
 
 
 def test_bart_random():
@@ -62,6 +62,7 @@ def test_bart_random():
     rng = RandomState(12345)
     pred_first = mu.owner.op.rng_fn(rng, X_new=X[:10])
 
+    assert_almost_equal(pred_first, pred_all[0, :10], decimal=4)
     assert pred_all.shape == (2, 50)
     assert pred_first.shape == (10,)
 


### PR DESCRIPTION
I am also reverting back the default response to "constant", even when BART is still experimental and "mix" or "linear" seems to provide a better fit, maybe better to be a little bit more conservative until we have results for more experiments.  