### PR TITLE
[BUG] Replace deprecated batched_dot with pt.sum in KroneckerNormal

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2124,8 +2124,8 @@ class KroneckerNormal(Continuous):
         sqrt_quad = sqrt_quad / pt.sqrt(eigs[:, None])
         logdet = pt.sum(pt.log(eigs))
 
-        # Square each sample
-        quad = pt.batched_dot(sqrt_quad.T, sqrt_quad.T)
+        # Square each sample - compute squared norm for each sample
+        quad = pt.sum(sqrt_quad.T ** 2, axis=-1)
         if onedim:
             quad = quad[0]
 

--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -2125,7 +2125,7 @@ class KroneckerNormal(Continuous):
         logdet = pt.sum(pt.log(eigs))
 
         # Square each sample - compute squared norm for each sample
-        quad = pt.sum(sqrt_quad.T ** 2, axis=-1)
+        quad = pt.sum(sqrt_quad.T**2, axis=-1)
         if onedim:
             quad = quad[0]
 


### PR DESCRIPTION
- Fixes Issue #7878
- Replace pt.batched_dot(sqrt_quad.T, sqrt_quad.T) with pt.sum(sqrt_quad.T ** 2, axis=-1)
- Computes squared norm per sample using modern PyTensor operations
- Eliminates deprecation warnings and ensures future compatibility

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc start -->
----
📚 Documentation preview 📚: https://pymc--7942.org.readthedocs.build/en/7942/

<!-- readthedocs-preview pymc end -->