### PR TITLE
Fix `independent_rvs` determination in `vectorize_over_posterior`

### DIFF
--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -1059,14 +1059,11 @@ def vectorize_over_posterior(
         for rv in general_toposort(  # type: ignore[call-overload]
             all_rvs, lambda x: x.owner.inputs if x.owner is not None else None
         )
-        if rv in all_rvs
+        if rv in all_rvs and rv not in needed_rvs
     ]:
-        rv_ancestors = ancestors([rv], blockers=[*needed_rvs, *independent_rvs, *outputs])
-        if (
-            rv not in needed_rvs
-            and not ({*outputs, *independent_rvs} & set(rv_ancestors))
-            and {var for var in rv_ancestors if var in all_rvs} <= {rv, *needed_rvs}
-        ):
+        blockers = [*needed_rvs, *independent_rvs, *outputs]
+        rv_ancestors = ancestors([rv], blockers=blockers)
+        if not (set(blockers) & set(rv_ancestors)):
             independent_rvs.append(rv)
     for rv in independent_rvs:
         replace_dict[rv] = change_dist_size(rv, new_size=batch_shape, expand=True)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
This PR fixes the determination of `independent_rvs` RVs in `vectorize_over_posterior`. I think that the fixed check is much clearer now. It says that an `rv` is independent if it doesn't depend on an `output`, a `needed_rv` (a model freeRV that is replaced by its posterior samples), or another `independent_rv`. To make sure the check works correctly, the candidate rv nodes are searched in the order given by their topological sort.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [X] Closes #7889
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [X] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [X] Included tests that prove the fix is effective or that the new feature works
- [X] Added necessary documentation (docstrings and/or example notebooks)
- [X] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [X] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7890.org.readthedocs.build/en/7890/

<!-- readthedocs-preview pymc end -->