### PR TITLE
Implement `Model.debug()` helper

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -234,24 +234,26 @@ def get_tau_sigma(tau=None, sigma=None):
             tau = 1.0
         else:
             if isinstance(sigma, Variable):
-                sigma_ = check_parameters(sigma, sigma > 0, msg="sigma > 0")
+                # Keep tau negative, if sigma was negative, so that it will fail when used
+                tau = (sigma**-2.0) * pt.sgn(sigma)
             else:
                 sigma_ = np.asarray(sigma)
                 if np.any(sigma_ <= 0):
                     raise ValueError("sigma must be positive")
-            tau = sigma_**-2.0
+                tau = sigma_**-2.0
 
     else:
         if sigma is not None:
             raise ValueError("Can't pass both tau and sigma")
         else:
             if isinstance(tau, Variable):
-                tau_ = check_parameters(tau, tau > 0, msg="tau > 0")
+                # Keep sigma negative, if tau was negative, so that it will fail when used
+                sigma = pt.abs(tau) ** (-0.5) * pt.sgn(tau)
             else:
                 tau_ = np.asarray(tau)
                 if np.any(tau_ <= 0):
                     raise ValueError("tau must be positive")
-            sigma = tau_**-0.5
+                sigma = tau_**-0.5
 
     return floatX(tau), floatX(sigma)
 

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 import functools as ft
+import warnings
 
 import numpy as np
 import numpy.testing as npt
@@ -890,24 +891,26 @@ class TestMatchesScipy:
         assert np.isinf(logp[2])
 
     def test_get_tau_sigma(self):
-        sigma = np.array(2)
-        npt.assert_almost_equal(get_tau_sigma(sigma=sigma), [1.0 / sigma**2, sigma])
+        # Fail on warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
 
-        tau = np.array(2)
-        npt.assert_almost_equal(get_tau_sigma(tau=tau), [tau, tau**-0.5])
+            sigma = np.array(2)
+            npt.assert_almost_equal(get_tau_sigma(sigma=sigma), [1.0 / sigma**2, sigma])
 
-        tau, _ = get_tau_sigma(sigma=pt.constant(-2))
-        with pytest.raises(ParameterValueError):
-            tau.eval()
+            tau = np.array(2)
+            npt.assert_almost_equal(get_tau_sigma(tau=tau), [tau, tau**-0.5])
 
-        _, sigma = get_tau_sigma(tau=pt.constant(-2))
-        with pytest.raises(ParameterValueError):
-            sigma.eval()
+            tau, _ = get_tau_sigma(sigma=pt.constant(-2))
+            npt.assert_almost_equal(tau.eval(), -0.25)
 
-        sigma = [1, 2]
-        npt.assert_almost_equal(
-            get_tau_sigma(sigma=sigma), [1.0 / np.array(sigma) ** 2, np.array(sigma)]
-        )
+            _, sigma = get_tau_sigma(tau=pt.constant(-2))
+            npt.assert_almost_equal(sigma.eval(), -np.sqrt(1 / 2))
+
+            sigma = [1, 2]
+            npt.assert_almost_equal(
+                get_tau_sigma(sigma=sigma), [1.0 / np.array(sigma) ** 2, np.array(sigma)]
+            )
 
     @pytest.mark.parametrize(
         "value,mu,sigma,nu,logp",


### PR DESCRIPTION
Example:
```python
import pymc as pm

with pm.Model() as m:
    x = pm.Normal("x", [1, -1, 1])
    y = pm.Normal("y", mu=x, sigma=x * 2)
m.debug()
```

Outputs:
```
point={'x': array([ 1., -1.,  1.]), 'y': array([ 1., -1.,  1.])}

The variable y has the following parameters:
0: x [id A] <TensorType(float64, (3,))>
1: Elemwise{mul,no_inplace} [id B] <TensorType(float64, (3,))>
 |TensorConstant{(1,) of 2.0} [id C] <TensorType(float64, (1,))>
 |x [id A] <TensorType(float64, (3,))>
The parameters evaluate to:
0: [ 1. -1.  1.]
1: [ 2. -2.  2.]
This does not respect one of the following constraints: sigma > 0
```

Another example:
```python
import pymc as pm

with pm.Model() as m:
    theta = pm.Uniform('theta', lower=0, upper=1)
    y = pm.Uniform('y', lower=0, upper=theta, observed=[0.49, 0.27, 0.53, 0.19])
m.debug()    
```
```
point={'theta_interval__': array(0.)}

The variable y has the following parameters:
0: TensorConstant{0.0} [id A] <TensorType(float64, ())>
1: Elemwise{sigmoid,no_inplace} [id B] <TensorType(float64, ())> 'theta'
 |theta_interval__ [id C] <TensorType(float64, ())>
The parameters evaluate to:
0: 0.0
1: 0.5
Some of the observed values of variable y are associated with a non-finite logp:
 value = 0.53 -> logp = -inf
```

Closes #4205 