### PR TITLE
HSGP misc fixes

### DIFF
--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -31,10 +31,13 @@ TensorLike = np.ndarray | pt.TensorVariable
 
 
 def set_boundary(Xs: TensorLike, c: numbers.Real | TensorLike) -> np.ndarray:
-    """Set the boundary using the `Xs` centered around 0 and `c`. `c` is usually a scalar
-    multiplier greater than 1.0, but it may be one value per dimension or column of `Xs`.
+    """Set the boundary using the `Xs` and `c`.  `Xs` must be centered around zero, and `c`
+    is usually a scalar multiplier greater than 1.0, but it may also be one value per dimension
+    or column of `Xs`.
     """
-    S = pt.max(pt.abs(Xs), axis=0)  # important: the Xs should be centered around 0
+    S = pt.max(
+        pt.abs(Xs), axis=0
+    )  # important: the Xs should have previously been centered around 0
     L = (c * S).eval()  # eval() makes sure L is not changed with out-of-sample preds
     return L
 

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -31,8 +31,8 @@ TensorLike = np.ndarray | pt.TensorVariable
 
 
 def set_boundary(X: TensorLike, c: numbers.Real | TensorLike) -> np.ndarray:
-    """Set the boundary using `X` and `c`.  `X` can be centered around zero but doesn't have to be, 
-    and `c` is usually a scalar multiplier greater than 1.0, but it may also be one value per 
+    """Set the boundary using `X` and `c`.  `X` can be centered around zero but doesn't have to be,
+    and `c` is usually a scalar multiplier greater than 1.0, but it may also be one value per
     dimension or column of `X`.
     """
     # compute radius. Works whether X is 0-centered or not

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -30,14 +30,14 @@ from pymc.gp.mean import Mean, Zero
 TensorLike = np.ndarray | pt.TensorVariable
 
 
-def set_boundary(Xs: TensorLike, c: numbers.Real | TensorLike) -> np.ndarray:
-    """Set the boundary using the `Xs` and `c`.  `Xs` must be centered around zero, and `c`
-    is usually a scalar multiplier greater than 1.0, but it may also be one value per dimension
-    or column of `Xs`.
+def set_boundary(X: TensorLike, c: numbers.Real | TensorLike) -> np.ndarray:
+    """Set the boundary using `X` and `c`.  `X` can be centered around zero but doesn't have to be, 
+    and `c` is usually a scalar multiplier greater than 1.0, but it may also be one value per 
+    dimension or column of `X`.
     """
-    S = pt.max(
-        pt.abs(Xs), axis=0
-    )  # important: the Xs should have previously been centered around 0
+    # compute radius. Works whether X is 0-centered or not
+    S = (pt.max(X, axis=0) - pt.min(X, axis=0)) / 2.0
+
     L = (c * S).eval()  # eval() makes sure L is not changed with out-of-sample preds
     return L
 

--- a/tests/gp/test_hsgp_approx.py
+++ b/tests/gp/test_hsgp_approx.py
@@ -129,7 +129,7 @@ class TestHSGP(_BaseFixtures):
             _ = pm.Data("X", X)
             cov_func = pm.gp.cov.ExpQuad(1, ls=3)
             gp = pm.gp.HSGP(m=[20], L=[10], cov_func=cov_func)
-            _ = gp.prior_linearized(Xs=X)
+            _ = gp.prior_linearized(X=X)
 
         x_new = np.linspace(-10, 20, 100)[:, None]
         with model:


### PR DESCRIPTION
## Description
- Fix centering calculation (replace - with +) (nice catch @ulfaslak!)
- Use `x_range` instead of `x` in `approx_hsgp_hyperparams`.  I don't _think_ the full `x` is needed anymore, could be missing something though.
- Add more detail in docstring of `approx_hsgp_hyperparams` about usage.
- Renamed `Xs` to `X`.  The "s" stood for "scaled", for when the user had to center or mean subtract the incoming `X`.  Now this is done automatically, so it can just be called `X`.  Though minor, **it is a breaking change**.  Would it be good to add a deprecation warning and keep the `Xs` syntax for a while?

Also, didn't make this change, but what do people think about not returning `S` from `approx_hsgp_hyperparams`, so it would just return `m` and `c`?  The idea was that returning S here would be helpful for the user when centering things, but that's not really necessary anymore.

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7342.org.readthedocs.build/en/7342/

<!-- readthedocs-preview pymc end -->