### PR TITLE
doc: remove `MutableData`

### DIFF
--- a/docs/source/api/data.rst
+++ b/docs/source/api/data.rst
@@ -6,8 +6,6 @@ Data
 .. autosummary::
    :toctree: generated/
 
-   ConstantData
-   MutableData
-   get_data
    Data
+   get_data
    Minibatch

--- a/pymc/gp/hsgp_approx.py
+++ b/pymc/gp/hsgp_approx.py
@@ -620,7 +620,7 @@ class HSGPPeriodic(Base):
         they may share the same basis.
 
         Correct results when using `prior_linearized` in tandem with
-        `pm.set_data` and `pm.MutableData` require that the `Xs` are
+        `pm.set_data` and `pm.Data` require that the `Xs` are
         zero-centered, so its mean must be subtracted.
 
         An example is given below.

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -607,8 +607,8 @@ def sample_posterior_predictive(
 
         import pymc as pm
 
-        with pm.Model(coords_mutable={"trial": [0, 1, 2]}) as model:
-            x = pm.MutableData("x", [-1, 0, 1], dims=["trial"])
+        with pm.Model(coords={"trial": [0, 1, 2]}) as model:
+            x = pm.Data("x", [-1, 0, 1], dims=["trial"])
             beta = pm.Normal("beta")
             noise = pm.HalfNormal("noise")
             y = pm.Normal("y", mu=x * beta, sigma=noise, observed=[-2, 0, 3], dims=["trial"])
@@ -634,8 +634,8 @@ def sample_posterior_predictive(
 
     .. code-block:: python
 
-        with pm.Model(coords_mutable={"trial": [3, 4]}) as predictions_model:
-            x = pm.MutableData("x", [-2, 2], dims=["trial"])
+        with pm.Model(coords={"trial": [3, 4]}) as predictions_model:
+            x = pm.Data("x", [-2, 2], dims=["trial"])
             beta = pm.Normal("beta")
             noise = pm.HalfNormal("noise")
             y = pm.Normal("y", mu=x * beta, sigma=noise, dims=["trial"])
@@ -651,8 +651,8 @@ def sample_posterior_predictive(
 
     .. code-block:: python
 
-        with pm.Model(coords_mutable={"trial": [3, 4]}) as distinct_predictions_model:
-            x = pm.MutableData("x", [-2, 2], dims=["trial"])
+        with pm.Model(coords={"trial": [3, 4]}) as distinct_predictions_model:
+            x = pm.Data("x", [-2, 2], dims=["trial"])
             beta = pm.Normal("beta")
             noise = pm.HalfNormal("noise")
             extra_noise = pm.HalfNormal("extra_noise", sigma=noise)

--- a/tests/distributions/test_censored.py
+++ b/tests/distributions/test_censored.py
@@ -137,15 +137,13 @@ class TestCensored:
 
         # No censoring
         censored_norm = pm.Censored.dist(norm, lower=None, upper=None)
-        with pytest.warns(RuntimeWarning, match=match_str):
-            censored_eval = logcdf(censored_norm, eval_points).eval()
+        censored_eval = logcdf(censored_norm, eval_points).eval()
         np.testing.assert_allclose(censored_eval, expected_logcdf_uncensored)
 
         # Left censoring
         censored_norm = pm.Censored.dist(norm, lower=-1, upper=None)
         expected_left = np.where(eval_points < -1, -np.inf, expected_logcdf_uncensored)
-        with pytest.warns(RuntimeWarning, match=match_str):
-            censored_eval = logcdf(censored_norm, eval_points).eval()
+        censored_eval = logcdf(censored_norm, eval_points).eval()
         np.testing.assert_allclose(
             censored_eval,
             expected_left,
@@ -155,8 +153,7 @@ class TestCensored:
         # Right censoring
         censored_norm = pm.Censored.dist(norm, lower=None, upper=1)
         expected_right = np.where(eval_points >= 1, 0.0, expected_logcdf_uncensored)
-        with pytest.warns(RuntimeWarning, match=match_str):
-            censored_eval = logcdf(censored_norm, eval_points).eval()
+        censored_eval = logcdf(censored_norm, eval_points).eval()
         np.testing.assert_allclose(
             censored_eval,
             expected_right,
@@ -167,8 +164,7 @@ class TestCensored:
         censored_norm = pm.Censored.dist(norm, lower=-1, upper=1)
         expected_interval = np.where(eval_points < -1, -np.inf, expected_logcdf_uncensored)
         expected_interval = np.where(eval_points >= 1, 0.0, expected_interval)
-        with pytest.warns(RuntimeWarning, match=match_str):
-            censored_eval = logcdf(censored_norm, eval_points).eval()
+        censored_eval = logcdf(censored_norm, eval_points).eval()
         np.testing.assert_allclose(
             censored_eval,
             expected_interval,

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -1022,7 +1022,7 @@ class TestSamplePPC:
             caplog.clear()
         elif kind == "Dataset":
             # Dataset has all MCMC posterior samples and the values of the coordinates. This
-            # enables it to see that the coordinates have not changed, but the MutableData is
+            # enables it to see that the coordinates have not changed, but the Data is
             # assumed volatile by default
             assert caplog.record_tuples == [
                 ("pymc.sampling.forward", logging.INFO, "Sampling: [b, y]")
@@ -1031,7 +1031,7 @@ class TestSamplePPC:
 
         original_offsets = model["offsets"].get_value()
         with model:
-            # Changing the MutableData values. This will only be picked up by InferenceData
+            # Changing the Data values. This will only be picked up by InferenceData
             pm.set_data({"offsets": original_offsets + 1})
             pm.sample_posterior_predictive(samples)
         if kind == "MultiTrace":
@@ -1072,7 +1072,7 @@ class TestSamplePPC:
             caplog.clear()
 
         with model:
-            # Changing the mutable coordinate values, but not shape, and also changing MutableData.
+            # Changing the mutable coordinate values, but not shape, and also changing Data.
             # This will trigger resampling of all variables
             model.set_dim("name", new_length=3, coord_values=["A", "B", "D"])
             pm.set_data({"offsets": original_offsets + 1, "y_obs": np.zeros((10, 3))})


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
  - Replace deprecated `pm.MutableData` references with `pm.Data`
  - Fix docstring examples to use correct `coords` parameter
## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #7047 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7900.org.readthedocs.build/en/7900/

<!-- readthedocs-preview pymc end -->