### PR TITLE
Fix logo url on v3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://cdn.rawgit.com/pymc-devs/pymc3/master/docs/logos/svg/PyMC3_banner.svg
+.. image:: https://cdn.rawgit.com/pymc-devs/pymc/v3/docs/logos/svg/PyMC3_banner.svg
     :height: 100px
     :alt: PyMC3 logo
     :align: center

--- a/docs/source/semantic_sphinx/layout.html
+++ b/docs/source/semantic_sphinx/layout.html
@@ -54,7 +54,7 @@ such as on Chrome for documents on localhost #}
     <div class="ui container">
         <div class="ui large secondary pointing menu">
             <a class="item" href="/">
-                <img class="ui bottom aligned tiny image" src="https://cdn.rawgit.com/pymc-devs/pymc3/master/docs/logos/svg/PyMC3_banner.svg" />
+                <img class="ui bottom aligned tiny image" src="https://cdn.rawgit.com/pymc-devs/pymc/v3/docs/logos/svg/PyMC3_banner.svg" />
             </a>
             {% if
             theme_navbar_links %} {%- for link in theme_navbar_links %} <a href="{{ pathto(*link[1:]) }}" class="item">{{
@@ -74,7 +74,7 @@ such as on Chrome for documents on localhost #}
     </div>
     {% if pagename == 'index' %}
     <div class="ui center aligned text container">
-        <img src="https://cdn.rawgit.com/pymc-devs/pymc3/master/docs/logos/svg/PyMC3_banner.svg" />
+        <img src="https://cdn.rawgit.com/pymc-devs/pymc/v3/docs/logos/svg/PyMC3_banner.svg" />
         <h2>Probabilistic Programming in Python</h2>
         <a href="pymc-examples/examples/pymc3_howto/api_quickstart.html">
             <div class="ui huge primary button">Quickstart <i class="right arrow icon"></i></div>


### PR DESCRIPTION
If I open https://docs.pymc.io/en/stable/ in incognito mode, the PyMC3 image on landing page is missing.

Here's a screenshot of missing URL.
<img width="786" alt="Screenshot 2021-10-16 at 9 35 07 AM" src="https://user-images.githubusercontent.com/43073325/137573691-14ffbd3c-b5fd-423b-85ce-1b702bbc9c79.png">

