### PR TITLE
Allow access to different nutpie backends via pip-style syntax

### DIFF
--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -70,6 +70,8 @@ __all__ = (
     "sample_numpyro_nuts",
 )
 
+JaxNutsSampler = Literal["numpyro", "blackjax"]
+
 
 @jax_funcify.register(Assert)
 @jax_funcify.register(CheckParameterValue)
@@ -524,7 +526,7 @@ def sample_jax_nuts(
     postprocessing_chunks=None,
     idata_kwargs: dict | None = None,
     compute_convergence_checks: bool = True,
-    nuts_sampler: Literal["numpyro", "blackjax"],
+    nuts_sampler: JaxNutsSampler,
 ) -> az.InferenceData:
     """
     Draw samples from the posterior using a jax NUTS method.

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -577,8 +577,10 @@ def sample(
         method will be used, if appropriate to the model.
     var_names : list of str, optional
         Names of variables to be stored in the trace. Defaults to all free variables and deterministics.
-    nuts_sampler : str
-        Which NUTS implementation to run. One of ["pymc", "nutpie", "blackjax", "numpyro"].
+    nuts_sampler : str, default "pymc"
+        Which NUTS implementation to run. One of ["pymc", "nutpie", "blackjax", "numpyro"]. In addition, the compilation
+        backend for the chosen sampler can be set using square brackets, if available. For example, "nutpie[jax]" will
+        use the JAX backend for the nutpie sampler. Currently, "nutpie[jax]" and "nutpie[numba]" are allowed.
         This requires the chosen sampler to be installed.
         All samplers, except "pymc", require the full model to be continuous.
     blas_cores: int or "auto" or None, default = "auto"

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -91,10 +91,11 @@ __all__ = [
 
 Step: TypeAlias = BlockedStep | CompoundStep
 
-ExternalNutsSampler = ["nutpie", "numpyro", "blackjax"]
+ExternalNutsSampler = Literal["nutpie", "numpyro", "blackjax"]
 NutsSampler = Literal["pymc"] | ExternalNutsSampler
-
 NutpieBackend = Literal["numba", "jax"]
+
+
 NUTPIE_BACKENDS = get_args(NutpieBackend)
 NUTPIE_DEFAULT_BACKEND = cast(NutpieBackend, "numba")
 
@@ -412,6 +413,10 @@ def _sample_external_nuts(
 
     elif sampler in ("numpyro", "blackjax"):
         import pymc.sampling.jax as pymc_jax
+
+        from pymc.sampling.jax import JaxNutsSampler
+
+        sampler = cast(JaxNutsSampler, sampler)
 
         idata = pymc_jax.sample_jax_nuts(
             draws=draws,

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -23,13 +23,7 @@ import time
 import warnings
 
 from collections.abc import Callable, Iterator, Mapping, Sequence
-from typing import (
-    Any,
-    Literal,
-    TypeAlias,
-    cast,
-    overload,
-)
+from typing import Any, Literal, TypeAlias, cast, get_args, overload
 
 import numpy as np
 import pytensor.gradient as tg
@@ -352,15 +346,16 @@ def _sample_external_nuts(
 
         def extract_backend(string: str) -> NutpieBackend:
             match = re.search(r"(?<=\[)[^\]]+(?=\])", string)
-            if match is None:
+            if string == "nutpie":
                 return NUTPIE_DEFAULT_BACKEND
+            elif match is None:
+                raise ValueError(
+                    f"Could not parse nutpie backend. Found {string!r}, expected format 'nutpie[backend]'"
+                )
+
             result = cast(NutpieBackend, match.group(0))
             if result not in NUTPIE_BACKENDS:
-                last_option = f"{NUTPIE_BACKENDS[-1]}"
-                expected = (
-                    ", ".join([f'"{x}"' for x in NUTPIE_BACKENDS[:-1]]) + f' or "{last_option}"'
-                )
-                raise ValueError(f'Expected one of {expected}; found "{result}"')
+                raise ValueError(f'Expected one of {NUTPIE_BACKENDS}; found "{result}"')
             return result
 
         backend = extract_backend(sampler)

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -119,6 +119,7 @@ def test_numba_backend_options(pymc_model, recwarn, backend):
 
 
 def test_invalid_nutpie_backend_raises(pymc_model):
+    pytest.importorskip("nutpie")
     with pytest.raises(ValueError, match='Expected one of "numba" or "jax"; found "invalid"'):
         with pymc_model:
             sample(nuts_sampler="nutpie[invalid]", random_seed=123, chains=2, tune=500, draws=500)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
Adds a pip-style syntax to the `nuts_sampler` argument that allows access to alternative compile backends, when relevant. This lets you get the nutpie jax backend by setting `nuts_sampler='nutpie[jax]'`. For backwards compatibility, `nuts_sampler='nutpie'` is equivalent to `nuts_sampler='nutpie[numba]'`.

The current PR only deals with nutpie, but we could easily extend this to include the default PyMC sampler, to compile to JAX, numba, or pytorch directly, without going through nutpie. I'm willing to do that extension in this PR if it is deemed worthwhile..

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7497 
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7498.org.readthedocs.build/en/7498/

<!-- readthedocs-preview pymc end -->