### PR TITLE
Avoid creating float64 tensors in VI when possible

### DIFF
--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1073,11 +1073,11 @@ class Group(WithMemoization):
                     for v in self.group
                     if isinstance(v.owner.op, MinibatchRandomVariable)
                 ]
-                + [1.0]  # To avoid empty max
+                + [pm.floatX(1.0)]  # To avoid empty max
             )
         )
         t = self.symbolic_single_sample(t)
-        return pm.floatX(t)
+        return t
 
     @node_property
     def symbolic_logq_not_scaled(self):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
The change avoids creating float64 graphs under floatX=float32


## Bugfixes
- Reduce places where float64 is unintentional 


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--6788.org.readthedocs.build/en/6788/

<!-- readthedocs-preview pymc end -->