### PR TITLE
added postprocessing_chunks option to sample_blackjax_nuts and sample…

### DIFF
--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -338,9 +338,10 @@ def sample_blackjax_nuts(
         "vectorized".
     postprocessing_backend : str, optional
         Specify how postprocessing should be computed. gpu or cpu
-    postprocessing_chunks: int, default 1
+    postprocessing_chunks: Optional[int], default None
         Specify the number of chunks the postprocessing should be computed in. More
-        chunks reduces memory usage at the cost of losing some vectorization
+        chunks reduces memory usage at the cost of losing some vectorization, None
+        uses jax.vmap
     idata_kwargs : dict, optional
         Keyword arguments for :func:`arviz.from_dict`. It also accepts a boolean as
         value for the ``log_likelihood`` key to indicate that the pointwise log
@@ -553,9 +554,10 @@ def sample_numpyro_nuts(
         "parallel", and "vectorized".
     postprocessing_backend : Optional[str]
         Specify how postprocessing should be computed. gpu or cpu
-    postprocessing_chunks: int, default 1
+    postprocessing_chunks: Optional[int], default None
         Specify the number of chunks the postprocessing should be computed in. More
-        chunks reduces memory usage at the cost of losing some vectorization
+        chunks reduces memory usage at the cost of losing some vectorization, None
+        uses jax.vmap
     idata_kwargs : dict, optional
         Keyword arguments for :func:`arviz.from_dict`. It also accepts a boolean as
         value for the ``log_likelihood`` key to indicate that the pointwise log

--- a/pymc/tests/sampling/test_jax.py
+++ b/pymc/tests/sampling/test_jax.py
@@ -55,7 +55,8 @@ with pytest.warns(UserWarning, match="module is experimental"):
         ),
     ],
 )
-def test_transform_samples(sampler, postprocessing_backend, chains):
+@pytest.mark.parametrize("postprocessing_chunks", [None, 10])
+def test_transform_samples(sampler, postprocessing_backend, chains, postprocessing_chunks):
     pytensor.config.on_opt_error = "raise"
     np.random.seed(13244)
 
@@ -71,6 +72,7 @@ def test_transform_samples(sampler, postprocessing_backend, chains):
             random_seed=1322,
             keep_untransformed=True,
             postprocessing_backend=postprocessing_backend,
+            postprocessing_chunks=postprocessing_chunks
         )
 
     log_vals = trace.posterior["sigma_log__"].values

--- a/pymc/tests/sampling/test_jax.py
+++ b/pymc/tests/sampling/test_jax.py
@@ -72,7 +72,7 @@ def test_transform_samples(sampler, postprocessing_backend, chains, postprocessi
             random_seed=1322,
             keep_untransformed=True,
             postprocessing_backend=postprocessing_backend,
-            postprocessing_chunks=postprocessing_chunks
+            postprocessing_chunks=postprocessing_chunks,
         )
 
     log_vals = trace.posterior["sigma_log__"].values


### PR DESCRIPTION
**What is this PR about?**
Fix for the memory spike that happens at the end of jax sampling see: https://discourse.pymc.io/t/out-of-memory-when-transforming-variables-in-numpyro-jax/9904.

Uses experimental features from jax see: https://jax.readthedocs.io/en/latest/_autosummary/jax.experimental.maps.xmap.html.

Tested using `pytest pymc/tests/sampling/test_jax.py::test_transform_samples`
...

## Major / Breaking Changes
- None

## Bugfixes / New features
- Added a kwarg `postprocessing_chunks` to `sample_blackjax_nuts` and `sample_numpyro_nuts` so that the user can specify the chunking they want to use in postprocessing to reduce memory usage

## Docs / Maintenance