### PR TITLE
Use `dict_to_dataset_drop_incompatible_coords` everywhere

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -33,7 +33,7 @@ from typing import (
 import numpy as np
 import pytensor.gradient as tg
 
-from arviz import InferenceData, dict_to_dataset
+from arviz import InferenceData
 from arviz.data.base import make_attrs
 from pytensor.graph.basic import Variable
 from rich.theme import Theme
@@ -45,6 +45,7 @@ import pymc as pm
 from pymc.backends import RunType, TraceOrBackend, init_traces
 from pymc.backends.arviz import (
     coords_and_dims_for_inferencedata,
+    dict_to_dataset_drop_incompatible_coords,
     find_constants,
     find_observations,
 )
@@ -355,14 +356,14 @@ def _sample_external_nuts(
         # Temporary work-around. Revert once https://github.com/pymc-devs/nutpie/issues/74 is fixed
         # gather observed and constant data as nutpie.sample() has no access to the PyMC model
         coords, dims = coords_and_dims_for_inferencedata(model)
-        constant_data = dict_to_dataset(
+        constant_data = dict_to_dataset_drop_incompatible_coords(
             find_constants(model),
             library=pm,
             coords=coords,
             dims=dims,
             default_dims=[],
         )
-        observed_data = dict_to_dataset(
+        observed_data = dict_to_dataset_drop_incompatible_coords(
             find_observations(model),
             library=pm,
             coords=coords,

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -33,7 +33,7 @@ from rich.progress import (
 
 import pymc
 
-from pymc.backends.arviz import dict_to_dataset, to_inference_data
+from pymc.backends.arviz import dict_to_dataset_drop_incompatible_coords, to_inference_data
 from pymc.backends.base import MultiTrace
 from pymc.distributions.custom import CustomDistRV, CustomSymbolicDistRV
 from pymc.distributions.distribution import _support_point
@@ -264,7 +264,7 @@ def _save_sample_stats(
             else:
                 sample_stats_dict[stat] = np.array(value)
 
-        sample_stats = dict_to_dataset(
+        sample_stats = dict_to_dataset_drop_incompatible_coords(
             sample_stats_dict,
             attrs=sample_settings_dict,
             library=pymc,


### PR DESCRIPTION
Closes #7891 

The example in that issue:

```python
import pymc as pm

with pm.Model(coords={'dim_1': ['a', 'b', 'c'], 'other': [1, 2, 3, 4]}) as m:
    x = pm.Normal('x', mu=0, sigma=1, dims=['dim_1'])
    mu = pm.Deterministic('mu', 1 + x, dims=['other'])
    sigma = pm.HalfNormal('sigma', 1)

    y = pm.Normal('y', mu=mu, sigma=sigma, dims=['dim_1'])
    idata = pm.sample()
    
```
Outputs

```
UserWarning: Incompatible coordinate length of 4 for dimension 'other' of variable 'mu'.
The original coordinates for this dim will not be included in the returned dataset for any of the variables. Instead they will default to `np.arange`, possibly right-padded with nan.
To make this warning into an error set `pymc.backends.arviz.RAISE_ON_INCOMPATIBLE_COORD_LENGTHS` to `True`
```

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7908.org.readthedocs.build/en/7908/

<!-- readthedocs-preview pymc end -->