### PR TITLE
Speedup Slice sampler

### DIFF
--- a/pymc/step_methods/slicer.py
+++ b/pymc/step_methods/slicer.py
@@ -51,6 +51,7 @@ class Slice(ArrayStep):
     name = "slice"
     default_blocked = False
     stats_dtypes_shapes = {
+        "tune": (bool, []),
         "nstep_out": (int, []),
         "nstep_in": (int, []),
     }
@@ -140,6 +141,7 @@ class Slice(ArrayStep):
             self.n_tunes += 1
 
         stats = {
+            "tune": self.tune,
             "nstep_out": nstep_out,
             "nstep_in": nstep_in,
         }


### PR DESCRIPTION
Inherits from StepArrayShared to avoid the many mappings between raveled and non-raveled arrays, which greatly slowdown the sampler. This simple model samples 3 times as fast in my machine after the changes:

```python
import arviz as az
import pymc as pm

with pm.Model() as m:
    x = pm.Normal("x", shape=(200,))
    idata = pm.sample(step=pm.Slice([x]), random_seed=1)
    
az.summary(idata)
```

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6711.org.readthedocs.build/en/6711/

<!-- readthedocs-preview pymc end -->