### PR TITLE
Approximation's sample method uses model contexts

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1731,9 +1731,10 @@ def init_nuts(
             obj_optimizer=pm.adagrad_window,
             compile_kwargs=compile_kwargs,
         )
-        approx_sample = approx.sample(
-            draws=chains, random_seed=random_seed_list[0], return_inferencedata=False
-        )
+        with model:
+            approx_sample = approx.sample(
+                draws=chains, random_seed=random_seed_list[0], return_inferencedata=False
+            )
         initial_points = [
             {k: np.asarray(v) for k, v in approx_sample[i].items()} for i in range(chains)
         ]
@@ -1757,9 +1758,10 @@ def init_nuts(
             obj_optimizer=pm.adagrad_window,
             compile_kwargs=compile_kwargs,
         )
-        approx_sample = approx.sample(
-            draws=chains, random_seed=random_seed_list[0], return_inferencedata=False
-        )
+        with model:
+            approx_sample = approx.sample(
+                draws=chains, random_seed=random_seed_list[0], return_inferencedata=False
+            )
         initial_points = [
             {k: np.asarray(v) for k, v in approx_sample[i].items()} for i in range(chains)
         ]
@@ -1777,9 +1779,10 @@ def init_nuts(
             obj_optimizer=pm.adagrad_window,
             compile_kwargs=compile_kwargs,
         )
-        approx_sample = approx.sample(
-            draws=chains, random_seed=random_seed_list[0], return_inferencedata=False
-        )
+        with model:
+            approx_sample = approx.sample(
+                draws=chains, random_seed=random_seed_list[0], return_inferencedata=False
+            )
         initial_points = [
             {k: np.asarray(v) for k, v in approx_sample[i].items()} for i in range(chains)
         ]

--- a/pymc/variational/approximations.py
+++ b/pymc/variational/approximations.py
@@ -329,7 +329,8 @@ def sample_approx(approx, draws=100, include_transformed=True):
     trace: class:`pymc.backends.base.MultiTrace`
         Samples drawn from variational posterior.
     """
-    return approx.sample(draws=draws, include_transformed=include_transformed)
+    with approx.model:
+        return approx.sample(draws=draws, include_transformed=include_transformed)
 
 
 # single group shortcuts exported to user

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1564,8 +1564,10 @@ class Approximation(WithMemoization):
             for i in range(draws)
         )
 
+        model = modelcontext(None)
+
         trace = NDArray(
-            model=self.model,
+            model=model,
             test_point={name: np.asarray(records[0]) for name, records in samples.items()},
         )
         try:
@@ -1579,7 +1581,7 @@ class Approximation(WithMemoization):
         if not return_inferencedata:
             return multi_trace
         else:
-            return pm.to_inference_data(multi_trace, model=self.model, **kwargs)
+            return pm.to_inference_data(multi_trace, model=model, **kwargs)
 
     @property
     def ndim(self):

--- a/pymc/variational/opvi.py
+++ b/pymc/variational/opvi.py
@@ -1229,7 +1229,10 @@ class Approximation(WithMemoization):
             else:
                 rest.__init_group__(unseen_free_RVs)
                 self.groups.append(rest)
-        self.model = model
+
+    @property
+    def model(self):
+        return modelcontext(self.groups[0].model if self.groups else None)
 
     @property
     def has_logq(self):
@@ -1503,14 +1506,8 @@ class Approximation(WithMemoization):
 
         This node still needs :func:`set_size_and_deterministic` to be evaluated.
         """
-
-        def vars_names(vs):
-            return {self.model.rvs_to_values[v].name for v in vs}
-
-        for vars_, random, ordering in zip(
-            self.collect("group"), self.symbolic_randoms, self.collect("ordering")
-        ):
-            if name in vars_names(vars_):
+        for random, ordering in zip(self.symbolic_randoms, self.collect("ordering")):
+            if name in ordering:
                 name_, slc, shape, dtype = ordering[name]
                 found = random[..., slc].reshape((random.shape[0], *shape)).astype(dtype)
                 found.name = name + "_vi_random_slice"
@@ -1522,7 +1519,7 @@ class Approximation(WithMemoization):
     @node_property
     def sample_dict_fn(self):
         s = pt.iscalar()
-        names = [self.model.rvs_to_values[v].name for v in self.model.free_RVs]
+        names = [name for ordering in self.collect("ordering") for name in ordering]
         sampled = [self.rslice(name) for name in names]
         sampled = self.set_size_and_deterministic(sampled, s, 0)
         sample_fn = compile([s], sampled)

--- a/tests/variational/test_inference.py
+++ b/tests/variational/test_inference.py
@@ -448,7 +448,7 @@ def test_fit_data_coords(hierarchical_model, hierarchical_model_data):
         assert data["mu"].shape == ()
 
 
-def test_sample_posterior_predictive_after_set_data():
+def test_sample_posterior_after_minibatch():
     with pm.Model(coords={"obs_id": [0, 1, 2]}) as model:
         x = pm.Data("x", [1.0, 2.0, 3.0], dims="obs_id")
         y = pm.Data("y", [1.0, 2.0, 3.0], dims="obs_id")

--- a/tests/variational/test_inference.py
+++ b/tests/variational/test_inference.py
@@ -444,6 +444,27 @@ def test_fit_data_coords(hierarchical_model, hierarchical_model_data):
         assert data["mu"].shape == ()
 
 
+def test_sample_posterior_predictive_after_set_data():
+    y = np.array([1.0, 2.0, 3.0])
+    with pm.Model(coords={"obs_id": [0, 1, 2]}) as model:
+        x = pm.Data("x", [1.0, 2.0, 3.0], dims="obs_id")
+        beta = pm.Normal("beta", 0, 10.0)
+        pm.Normal("obs", beta * x, np.sqrt(1e-2), observed=y, dims="obs_id")
+        approx = pm.fit(
+            10,
+            method="advi",
+            progressbar=False,
+        )
+        trace = approx.sample(500)
+
+    with model:
+        x_test = [5, 6, 9, 12, 15]
+        pm.set_data(new_data={"x": x_test}, coords={"obs_id": list(range(len(x_test)))})
+        y_test = pm.sample_posterior_predictive(trace, predictions=True, progressbar=False)
+
+    assert y_test.predictions["obs"].shape == (1, 500, 5)
+
+
 def test_multiple_minibatch_variables():
     """Regression test for bug reported in
     https://discourse.pymc.io/t/verifying-that-minibatch-is-actually-randomly-sampling/14308

--- a/tests/variational/test_inference.py
+++ b/tests/variational/test_inference.py
@@ -14,6 +14,7 @@
 
 import io
 import operator
+import warnings
 
 import cloudpickle
 import numpy as np
@@ -24,6 +25,7 @@ import pytest
 import pymc as pm
 import pymc.variational.opvi as opvi
 
+from pymc.model.transform.basic import remove_minibatched_nodes
 from pymc.variational.inference import ADVI, ASVGD, SVGD, FullRankADVI
 from pymc.variational.opvi import NotImplementedInference
 from tests import models
@@ -174,8 +176,9 @@ def fit_kwargs(inference, use_minibatch):
     return _select[(type(inference), key)]
 
 
-def test_fit_oo(inference, fit_kwargs, simple_model_data):
-    trace = inference.fit(**fit_kwargs).sample(10000)
+def test_fit_oo(inference, fit_kwargs, simple_model, simple_model_data):
+    with simple_model:
+        trace = inference.fit(**fit_kwargs).sample(10000)
     mu_post = simple_model_data["mu_post"]
     d = simple_model_data["d"]
     np.testing.assert_allclose(np.mean(trace.posterior["mu"]), mu_post, rtol=0.05)
@@ -202,7 +205,8 @@ def test_fit_start(inference_spec, simple_model):
         inference = inference_spec(**kw)
 
     try:
-        trace = inference.fit(n=0).sample(10000)
+        with simple_model:
+            trace = inference.fit(n=0).sample(10000)
     except NotImplementedInference as e:
         pytest.skip(str(e))
 
@@ -448,24 +452,26 @@ def test_sample_posterior_predictive_after_set_data():
     with pm.Model(coords={"obs_id": [0, 1, 2]}) as model:
         x = pm.Data("x", [1.0, 2.0, 3.0], dims="obs_id")
         y = pm.Data("y", [1.0, 2.0, 3.0], dims="obs_id")
+        x_mini, y_mini = pm.Minibatch(x, y, batch_size=2)
         beta = pm.Normal("beta", 0, 10.0)
-        pm.Normal("obs", beta * x, np.sqrt(1e-2), observed=y, dims="obs_id")
+        y_hat = pm.Deterministic("y_hat", beta * x_mini, dims="obs_id")
+        pm.Normal("obs", y_hat, np.sqrt(1e-2), observed=y_mini, total_size=3, dims="obs_id")
         approx = pm.fit(
             10,
             method="advi",
             progressbar=False,
         )
-        pm.set_data(
-            new_data={"x": [4.0, 5.0], "y": [4.0, 5.0]},
-            coords={"obs_id": [0, 1]},
-        )
+
+    model_post = remove_minibatched_nodes(model)
+    with model_post:
         trace = approx.sample(500)
 
     assert trace.posterior["beta"].shape == (1, 500)
-    assert trace.constant_data["x"].shape == (2,)
-    assert trace.observed_data["obs"].shape == (2,)
+    assert trace.constant_data["x"].shape == (3,)
+    assert trace.observed_data["obs"].shape == (3,)
 
-    with model:
+    with model_post, warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "Numba will use object mode", UserWarning)
         x_test = [5, 6, 9, 12, 15]
         pm.set_data(
             new_data={"x": x_test, "y": [0.0] * len(x_test)},

--- a/tests/variational/test_inference.py
+++ b/tests/variational/test_inference.py
@@ -445,9 +445,9 @@ def test_fit_data_coords(hierarchical_model, hierarchical_model_data):
 
 
 def test_sample_posterior_predictive_after_set_data():
-    y = np.array([1.0, 2.0, 3.0])
     with pm.Model(coords={"obs_id": [0, 1, 2]}) as model:
         x = pm.Data("x", [1.0, 2.0, 3.0], dims="obs_id")
+        y = pm.Data("y", [1.0, 2.0, 3.0], dims="obs_id")
         beta = pm.Normal("beta", 0, 10.0)
         pm.Normal("obs", beta * x, np.sqrt(1e-2), observed=y, dims="obs_id")
         approx = pm.fit(
@@ -455,11 +455,22 @@ def test_sample_posterior_predictive_after_set_data():
             method="advi",
             progressbar=False,
         )
+        pm.set_data(
+            new_data={"x": [4.0, 5.0], "y": [4.0, 5.0]},
+            coords={"obs_id": [0, 1]},
+        )
         trace = approx.sample(500)
+
+    assert trace.posterior["beta"].shape == (1, 500)
+    assert trace.constant_data["x"].shape == (2,)
+    assert trace.observed_data["obs"].shape == (2,)
 
     with model:
         x_test = [5, 6, 9, 12, 15]
-        pm.set_data(new_data={"x": x_test}, coords={"obs_id": list(range(len(x_test)))})
+        pm.set_data(
+            new_data={"x": x_test, "y": [0.0] * len(x_test)},
+            coords={"obs_id": list(range(len(x_test)))},
+        )
         y_test = pm.sample_posterior_predictive(trace, predictions=True, progressbar=False)
 
     assert y_test.predictions["obs"].shape == (1, 500, 5)

--- a/tests/variational/test_opvi.py
+++ b/tests/variational/test_opvi.py
@@ -208,24 +208,27 @@ def three_var_approx_single_group_mf(three_var_model):
     return MeanField(model=three_var_model)
 
 
-def test_pickle_approx(three_var_approx):
+def test_pickle_approx(three_var_model, three_var_approx):
     import cloudpickle
 
     dump = cloudpickle.dumps(three_var_approx)
     new = cloudpickle.loads(dump)
-    assert new.sample(1)
+    with three_var_model:
+        assert new.sample(1)
 
 
-def test_pickle_single_group(three_var_approx_single_group_mf):
+def test_pickle_single_group(three_var_model, three_var_approx_single_group_mf):
     import cloudpickle
 
     dump = cloudpickle.dumps(three_var_approx_single_group_mf)
     new = cloudpickle.loads(dump)
-    assert new.sample(1)
+    with three_var_model:
+        assert new.sample(1)
 
 
-def test_sample_simple(three_var_approx):
-    trace = three_var_approx.sample(100, return_inferencedata=False)
+def test_sample_simple(three_var_model, three_var_approx):
+    with three_var_model:
+        trace = three_var_approx.sample(100, return_inferencedata=False)
     assert set(trace.varnames) == {"one", "one_log__", "three", "two"}
     assert len(trace) == 100
     assert trace[0]["one"].shape == (10, 2)


### PR DESCRIPTION
This change makes it so calling `sample` on fitted approximations uses the model context or an explicitly provided model. Previously, this had a hard assumption that we only want to sample from the same model as the one we fitted.

This also deprecates `self.model`.

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7940.org.readthedocs.build/en/7940/

<!-- readthedocs-preview pymc end -->