### PR TITLE
Reinstate nuts_kwargs in sample for passing arguments to numpyro

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -504,7 +504,7 @@ def sample(
     if nuts_kwargs is None:
         nuts_kwargs = {}
     if "target_accept" in kwargs:
-        if nuts_kwargs is not None and "target_accept" in nuts_kwargs:
+        if "target_accept" in nuts_kwargs:
             raise ValueError(
                 "`target_accept` was defined twice. Please specify it either as a direct keyword argument or in the `nuts_kwargs` dict."
             )


### PR DESCRIPTION
**What is this PR about?**

In the current release, optional parameters for sample_numpyro_nuts were not making it through when passed from pm.sample:

    ValueError: Unused step method arguments: {'postprocessing_backend', 'chain_method', 'nuts_kwargs'}

This PR reinstates the nuts_kwargs argument as a means for getting them to the sampler.

```
with model:
    trace = pm.sample(draws=500, tune=1000, chains=2, nuts_sampler='numpyro', target_accept=0.7, nuts_kwargs={"max_tree_depth": 12, "chain_method":'vectorized'}, idata_kwargs={"log_likelihood": False})
```

**Checklist**
+ [ ] Explain important implementation details 👆
+ [ ] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [ ] Are the changes covered by tests and docstrings?
+ [ ] Fill out the short summary sections 👇

## Major / Breaking Changes

No `nuts` kwarg anymore; uses `nuts_kwargs` instead

## New features

NA

## Bugfixes

Custom arguments can be passed to `sample_numpyro_nuts`

## Documentation
- ...

## Maintenance
- ...
