### PR TITLE
Refactor jax internals to support dense_mass kwarg for numpyro

### DIFF
--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -185,7 +185,7 @@ def test_get_log_likelihood():
     b_true = trace.log_likelihood.b.values
     a = np.array(trace.posterior.a)
     sigma_log_ = np.log(np.array(trace.posterior.sigma))
-    b_jax = _get_log_likelihood(model, [a, sigma_log_])["b"]
+    b_jax = _get_log_likelihood(model, {"a": a, "sigma_log__": sigma_log_})["b"]
 
     assert np.allclose(b_jax.reshape(-1), b_true.reshape(-1))
 
@@ -215,7 +215,7 @@ def test_get_jaxified_logp():
 
     jax_fn = get_jaxified_logp(m)
     # This would underflow if not optimized
-    assert not np.isinf(jax_fn((np.array(5000.0), np.array(5000.0))))
+    assert not np.isinf(jax_fn(dict(x=np.array(5000.0), y=np.array(5000.0))))
 
 
 @pytest.fixture(scope="module")
@@ -302,19 +302,19 @@ def test_get_batched_jittered_initial_points():
     ips = _get_batched_jittered_initial_points(
         model=model, chains=1, random_seed=1, initvals=None, jitter=False
     )
-    assert np.all(ips[0] == 0)
+    assert np.all(ips["x"] == 0)
 
     # Single chain
     ips = _get_batched_jittered_initial_points(model=model, chains=1, random_seed=1, initvals=None)
 
-    assert ips[0].shape == (2, 3)
-    assert np.all(ips[0] != 0)
+    assert ips["x"].shape == (2, 3)
+    assert np.all(ips["x"] != 0)
 
     # Multiple chains
     ips = _get_batched_jittered_initial_points(model=model, chains=2, random_seed=1, initvals=None)
 
-    assert ips[0].shape == (2, 2, 3)
-    assert np.all(ips[0][0] != ips[0][1])
+    assert ips["x"].shape == (2, 2, 3)
+    assert np.all(ips["x"][0] != ips["x"][1])
 
 
 @pytest.mark.parametrize(

--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -483,5 +483,5 @@ def test_sample_numpyro_nuts_block_adapt():
                 dense_mass=[
                     ("a", "a_g"),
                 ]
-            )
+            ),
         )

--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -477,6 +477,8 @@ def test_sample_numpyro_nuts_block_adapt():
         s_g = pm.HalfNormal("s_g")
         a_ig = pm.Normal("a_ig", a_g, s_g, dims=("county", "level"))
         trace = sample_numpyro_nuts(
+            tune=10,
+            draws=10,
             nuts_kwargs=dict(
                 dense_mass=[
                     ("a", "a_g"),

--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -217,6 +217,11 @@ def test_get_jaxified_logp():
     # This would underflow if not optimized
     assert not np.isinf(jax_fn(dict(x=np.array(5000.0), y=np.array(5000.0))))
 
+    # by default return array fn
+    jax_fn = get_jaxified_logp(m, point_fn=True)
+    # This would underflow if not optimized
+    assert not np.isinf(jax_fn(dict(x=np.array(5000.0), y=np.array(5000.0))))
+
 
 @pytest.fixture(scope="module")
 def model_test_idata_kwargs() -> pm.Model:

--- a/tests/sampling/test_jax.py
+++ b/tests/sampling/test_jax.py
@@ -459,3 +459,22 @@ def test_idata_contains_stats(sampler_name: str):
     for stat_var, stat_var_dims in stat_vars.items():
         assert stat_var in stats.variables
         assert stats.get(stat_var).values.shape == stat_var_dims
+
+
+def test_sample_numpyro_nuts_block_adapt():
+    with pm.Model(
+        coords=dict(level=["Basement", "Floor"], county=[1, 2]),
+    ) as model:
+        # multilevel modelling
+        a = pm.Normal("a")
+        s = pm.HalfNormal("s")
+        a_g = pm.Normal("a_g", a, s, dims="level")
+        s_g = pm.HalfNormal("s_g")
+        a_ig = pm.Normal("a_ig", a_g, s_g, dims=("county", "level"))
+        trace = sample_numpyro_nuts(
+            nuts_kwargs=dict(
+                dense_mass=[
+                    ("a", "a_g"),
+                ]
+            )
+        )


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

**What is this PR about?**
Enables Block Dense mass matrix adaptation for numpyro

**Checklist**
+ [x] Explain important implementation details 👆
+ [x] Make sure that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html).
+ [ ] Link relevant issues (preferably in [nice commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
+ [x] Are the changes covered by tests and docstrings?
+ [x] Fill out the short summary sections 👇

## Major / Breaking Changes
- ...

## New features
- Block mass matrix for numpyro
- `get_jaxified_logp` now accepts `point_fn` argument
```python
with pm.Model(
        coords=dict(level=["Basement", "Floor"], county=[1, 2]),
) as model:
    # multilevel modelling
    a = pm.Normal("a")
    s = pm.HalfNormal("s")
    a_g = pm.Normal("a_g", a, s, dims="level")
    s_g = pm.HalfNormal("s_g")
    a_ig = pm.Normal("a_ig", a_g, s_g, dims=("county", "level"))
    trace = sample_numpyro_nuts(
        nuts_kwargs=dict(
            dense_mass=[
                ("a", "a_g"),
            ]
        )
    )
```

## Bugfixes
- ...

## Documentation
- ...

## Maintenance
- ...


<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--7050.org.readthedocs.build/en/7050/

<!-- readthedocs-preview pymc end -->