### PR TITLE
Fix print name of `LogitNormal` and `DiscreteWeibull`

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -2577,20 +2577,12 @@ class ChiSquared:
         Degrees of freedom (nu > 0).
     """
 
-    name = "chi_squared"
-    extended_signature = "[rng],[size],(),()->[rng],()"
-    _print_name = ("ChiSquared", "\\operatorname{ChiSquared}")
-
     def __new__(cls, name, nu, **kwargs):
-        obj = Gamma(name, alpha=nu / 2, beta=1 / 2, **kwargs)
-        obj.owner.op._print_name = cls._print_name
-        return obj
+        return Gamma(name, alpha=nu / 2, beta=1 / 2, **kwargs)
 
     @classmethod
     def dist(cls, nu, **kwargs):
-        obj = Gamma.dist(alpha=nu / 2, beta=1 / 2, **kwargs)
-        obj.owner.op._print_name = cls._print_name
-        return obj
+        return Gamma.dist(alpha=nu / 2, beta=1 / 2, **kwargs)
 
 
 class WeibullBetaRV(SymbolicRandomVariable):

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -2532,22 +2532,7 @@ class InverseGamma(PositiveContinuous):
         )
 
 
-class ChiSquaredRV(RandomVariable):
-    name = "chi_squared"
-    signature = "()->()"
-    dtype = "floatX"
-    _print_name = ("ChiSquared", "\\operatorname{ChiSquared}")
-
-    @classmethod
-    def rng_fn(cls, rng, nu, size=None):
-        alpha = np.asarray(nu) / 2.0
-        return np.asarray(Gamma.rv_op.rng_fn(rng, alpha, 2.0, size=size))
-
-
-chi_squared = ChiSquaredRV()
-
-
-class ChiSquared(PositiveContinuous):
+class ChiSquared:
     r"""
     :math:`\chi^2` distribution.
 
@@ -2592,27 +2577,20 @@ class ChiSquared(PositiveContinuous):
         Degrees of freedom (nu > 0).
     """
 
-    rv_op = chi_squared
+    name = "chi_squared"
+    extended_signature = "[rng],[size],(),()->[rng],()"
+    _print_name = ("ChiSquared", "\\operatorname{ChiSquared}")
+
+    def __new__(cls, name, nu, **kwargs):
+        obj = Gamma(name, alpha=nu / 2, beta=1 / 2, **kwargs)
+        obj.owner.op._print_name = cls._print_name
+        return obj
 
     @classmethod
-    def dist(cls, nu, *args, **kwargs):
-        nu = pt.as_tensor_variable(nu)
-        return super().dist([nu], *args, **kwargs)
-
-    def support_point(rv, size, nu):
-        mean = nu
-        if not rv_size_is_none(size):
-            mean = pt.full(size, mean)
-        return mean
-
-    def logp(value, nu):
-        return Gamma.logp(value, alpha=nu / 2, scale=2)
-
-    def logcdf(value, nu):
-        return Gamma.logcdf(value, alpha=nu / 2, scale=2)
-
-    def icdf(value, nu):
-        return Gamma.icdf(value, alpha=nu / 2, scale=2)
+    def dist(cls, nu, **kwargs):
+        obj = Gamma.dist(alpha=nu / 2, beta=1 / 2, **kwargs)
+        obj.owner.op._print_name = cls._print_name
+        return obj
 
 
 class WeibullBetaRV(SymbolicRandomVariable):

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -2575,6 +2575,11 @@ class ChiSquared:
     ----------
     nu : tensor_like of float
         Degrees of freedom (nu > 0).
+
+    Notes
+    -----
+    This is implemented as a special case of the Gamma distribution.
+    :math:`\chi^2(\nu) = \text{Gamma}(\alpha=\nu/2, \beta=1/2)`
     """
 
     def __new__(cls, name, nu, **kwargs):

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -2532,7 +2532,22 @@ class InverseGamma(PositiveContinuous):
         )
 
 
-class ChiSquared:
+class ChiSquaredRV(RandomVariable):
+    name = "chi_squared"
+    signature = "()->()"
+    dtype = "floatX"
+    _print_name = ("ChiSquared", "\\operatorname{ChiSquared}")
+
+    @classmethod
+    def rng_fn(cls, rng, nu, size=None):
+        alpha = np.asarray(nu) / 2.0
+        return np.asarray(Gamma.rv_op.rng_fn(rng, alpha, 2.0, size=size))
+
+
+chi_squared = ChiSquaredRV()
+
+
+class ChiSquared(PositiveContinuous):
     r"""
     :math:`\chi^2` distribution.
 
@@ -2577,12 +2592,27 @@ class ChiSquared:
         Degrees of freedom (nu > 0).
     """
 
-    def __new__(cls, name, nu, **kwargs):
-        return Gamma(name, alpha=nu / 2, beta=1 / 2, **kwargs)
+    rv_op = chi_squared
 
     @classmethod
-    def dist(cls, nu, **kwargs):
-        return Gamma.dist(alpha=nu / 2, beta=1 / 2, **kwargs)
+    def dist(cls, nu, *args, **kwargs):
+        nu = pt.as_tensor_variable(nu)
+        return super().dist([nu], *args, **kwargs)
+
+    def support_point(rv, size, nu):
+        mean = nu
+        if not rv_size_is_none(size):
+            mean = pt.full(size, mean)
+        return mean
+
+    def logp(value, nu):
+        return Gamma.logp(value, alpha=nu / 2, scale=2)
+
+    def logcdf(value, nu):
+        return Gamma.logcdf(value, alpha=nu / 2, scale=2)
+
+    def icdf(value, nu):
+        return Gamma.icdf(value, alpha=nu / 2, scale=2)
 
 
 class WeibullBetaRV(SymbolicRandomVariable):
@@ -3601,7 +3631,7 @@ class Logistic(Continuous):
 class LogitNormalRV(SymbolicRandomVariable):
     name = "logit_normal"
     extended_signature = "[rng],[size],(),()->[rng],()"
-    _print_name = ("logitNormal", "\\operatorname{logitNormal}")
+    _print_name = ("LogitNormal", "\\operatorname{LogitNormal}")
 
     @classmethod
     def rv_op(cls, mu, sigma, *, size=None, rng=None):

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -393,7 +393,7 @@ class Bernoulli(Discrete):
 class DiscreteWeibullRV(SymbolicRandomVariable):
     name = "discrete_weibull"
     extended_signature = "[rng],[size],(),()->[rng],()"
-    _print_name = ("dWeibull", "\\operatorname{dWeibull}")
+    _print_name = ("DiscreteWeibull", "\\operatorname{DiscreteWeibull}")
 
     @classmethod
     def rv_op(cls, q, beta, *, size=None, rng=None):


### PR DESCRIPTION
`dist.owner.op._print_name[0]` was returning incorrect names for:
* DiscreteWibull and LogitNormal, as they did not follow the conventions used for the rest of the distributions
* ~ChiSquared was returning "Gamma", because it's implemented as a special case of Gamma.~

~Not sure if there is a simpler way to fix the issue for ChiSquared.~

<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7935.org.readthedocs.build/en/7935/

<!-- readthedocs-preview pymc end -->