### PR TITLE
spelling fixing from focussing to focusing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -270,7 +270,7 @@ Domain specific
 
 - `Exoplanet <https://github.com/dfm/exoplanet>`__: a toolkit for modeling of transit and/or radial velocity observations of exoplanets and other astronomical time series.
 - `beat <https://github.com/hvasbath/beat>`__: Bayesian Earthquake Analysis Tool.
-- `CausalPy <https://github.com/pymc-labs/CausalPy>`__: A package focussing on causal inference in quasi-experimental settings.
+- `CausalPy <https://github.com/pymc-labs/CausalPy>`__: A package focusing on causal inference in quasi-experimental settings.
 - `PyMC-Marketing <https://github.com/pymc-labs/pymc-marketing>`__: Bayesian marketing toolbox for marketing mix modeling, customer lifetime value, and more.
 
 See also the `ecosystem page <https://www.pymc.io/about/ecosystem.html>`__ on our website. Please contact us if your software is not listed here.


### PR DESCRIPTION
Fixes #7847

This PR fixes the spelling of "focussing" to "focusing" in the README.rst file as reported in issue #7847.

**Changed:**
- Line 273: "A package focussing on causal inference" ---------> "A package focusing on causal inference"

This is my first open source contribution. Thank you for reviewing!