### PR TITLE
replace deprecationwarning with futurewarning

### DIFF
--- a/pymc/backends/tracetab.py
+++ b/pymc/backends/tracetab.py
@@ -45,7 +45,7 @@ def trace_to_dataframe(trace, chains=None, varnames=None, include_transformed=Fa
         "The `trace_to_dataframe` function will soon be removed. "
         "Please use ArviZ to save traces. "
         "If you have good reasons for using the `trace_to_dataframe` function, file an issue and tell us about them. ",
-        DeprecationWarning,
+        FutureWarning,
     )
     var_shapes = trace._straces[0].var_shapes
 

--- a/pymc/distributions/dist_math.py
+++ b/pymc/distributions/dist_math.py
@@ -510,7 +510,7 @@ def log_i0(x):
 def incomplete_beta(a, b, value):
     warnings.warn(
         "incomplete_beta has been deprecated. Use aesara.tensor.betainc instead.",
-        DeprecationWarning,
+        FutureWarning,
         stacklevel=2,
     )
     return at.betainc(a, b, value)

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -78,7 +78,7 @@ class DistributionMeta(ABCMeta):
             def _random(*args, **kwargs):
                 warnings.warn(
                     "The old `Distribution.random` interface is deprecated.",
-                    DeprecationWarning,
+                    FutureWarning,
                     stacklevel=2,
                 )
                 return clsdict["random"](*args, **kwargs)
@@ -204,7 +204,7 @@ class Distribution(metaclass=DistributionMeta):
             initval = kwargs.pop("testval")
             warnings.warn(
                 "The `testval` argument is deprecated; use `initval`.",
-                DeprecationWarning,
+                FutureWarning,
                 stacklevel=2,
             )
 
@@ -296,7 +296,7 @@ class Distribution(metaclass=DistributionMeta):
                 "The `.dist(testval=...)` argument is deprecated and has no effect. "
                 "Initial values for sampling/optimization can be specified with `initval` in a modelcontext. "
                 "For using Aesara's test value features, you must assign the `.tag.test_value` yourself.",
-                DeprecationWarning,
+                FutureWarning,
                 stacklevel=2,
             )
         if "initval" in kwargs:

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -1410,7 +1410,7 @@ class LKJCorr(Continuous):
                 "Parameters to LKJCorr have changed: shape parameter n -> eta "
                 "dimension parameter p -> n. Please update your code. "
                 "Automatically re-assigning parameters for backwards compatibility.",
-                DeprecationWarning,
+                FutureWarning,
             )
             self.n = p
             self.eta = n
@@ -1435,7 +1435,7 @@ class LKJCorr(Continuous):
         warnings.warn(
             "Parameters in LKJCorr have been rename: shape parameter n -> eta "
             "dimension parameter p -> n. Please double check your initialization.",
-            DeprecationWarning,
+            FutureWarning,
         )
         self.tri_index = np.zeros([n, n], dtype="int32")
         self.tri_index[np.triu_indices(n, k=1)] = np.arange(shape)
@@ -1665,7 +1665,7 @@ class MatrixNormal(Continuous):
                 "The shape argument in MatrixNormal is deprecated and will be ignored."
                 "MatrixNormal automatically derives the shape"
                 "from row and column matrix dimensions.",
-                DeprecationWarning,
+                FutureWarning,
             )
 
         # Among-row matrices

--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -725,7 +725,7 @@ class MarginalSparse(Marginal):
                 self.sigma = sigma
                 warnings.warn(
                     "The 'sigma' argument has been deprecated. Use 'noise' instead.",
-                    DeprecationWarning,
+                    FutureWarning,
                 )
         else:
             self.sigma = noise

--- a/pymc/math.py
+++ b/pymc/math.py
@@ -205,7 +205,7 @@ def invlogit(x, eps=None):
     if eps is not None:
         warnings.warn(
             "pymc.math.invlogit no longer supports the ``eps`` argument and it will be ignored.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
     return at.sigmoid(x)

--- a/pymc/model.py
+++ b/pymc/model.py
@@ -838,7 +838,7 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
     def vars(self):
         warnings.warn(
             "Model.vars has been deprecated. Use Model.value_vars instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
         return self.value_vars
 
@@ -942,7 +942,7 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
         """Deprecated alias for `Model.recompute_initial_point(seed=None)`."""
         warnings.warn(
             "`Model.test_point` has been deprecated. Use `Model.recompute_initial_point(seed=None)`.",
-            DeprecationWarning,
+            FutureWarning,
         )
         return self.recompute_initial_point()
 
@@ -951,7 +951,7 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
         """Deprecated alias for `Model.recompute_initial_point(seed=None)`."""
         warnings.warn(
             "`Model.initial_point` has been deprecated. Use `Model.recompute_initial_point(seed=None)`.",
-            DeprecationWarning,
+            FutureWarning,
         )
         return self.recompute_initial_point()
 
@@ -1548,7 +1548,7 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
         conditional on the values of `b` and stored in `b`.
 
         """
-        raise DeprecationWarning(
+        raise FutureWarning(
             "The `Model.update_start_vals` method was removed."
             " To change initial values you may set the items of `Model.initial_values` directly."
         )
@@ -1630,7 +1630,7 @@ class Model(Factor, WithMemoization, metaclass=ContextMeta):
     def check_test_point(self, *args, **kwargs):
         warnings.warn(
             "`Model.check_test_point` has been deprecated. Use `Model.point_logps` instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
         return self.point_logps(*args, **kwargs)
 

--- a/pymc/plots/__init__.py
+++ b/pymc/plots/__init__.py
@@ -36,7 +36,7 @@ def alias_deprecation(func, alias: str):
 
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
-        raise DeprecationWarning(
+        raise FutureWarning(
             f"The function `{alias}` from PyMC was an alias for `{original}` from ArviZ. "
             "It was removed in PyMC 4.0. "
             f"Switch to `pymc.{original}` or `arviz.{original}`."

--- a/pymc/plots/posteriorplot.py
+++ b/pymc/plots/posteriorplot.py
@@ -59,7 +59,7 @@ def plot_posterior_predictive_glm(
     warnings.warn(
         "The `plot_posterior_predictive_glm` function will migrate to Arviz in a future release. "
         "\nKeep up to date with `ArviZ <https://arviz-devs.github.io/arviz/>`_ for future updates.",
-        DeprecationWarning,
+        FutureWarning,
     )
 
     if lm is None:

--- a/pymc/sampling.py
+++ b/pymc/sampling.py
@@ -1650,7 +1650,7 @@ def sample_posterior_predictive(
         warnings.warn(
             "In this version, RNG seeding is managed by the Model objects. "
             "See the `rng_seeder` argument in Model's constructor.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
 
@@ -1806,7 +1806,7 @@ def sample_posterior_predictive_w(
         warnings.warn(
             "In this version, RNG seeding is managed by the Model objects. "
             "See the `rng_seeder` argument in Model's constructor.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
 
@@ -1973,7 +1973,7 @@ def sample_prior_predictive(
         warnings.warn(
             "In this version, RNG seeding is managed by the Model objects. "
             "See the `rng_seeder` argument in Model's constructor.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
 

--- a/pymc/smc/sample_smc.py
+++ b/pymc/smc/sample_smc.py
@@ -151,7 +151,7 @@ def sample_smc(
         warnings.warn(
             f'The kernel string argument "{kernel}" in sample_smc has been deprecated. '
             f"It is no longer needed to distinguish between `abc` and `metropolis`",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
         kernel = IMH
@@ -160,7 +160,7 @@ def sample_smc(
         warnings.warn(
             "save_sim_data has been deprecated. Use pm.sample_posterior_predictive "
             "to obtain the same type of samples.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
 
@@ -168,7 +168,7 @@ def sample_smc(
         warnings.warn(
             "save_log_pseudolikelihood has been deprecated. This information is "
             "now saved as log_likelihood in models with Simulator distributions.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
 
@@ -176,7 +176,7 @@ def sample_smc(
     if parallel is not None:
         warnings.warn(
             "The argument parallel is deprecated, use the argument cores instead.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
         if parallel is False:

--- a/pymc/tests/test_dist_math.py
+++ b/pymc/tests/test_dist_math.py
@@ -264,6 +264,6 @@ def test_multigamma():
 
 
 def test_incomplete_beta_deprecation():
-    with pytest.warns(DeprecationWarning, match="incomplete_beta has been deprecated"):
+    with pytest.warns(FutureWarning, match="incomplete_beta has been deprecated"):
         res = incomplete_beta(3, 5, 0.5).eval()
     assert np.isclose(res, at.betainc(3, 5, 0.5).eval())

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -2122,7 +2122,7 @@ class TestMatchesScipy:
         dir_rv = Dirichlet.dist(a)
         assert dir_rv.shape.eval() == (2,)
 
-        with pytest.warns(DeprecationWarning), aesara.change_flags(compute_test_value="ignore"):
+        with pytest.warns(FutureWarning), aesara.change_flags(compute_test_value="ignore"):
             dir_rv = Dirichlet.dist(at.vector())
 
     def test_dirichlet_2D(self):

--- a/pymc/tests/test_distributions.py
+++ b/pymc/tests/test_distributions.py
@@ -2122,7 +2122,7 @@ class TestMatchesScipy:
         dir_rv = Dirichlet.dist(a)
         assert dir_rv.shape.eval() == (2,)
 
-        with pytest.warns(FutureWarning), aesara.change_flags(compute_test_value="ignore"):
+        with pytest.warns(DeprecationWarning), aesara.change_flags(compute_test_value="ignore"):
             dir_rv = Dirichlet.dist(at.vector())
 
     def test_dirichlet_2D(self):

--- a/pymc/tests/test_distributions_random.py
+++ b/pymc/tests/test_distributions_random.py
@@ -1635,7 +1635,7 @@ class TestMatrixNormal(BaseTestDistribution):
                 logpt(matrixnormal, aesara.tensor.ones((3, 3, 3)))
 
         with pm.Model():
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(FutureWarning):
                 matrixnormal = pm.MatrixNormal(
                     "matnormal",
                     mu=np.random.random((3, 3)),

--- a/pymc/tests/test_initial_point.py
+++ b/pymc/tests/test_initial_point.py
@@ -32,7 +32,7 @@ def transform_back(rv, transformed) -> np.ndarray:
 
 class TestInitvalAssignment:
     def test_dist_warnings_and_errors(self):
-        with pytest.warns(DeprecationWarning, match="argument is deprecated and has no effect"):
+        with pytest.warns(FutureWarning, match="argument is deprecated and has no effect"):
             rv = pm.Exponential.dist(lam=1, testval=0.5)
         assert not hasattr(rv.tag, "test_value")
 
@@ -42,7 +42,7 @@ class TestInitvalAssignment:
 
     def test_new_warnings(self):
         with pm.Model() as pmodel:
-            with pytest.warns(DeprecationWarning, match="`testval` argument is deprecated"):
+            with pytest.warns(FutureWarning, match="`testval` argument is deprecated"):
                 rv = pm.Uniform("u", 0, 1, testval=0.75)
                 initial_point = pmodel.recompute_initial_point(seed=0)
                 assert initial_point["u_interval__"] == transform_fwd(rv, 0.75)

--- a/pymc/tests/test_math.py
+++ b/pymc/tests/test_math.py
@@ -255,7 +255,7 @@ def test_expand_packed_triangular():
 
 def test_invlogit_deprecation_warning():
     with pytest.warns(
-        DeprecationWarning,
+        FutureWarning,
         match="pymc.math.invlogit no longer supports the",
     ):
         res = invlogit(np.array(-750.0), 1e-5).eval()

--- a/pymc/tests/test_model.py
+++ b/pymc/tests/test_model.py
@@ -425,7 +425,7 @@ def test_model_vars():
         a = pm.Normal("a")
         pm.Normal("x", a)
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(FutureWarning):
         old_vars = model.vars
 
     assert old_vars == model.value_vars
@@ -495,14 +495,14 @@ def test_initial_point():
         a = pm.Uniform("a")
         x = pm.Normal("x", a)
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(FutureWarning):
         initial_point = model.test_point
 
     assert all(var.name in initial_point for var in model.value_vars)
 
     b_initval = np.array(0.3, dtype=aesara.config.floatX)
 
-    with pytest.warns(DeprecationWarning), model:
+    with pytest.warns(FutureWarning), model:
         b = pm.Uniform("b", testval=b_initval)
 
     b_value_var = model.rvs_to_values[b]
@@ -526,7 +526,7 @@ def test_point_logps():
         a = pm.Uniform("a")
         pm.Normal("x", a)
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(FutureWarning):
         logp_vals = model.check_test_point()
 
     assert "x" in logp_vals.keys()

--- a/pymc/tests/test_smc.py
+++ b/pymc/tests/test_smc.py
@@ -212,7 +212,7 @@ class TestSMC(SeededTest):
     def test_deprecated_parallel_arg(self):
         with self.fast_model:
             with pytest.warns(
-                DeprecationWarning,
+                FutureWarning,
                 match="The argument parallel is deprecated",
             ):
                 pm.sample_smc(draws=10, chains=1, parallel=False)
@@ -220,25 +220,25 @@ class TestSMC(SeededTest):
     def test_deprecated_abc_args(self):
         with self.fast_model:
             with pytest.warns(
-                DeprecationWarning,
+                FutureWarning,
                 match='The kernel string argument "ABC" in sample_smc has been deprecated',
             ):
                 pm.sample_smc(draws=10, chains=1, kernel="ABC")
 
             with pytest.warns(
-                DeprecationWarning,
+                FutureWarning,
                 match='The kernel string argument "Metropolis" in sample_smc has been deprecated',
             ):
                 pm.sample_smc(draws=10, chains=1, kernel="Metropolis")
 
             with pytest.warns(
-                DeprecationWarning,
+                FutureWarning,
                 match="save_sim_data has been deprecated",
             ):
                 pm.sample_smc(draws=10, chains=1, save_sim_data=True)
 
             with pytest.warns(
-                DeprecationWarning,
+                FutureWarning,
                 match="save_log_pseudolikelihood has been deprecated",
             ):
                 pm.sample_smc(draws=10, chains=1, save_log_pseudolikelihood=True)

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -236,7 +236,7 @@ def biwrap(wrapper):
 def dataset_to_point_dict(ds: xarray.Dataset) -> List[Dict[str, np.ndarray]]:
     warnings.warn(
         "dataset_to_point_dict was renamed to dataset_to_point_list and will be removed!",
-        DeprecationWarning,
+        FutureWarning,
     )
     return dataset_to_point_list(ds)
 


### PR DESCRIPTION
`DeprecationWarning` is intended for other developers and `FutureWarning` for users. When in doubt is probably safer to go with `FutureWarning`. 