### PR TITLE
Replace VarName with built-in str

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -67,7 +67,6 @@ from pymc.pytensorf import (
 )
 from pymc.util import (
     UNSET,
-    VarName,
     WithMemoization,
     _UnsetType,
     get_transformed_name,
@@ -1968,7 +1967,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
     def to_graphviz(
         self,
         *,
-        var_names: Iterable[VarName] | None = None,
+        var_names: Iterable[str] | None = None,
         formatting: str = "plain",
         save: str | None = None,
         figsize: tuple[int, int] | None = None,
@@ -2172,7 +2171,7 @@ def compile_fn(
     )
 
 
-def Point(*args, filter_model_vars=False, **kwargs) -> dict[VarName, np.ndarray]:
+def Point(*args, filter_model_vars=False, **kwargs) -> dict[str, np.ndarray]:
     """Build a point.
 
     Uses same args as dict() does.

--- a/pymc/model_graph.py
+++ b/pymc/model_graph.py
@@ -27,7 +27,7 @@ from pytensor.tensor.shape import Shape
 
 from pymc.model.core import modelcontext
 from pymc.pytensorf import _cheap_eval_mode
-from pymc.util import VarName, get_default_varnames, get_var_name
+from pymc.util import get_default_varnames, get_var_name
 
 __all__ = (
     "ModelGraph",
@@ -173,7 +173,7 @@ def default_data(var: Variable) -> GraphvizNodeKwargs:
     }
 
 
-def get_node_type(var_name: VarName, model) -> NodeType:
+def get_node_type(var_name: str, model) -> NodeType:
     """Return the node type of the variable in the model."""
     v = model[var_name]
 
@@ -242,7 +242,7 @@ class ModelGraph:
         self._all_vars = {model[var_name] for var_name in self._all_var_names}
         self.var_list = self.model.named_vars.values()
 
-    def get_parent_names(self, var: Variable) -> set[VarName]:
+    def get_parent_names(self, var: Variable) -> set[str]:
         if var.owner is None:
             return set()
 
@@ -261,12 +261,12 @@ class ModelGraph:
             return x.owner.inputs
 
         return {
-            cast(VarName, ancestor.name)  # type: ignore[union-attr]
+            cast(str, ancestor.name)  # type: ignore[union-attr]
             for ancestor in walk(nodes=var.owner.inputs, expand=_expand)
             if ancestor in named_vars
         }
 
-    def vars_to_plot(self, var_names: Iterable[VarName] | None = None) -> list[VarName]:
+    def vars_to_plot(self, var_names: Iterable[str] | None = None) -> list[str]:
         if var_names is None:
             return self._all_var_names
 
@@ -296,13 +296,11 @@ class ModelGraph:
         # ordering of self._all_var_names is important
         return [get_var_name(var) for var in selected_ancestors]
 
-    def make_compute_graph(
-        self, var_names: Iterable[VarName] | None = None
-    ) -> dict[VarName, set[VarName]]:
+    def make_compute_graph(self, var_names: Iterable[str] | None = None) -> dict[str, set[str]]:
         """Get map of var_name -> set(input var names) for the model."""
         model = self.model
         named_vars = self._all_vars
-        input_map: dict[VarName, set[VarName]] = defaultdict(set)
+        input_map: dict[str, set[str]] = defaultdict(set)
 
         var_names_to_plot = self.vars_to_plot(var_names)
         for var_name in var_names_to_plot:
@@ -319,7 +317,7 @@ class ModelGraph:
                 for ancestor in ancestors([obs_var]):
                     if ancestor not in named_vars:
                         continue
-                    obs_name = cast(VarName, ancestor.name)
+                    obs_name = cast(str, ancestor.name)
                     input_map[var_name].discard(obs_name)
                     input_map[obs_name].add(var_name)
 
@@ -327,7 +325,7 @@ class ModelGraph:
 
     def get_plates(
         self,
-        var_names: Iterable[VarName] | None = None,
+        var_names: Iterable[str] | None = None,
     ) -> list[Plate]:
         """Rough but surprisingly accurate plate detection.
 
@@ -337,7 +335,7 @@ class ModelGraph:
         Returns
         -------
         dict
-            Maps plate labels to the set of ``VarName``s inside the plate.
+            Maps plate labels to the set of strings inside the plate.
         """
         plates = defaultdict(set)
 
@@ -389,8 +387,8 @@ class ModelGraph:
 
     def edges(
         self,
-        var_names: Iterable[VarName] | None = None,
-    ) -> list[tuple[VarName, VarName]]:
+        var_names: Iterable[str] | None = None,
+    ) -> list[tuple[str, str]]:
         """Get edges between the variables in the model.
 
         Parameters
@@ -405,7 +403,7 @@ class ModelGraph:
 
         """
         return [
-            (VarName(child.replace(":", "&")), VarName(parent.replace(":", "&")))
+            (str(child.replace(":", "&")), str(parent.replace(":", "&")))
             for child, parents in self.make_compute_graph(var_names=var_names).items()
             for parent in parents
         ]
@@ -422,7 +420,7 @@ class ModelGraph:
 def make_graph(
     name: str,
     plates: list[Plate],
-    edges: list[tuple[VarName, VarName]],
+    edges: list[tuple[str, str]],
     formatting: str = "plain",
     save=None,
     figsize=None,
@@ -496,7 +494,7 @@ def make_graph(
 def make_networkx(
     name: str,
     plates: list[Plate],
-    edges: list[tuple[VarName, VarName]],
+    edges: list[tuple[str, str]],
     formatting: str = "plain",
     node_formatters: NodeTypeFormatterMapping | None = None,
     create_plate_label: PlateLabelFunc = create_plate_label_with_dim_length,
@@ -566,7 +564,7 @@ def make_networkx(
 def model_to_networkx(
     model=None,
     *,
-    var_names: Iterable[VarName] | None = None,
+    var_names: Iterable[str] | None = None,
     formatting: str = "plain",
     node_formatters: NodeTypeFormatterMapping | None = None,
     include_dim_lengths: bool = True,
@@ -660,7 +658,7 @@ def model_to_networkx(
 def model_to_graphviz(
     model=None,
     *,
-    var_names: Iterable[VarName] | None = None,
+    var_names: Iterable[str] | None = None,
     formatting: str = "plain",
     save: str | None = None,
     figsize: tuple[int, int] | None = None,

--- a/pymc/util.py
+++ b/pymc/util.py
@@ -18,7 +18,7 @@ import re
 from collections import namedtuple
 from collections.abc import Sequence
 from copy import deepcopy
-from typing import NewType, cast
+from typing import cast
 
 import arviz
 import cloudpickle
@@ -30,8 +30,6 @@ from pytensor import Variable
 from pytensor.compile import SharedVariable
 
 from pymc.exceptions import BlockModelAccessError
-
-VarName = NewType("VarName", str)
 
 
 class _UnsetType:
@@ -214,9 +212,9 @@ def get_default_varnames(var_iterator, include_transformed):
         return [var for var in var_iterator if not is_transformed_name(get_var_name(var))]
 
 
-def get_var_name(var) -> VarName:
+def get_var_name(var) -> str:
     """Get an appropriate, plain variable name for a variable."""
-    return VarName(str(getattr(var, "name", var)))
+    return var if isinstance(var, str) else str(var.name)
 
 
 def get_transformed(z):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
This change:

* Replaces VarName type with built-in `str`
* Updates `get_var_name` to have it work without getattr

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7843
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7855.org.readthedocs.build/en/7855/

<!-- readthedocs-preview pymc end -->