### PR TITLE
Tweak run_mypy.py to be more user-friendly

### DIFF
--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -102,11 +102,13 @@ def check_no_unexpected_results(mypy_df: pd.DataFrame, show_expected: bool):
         else:
             print("\nThese files did not fail before. Fix all errors reported in the output above.")
         print("You can run `python scripts/run_mypy.py` to reproduce this test locally.")
-        print(
-            f"\nNote: In addition to these errors, {len(failing.intersection(expected_failing))} errors in files "
-            f'marked as "expected failures" were also found. To see these failures, run: '
-            f"`python scripts/run_mypy.py --show-expected`"
-        )
+
+        if not show_expected:
+            print(
+                f"\nNote: In addition to these errors, {len(failing.intersection(expected_failing))} errors in files "
+                f'marked as "expected failures" were also found. To see these failures, run: '
+                f"`python scripts/run_mypy.py --show-expected`"
+            )
 
         sys.exit(1)
 


### PR DESCRIPTION
Very small changes to reflect how this script is used by developers:

- `--verbose`  is now the default
- By default, "expected" failures are filtered. You can see all failures by passing a `--show-expected` flag.

Justifications:

1. I have never run this command without `--verbose`, so why not?
2. The way this script is used is to fix mypy problems with a specific PR. This requires fixing only the new failures. Unless we're actively working on cleaning up the code base, we're only interested in the new failures.  