### PR TITLE
Add dims to *Ordered probs variables when appropriate

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -1745,7 +1745,8 @@ class OrderedLogistic:
     def __new__(cls, name, *args, compute_p=True, **kwargs):
         out_rv = _OrderedLogistic(name, *args, **kwargs)
         if compute_p:
-            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[3])
+            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[3],
+                             dims=kwargs.get('dims'))
         return out_rv
 
     @classmethod
@@ -1856,7 +1857,8 @@ class OrderedProbit:
     def __new__(cls, name, *args, compute_p=True, **kwargs):
         out_rv = _OrderedProbit(name, *args, **kwargs)
         if compute_p:
-            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[3])
+            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[3],
+                             dims=kwargs.get('dims'))
         return out_rv
 
     @classmethod

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -1745,8 +1745,7 @@ class OrderedLogistic:
     def __new__(cls, name, *args, compute_p=True, **kwargs):
         out_rv = _OrderedLogistic(name, *args, **kwargs)
         if compute_p:
-            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[3],
-                             dims=kwargs.get('dims'))
+            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[3], dims=kwargs.get('dims'))
         return out_rv
 
     @classmethod
@@ -1857,8 +1856,7 @@ class OrderedProbit:
     def __new__(cls, name, *args, compute_p=True, **kwargs):
         out_rv = _OrderedProbit(name, *args, **kwargs)
         if compute_p:
-            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[3],
-                             dims=kwargs.get('dims'))
+            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[3], dims=kwargs.get('dims'))
         return out_rv
 
     @classmethod

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -1745,7 +1745,7 @@ class OrderedLogistic:
     def __new__(cls, name, *args, compute_p=True, **kwargs):
         out_rv = _OrderedLogistic(name, *args, **kwargs)
         if compute_p:
-            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[3], dims=kwargs.get('dims'))
+            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[3], dims=kwargs.get("dims"))
         return out_rv
 
     @classmethod
@@ -1856,7 +1856,7 @@ class OrderedProbit:
     def __new__(cls, name, *args, compute_p=True, **kwargs):
         out_rv = _OrderedProbit(name, *args, **kwargs)
         if compute_p:
-            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[3], dims=kwargs.get('dims'))
+            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[3], dims=kwargs.get("dims"))
         return out_rv
 
     @classmethod

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -752,7 +752,8 @@ class OrderedMultinomial:
     def __new__(cls, name, *args, compute_p=True, **kwargs):
         out_rv = _OrderedMultinomial(name, *args, **kwargs)
         if compute_p:
-            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[4])
+            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[4],
+                             dims=kwargs.get('dims'))
         return out_rv
 
     @classmethod

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -752,7 +752,7 @@ class OrderedMultinomial:
     def __new__(cls, name, *args, compute_p=True, **kwargs):
         out_rv = _OrderedMultinomial(name, *args, **kwargs)
         if compute_p:
-            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[4], dims=kwargs.get('dims'))
+            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[4], dims=kwargs.get("dims"))
         return out_rv
 
     @classmethod

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -752,8 +752,7 @@ class OrderedMultinomial:
     def __new__(cls, name, *args, compute_p=True, **kwargs):
         out_rv = _OrderedMultinomial(name, *args, **kwargs)
         if compute_p:
-            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[4],
-                             dims=kwargs.get('dims'))
+            pm.Deterministic(f"{name}_probs", out_rv.owner.inputs[4], dims=kwargs.get('dims'))
         return out_rv
 
     @classmethod


### PR DESCRIPTION
Add `dims` to `_probs` RV for ordered distributions when appropriate.
