### PR TITLE
Add `_as_tensor_variable` converter for pandas objects

### DIFF
--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -29,6 +29,7 @@ from typing import (
 import aesara
 import aesara.tensor as at
 import numpy as np
+import pandas as pd
 import scipy.sparse as sps
 
 from aeppl.abstract import MeasurableVariable
@@ -143,18 +144,10 @@ def convert_observed_data(data):
         return floatX(ret)
 
 
-try:
-    import pandas as pd
-
-    _pd_available: bool = True
-except ModuleNotFoundError:
-    _pd_available: bool = False
-
-if _pd_available:
-
-    @_as_tensor_variable.register(pd.DataFrame)
-    def dataframe_to_tensor_variable(df: pd.DataFrame, *args, **kwargs) -> TensorVariable:
-        return at.as_tensor_variable(df.to_numpy(), *args, **kwargs)
+@_as_tensor_variable.register(pd.Series)
+@_as_tensor_variable.register(pd.DataFrame)
+def dataframe_to_tensor_variable(df: pd.DataFrame, *args, **kwargs) -> TensorVariable:
+    return at.as_tensor_variable(df.to_numpy(), *args, **kwargs)
 
 
 def change_rv_size(

--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -29,6 +29,7 @@ from typing import (
 import aesara
 import aesara.tensor as at
 import numpy as np
+import pandas as pd
 import scipy.sparse as sps
 
 from aeppl.abstract import MeasurableVariable
@@ -140,6 +141,11 @@ def convert_observed_data(data):
     # needed for uses of this function other than with pm.Data:
     else:
         return floatX(ret)
+
+
+@_as_tensor_variable.register(pd.DataFrame)
+def dataframe_to_tensor_variable(df: pd.DataFrame, *args, **kwargs) -> TensorVariable:
+    return at.as_tensor_variable(df.to_numpy(), *args, **kwargs)
 
 
 def change_rv_size(
@@ -1031,15 +1037,3 @@ def compile_pymc(
         **kwargs,
     )
     return aesara_function
-
-
-def pd_df_to_aesara_tensor(df):
-    try:
-        import pandas as pd
-
-        @_as_tensor_variable.register(pd.DataFrame)
-        def dataframe_to_tensor_variable(df, *args, **kwargs):
-            return at.as_tensor_variable(df.to_numpy(), *args, **kwargs)
-
-    except ModuleNotFoundError:
-        pass

--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -29,7 +29,6 @@ from typing import (
 import aesara
 import aesara.tensor as at
 import numpy as np
-import pandas as pd
 import scipy.sparse as sps
 
 from aeppl.abstract import MeasurableVariable
@@ -51,6 +50,7 @@ from aesara.graph.fg import FunctionGraph
 from aesara.graph.op import Op, compute_test_value
 from aesara.sandbox.rng_mrg import MRG_RandomStream as RandomStream
 from aesara.scalar.basic import Cast
+from aesara.tensor.basic import _as_tensor_variable
 from aesara.tensor.elemwise import Elemwise
 from aesara.tensor.random.op import RandomVariable
 from aesara.tensor.random.var import (
@@ -143,9 +143,18 @@ def convert_observed_data(data):
         return floatX(ret)
 
 
-@_as_tensor_variable.register(pd.DataFrame)
-def dataframe_to_tensor_variable(df: pd.DataFrame, *args, **kwargs) -> TensorVariable:
-    return at.as_tensor_variable(df.to_numpy(), *args, **kwargs)
+try:
+    import pandas as pd
+
+    _pd_available: bool = True
+except ModuleNotFoundError:
+    _pd_available: bool = False
+
+if _pd_available:
+
+    @_as_tensor_variable.register(pd.DataFrame)
+    def dataframe_to_tensor_variable(df: pd.DataFrame, *args, **kwargs) -> TensorVariable:
+        return at.as_tensor_variable(df.to_numpy(), *args, **kwargs)
 
 
 def change_rv_size(

--- a/pymc/aesaraf.py
+++ b/pymc/aesaraf.py
@@ -1031,3 +1031,15 @@ def compile_pymc(
         **kwargs,
     )
     return aesara_function
+
+
+def pd_df_to_aesara_tensor(df):
+    try:
+        import pandas as pd
+
+        @_as_tensor_variable.register(pd.DataFrame)
+        def dataframe_to_tensor_variable(df, *args, **kwargs):
+            return at.as_tensor_variable(df.to_numpy(), *args, **kwargs)
+
+    except ModuleNotFoundError:
+        pass

--- a/pymc/tests/test_aesaraf.py
+++ b/pymc/tests/test_aesaraf.py
@@ -18,6 +18,7 @@ import aesara.tensor as at
 import numpy as np
 import numpy.ma as ma
 import numpy.testing as npt
+import pandas as pd
 import pytest
 import scipy.sparse as sps
 
@@ -56,7 +57,6 @@ from pymc.vartypes import int_types
     ],
 )
 def test_pd_dataframe_as_tensor_variable(np_array: np.ndarray) -> None:
-    pd = pytest.importorskip("pandas")
     df: pd.DataFrame = pd.DataFrame(np_array)
     np.testing.assert_array_equal(x=at.as_tensor_variable(x=df).eval(), y=np_array)
 
@@ -66,13 +66,11 @@ def test_pd_dataframe_as_tensor_variable(np_array: np.ndarray) -> None:
     argvalues=[np.array([1.0, 2.0, -1.0]), np.ones(shape=4), np.zeros(shape=10), [1, 2, 3, 4]],
 )
 def test_pd_series_as_tensor_variable(np_array: np.ndarray) -> None:
-    pd = pytest.importorskip("pandas")
     df: pd.DataFrame = pd.Series(np_array)
     np.testing.assert_array_equal(x=at.as_tensor_variable(x=df).eval(), y=np_array)
 
 
 def test_pd_as_tensor_variable_multiindex() -> None:
-    pd = pytest.importorskip("pandas")
 
     tuples = [("L", "Q"), ("L", "I"), ("O", "L"), ("O", "I")]
 
@@ -261,7 +259,6 @@ def test_convert_observed_data(input_dtype):
     Ensure that convert_observed_data returns the dense array, masked array,
     graph variable, TensorVariable, or sparse matrix as appropriate.
     """
-    pd = pytest.importorskip("pandas")
     # Create the various inputs to the function
     sparse_input = sps.csr_matrix(np.eye(3)).astype(input_dtype)
     dense_input = np.arange(9).reshape((3, 3)).astype(input_dtype)
@@ -337,7 +334,6 @@ def test_convert_observed_data(input_dtype):
 
 
 def test_pandas_to_array_pandas_index():
-    pd = pytest.importorskip("pandas")
     data = pd.Index([1, 2, 3])
     result = convert_observed_data(data)
     expected = np.array([1, 2, 3])

--- a/pymc/tests/test_aesaraf.py
+++ b/pymc/tests/test_aesaraf.py
@@ -57,7 +57,7 @@ from pymc.vartypes import int_types
     ],
 )
 def test_pd_dataframe_as_tensor_variable(np_array: np.ndarray) -> None:
-    df: pd.DataFrame = pd.DataFrame(np_array)
+    df = pd.DataFrame(np_array)
     np.testing.assert_array_equal(x=at.as_tensor_variable(x=df).eval(), y=np_array)
 
 
@@ -66,7 +66,7 @@ def test_pd_dataframe_as_tensor_variable(np_array: np.ndarray) -> None:
     argvalues=[np.array([1.0, 2.0, -1.0]), np.ones(shape=4), np.zeros(shape=10), [1, 2, 3, 4]],
 )
 def test_pd_series_as_tensor_variable(np_array: np.ndarray) -> None:
-    df: pd.DataFrame = pd.Series(np_array)
+    df = pd.Series(np_array)
     np.testing.assert_array_equal(x=at.as_tensor_variable(x=df).eval(), y=np_array)
 
 

--- a/pymc/tests/test_aesaraf.py
+++ b/pymc/tests/test_aesaraf.py
@@ -18,7 +18,6 @@ import aesara.tensor as at
 import numpy as np
 import numpy.ma as ma
 import numpy.testing as npt
-import pandas as pd
 import pytest
 import scipy.sparse as sps
 
@@ -49,13 +48,12 @@ from pymc.vartypes import int_types
 
 
 @pytest.mark.parametrize(
-    argnames="df, np_array",
-    argvalues=[
-        (pd.DataFrame(data={"col": [1.0, 2.0, -1.0]}), np.array([[1.0], [2.0], [-1.0]])),
-        (pd.DataFrame([np.ones(3), np.zeros(3)]), np.array([[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]])),
-    ],
+    argnames="np_array",
+    argvalues=[np.array([[1.0], [2.0], [-1.0]]), np.array([[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]])],
 )
-def test_pd_as_tensor_variable(df: pd.DataFrame, np_array: np.ndarray) -> None:
+def test_pd_as_tensor_variable(np_array: np.ndarray) -> None:
+    pd = pytest.importorskip("pandas")
+    df: pd.DataFrame = pd.DataFrame(np_array)
     np.testing.assert_array_equal(x=at.as_tensor_variable(x=df).eval(), y=np_array)
 
 

--- a/pymc/tests/test_aesaraf.py
+++ b/pymc/tests/test_aesaraf.py
@@ -18,6 +18,7 @@ import aesara.tensor as at
 import numpy as np
 import numpy.ma as ma
 import numpy.testing as npt
+import pandas as pd
 import pytest
 import scipy.sparse as sps
 
@@ -45,6 +46,17 @@ from pymc.aesaraf import (
 from pymc.distributions.dist_math import check_parameters
 from pymc.exceptions import ShapeError
 from pymc.vartypes import int_types
+
+
+@pytest.mark.parametrize(
+    argnames="df, np_array",
+    argvalues=[
+        (pd.DataFrame(data={"col": [1.0, 2.0, -1.0]}), np.array([[1.0], [2.0], [-1.0]])),
+        (pd.DataFrame([np.ones(3), np.zeros(3)]), np.array([[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]])),
+    ],
+)
+def test_pd_as_tensor_variable(df: pd.DataFrame, np_array: np.ndarray) -> None:
+    np.testing.assert_array_equal(x=at.as_tensor_variable(x=df).eval(), y=np_array)
 
 
 def test_change_rv_size():

--- a/pymc/tests/test_aesaraf.py
+++ b/pymc/tests/test_aesaraf.py
@@ -57,6 +57,19 @@ def test_pd_as_tensor_variable(np_array: np.ndarray) -> None:
     np.testing.assert_array_equal(x=at.as_tensor_variable(x=df).eval(), y=np_array)
 
 
+def test_pd_as_tensor_variable_multiindex() -> None:
+    pd = pytest.importorskip("pandas")
+
+    tuples = [("L", "Q"), ("L", "I"), ("O", "L"), ("O", "I")]
+
+    index = pd.MultiIndex.from_tuples(tuples, names=["Id1", "Id2"])
+
+    df = pd.DataFrame({"A": [12.0, 80.0, 30.0, 20.0], "B": [120.0, 700.0, 30.0, 20.0]}, index=index)
+    np_array = np.array([[12.0, 80.0, 30.0, 20.0], [120.0, 700.0, 30.0, 20.0]]).T
+    assert isinstance(df.index, pd.MultiIndex)
+    np.testing.assert_array_equal(x=at.as_tensor_variable(x=df).eval(), y=np_array)
+
+
 def test_change_rv_size():
     loc = at.as_tensor_variable([1, 2])
     rv = normal(loc=loc)

--- a/pymc/tests/test_aesaraf.py
+++ b/pymc/tests/test_aesaraf.py
@@ -49,11 +49,25 @@ from pymc.vartypes import int_types
 
 @pytest.mark.parametrize(
     argnames="np_array",
-    argvalues=[np.array([[1.0], [2.0], [-1.0]]), np.array([[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]])],
+    argvalues=[
+        np.array([[1.0], [2.0], [-1.0]]),
+        np.array([[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]]),
+        np.ones(shape=(10, 1)),
+    ],
 )
-def test_pd_as_tensor_variable(np_array: np.ndarray) -> None:
+def test_pd_dataframe_as_tensor_variable(np_array: np.ndarray) -> None:
     pd = pytest.importorskip("pandas")
     df: pd.DataFrame = pd.DataFrame(np_array)
+    np.testing.assert_array_equal(x=at.as_tensor_variable(x=df).eval(), y=np_array)
+
+
+@pytest.mark.parametrize(
+    argnames="np_array",
+    argvalues=[np.array([1.0, 2.0, -1.0]), np.ones(shape=4), np.zeros(shape=10), [1, 2, 3, 4]],
+)
+def test_pd_series_as_tensor_variable(np_array: np.ndarray) -> None:
+    pd = pytest.importorskip("pandas")
+    df: pd.DataFrame = pd.Series(np_array)
     np.testing.assert_array_equal(x=at.as_tensor_variable(x=df).eval(), y=np_array)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ cachetools>=4.2.1
 cloudpickle
 fastprogress>=0.2.0
 numpy>=1.15.0
+pandas>=0.24.0
 scipy>=1.4.1
 typing-extensions>=3.7.4


### PR DESCRIPTION
This is an attempt to solve https://github.com/pymc-devs/pymc/issues/5877

@ricardoV94 I went through `pymc/aesaraf.py` but I could not figure out by myself where to add your suggestion. I decided to open a PR anyway but I would appreciate some hints on which function this has to be included and tested 🙏 