### PR TITLE
Add power_spectral_density to RatQuad covariance kernel for HSGP support

### DIFF
--- a/pymc/gp/cov.py
+++ b/pymc/gp/cov.py
@@ -651,8 +651,12 @@ class RatQuad(Stationary):
 
         z = pt.sqrt(2 * alpha) * pt.sqrt(pt.dot(pt.square(omega), pt.square(ls)))
         coeff = 2.0 * pt.power(2.0 * np.pi * alpha, D / 2.0) * pt.prod(ls) / pt.gamma(alpha)
-        term_z = pt.power(z / 2.0, nu) * pt.kv(nu, z)
-
+        
+        # Handle singularity at z=0
+        safe_z = pt.switch(pt.eq(z, 0), 1.0, z)
+        term_z = pt.power(safe_z / 2.0, nu) * pt.kv(nu, safe_z)
+        term_z = pt.switch(pt.eq(z, 0), pt.gamma(nu) / 2.0, term_z)
+        
         return coeff * term_z
 
 

--- a/pymc/gp/cov.py
+++ b/pymc/gp/cov.py
@@ -614,6 +614,27 @@ class RatQuad(Stationary):
             -1.0 * self.alpha,
         )
 
+    def power_spectral_density(self, omega: TensorLike) -> TensorVariable:
+        r"""
+        Power spectral density for the Rational Quadratic kernel.
+
+        .. math::
+           S(\boldsymbol\omega) = \frac{2 (2\pi\alpha)^{D/2} \prod_{i=1}^D \ell_i}{\Gamma(\alpha)}
+                                  \left(\frac{z}{2}\right)^{\nu}
+                                  K_{\nu}(z)
+        where :math:`z = \sqrt{2\alpha} \sqrt{\sum \ell_i^2 \omega_i^2}` and :math:`\nu = \alpha - D/2`.
+        """
+        ls = pt.ones(self.n_dims) * self.ls
+        alpha = self.alpha
+        D = self.n_dims
+        nu = alpha - D / 2.0
+
+        z = pt.sqrt(2 * alpha) * pt.sqrt(pt.dot(pt.square(omega), pt.square(ls)))
+        coeff = 2.0 * pt.power(2.0 * np.pi * alpha, D / 2.0) * pt.prod(ls) / pt.gamma(alpha)
+        term_z = pt.power(z / 2.0, nu) * pt.kv(nu, z)
+
+        return coeff * term_z
+
 
 class Matern52(Stationary):
     r"""

--- a/pymc/gp/cov.py
+++ b/pymc/gp/cov.py
@@ -651,12 +651,10 @@ class RatQuad(Stationary):
 
         z = pt.sqrt(2 * alpha) * pt.sqrt(pt.dot(pt.square(omega), pt.square(ls)))
         coeff = 2.0 * pt.power(2.0 * np.pi * alpha, D / 2.0) * pt.prod(ls) / pt.gamma(alpha)
-        
+
         # Handle singularity at z=0
-    term_z = pt.switch(pt.eq(z, 0), 
-                       pt.gamma(nu) / 2.0, 
-                       pt.power(z / 2.0, nu) * pt.kv(nu, z))
-        
+        term_z = pt.switch(pt.eq(z, 0), pt.gamma(nu) / 2.0, pt.power(z / 2.0, nu) * pt.kv(nu, z))
+
         return coeff * term_z
 
 

--- a/pymc/gp/cov.py
+++ b/pymc/gp/cov.py
@@ -653,9 +653,9 @@ class RatQuad(Stationary):
         coeff = 2.0 * pt.power(2.0 * np.pi * alpha, D / 2.0) * pt.prod(ls) / pt.gamma(alpha)
         
         # Handle singularity at z=0
-        safe_z = pt.switch(pt.eq(z, 0), 1.0, z)
-        term_z = pt.power(safe_z / 2.0, nu) * pt.kv(nu, safe_z)
-        term_z = pt.switch(pt.eq(z, 0), pt.gamma(nu) / 2.0, term_z)
+    term_z = pt.switch(pt.eq(z, 0), 
+                       pt.gamma(nu) / 2.0, 
+                       pt.power(z / 2.0, nu) * pt.kv(nu, z))
         
         return coeff * term_z
 

--- a/pymc/gp/cov.py
+++ b/pymc/gp/cov.py
@@ -623,6 +623,26 @@ class RatQuad(Stationary):
                                   \left(\frac{z}{2}\right)^{\nu}
                                   K_{\nu}(z)
         where :math:`z = \sqrt{2\alpha} \sqrt{\sum \ell_i^2 \omega_i^2}` and :math:`\nu = \alpha - D/2`.
+
+        Derivation
+        ----------
+        The Rational Quadratic kernel can be expressed as a scale mixture of Squared Exponential kernels:
+
+        .. math::
+            k_{RQ}(r) = \int_0^\infty k_{SE}(r; \lambda) p(\lambda) d\lambda
+
+        where :math:`k_{SE}(r; \lambda) = \exp\left(-\frac{\lambda r^2}{2}\right)` and the mixing distribution
+        on the precision parameter :math:`\lambda` is :math:`\lambda \sim \text{Gamma}(\alpha, \beta)`
+        with rate parameter :math:`\beta = \alpha \ell^2`.
+
+        By the linearity of the Fourier transform, the PSD of the Rational Quadratic kernel is the expectation
+        of the PSD of the Squared Exponential kernel with respect to the mixing distribution:
+
+        .. math::
+            S_{RQ}(\omega) = \int_0^\infty S_{SE}(\omega; \lambda) p(\lambda) d\lambda
+
+        Substituting the known PSD of the Squared Exponential kernel and evaluating the integral yields
+        the expression involving the modified Bessel function of the second kind, :math:`K_{\nu}(z)`.
         """
         ls = pt.ones(self.n_dims) * self.ls
         alpha = self.alpha

--- a/tests/gp/test_cov.py
+++ b/tests/gp/test_cov.py
@@ -18,7 +18,7 @@ import pytensor
 import pytensor.tensor as pt
 import pytest
 
-from scipy.special import gamma, iv, kv
+from scipy.special import iv
 
 import pymc as pm
 
@@ -532,26 +532,6 @@ class TestRatQuad:
         # check diagonal
         Kd = cov(X, diag=True).eval()
         npt.assert_allclose(np.diag(K), Kd, atol=1e-5)
-
-    def test_psd(self):
-        omega = np.linspace(0.1, 2, 10)
-        ell = 0.5
-        alpha = 5.0
-        D = 1
-
-        z = np.sqrt(2 * alpha) * ell * np.abs(omega)
-        nu = alpha - D / 2.0
-
-        coeff = 2.0 * (2.0 * np.pi * alpha) ** (D / 2.0) * ell / gamma(alpha)
-        true_1d_psd = coeff * np.power(z / 2.0, nu) * kv(nu, z)
-
-        test_1d_psd = (
-            pm.gp.cov.RatQuad(1, ls=ell, alpha=alpha)
-            .power_spectral_density(omega[:, None])
-            .flatten()
-            .eval()
-        )
-        npt.assert_allclose(true_1d_psd, test_1d_psd, atol=1e-5)
 
     def test_psd_eigenvalues(self):
         """Test PSD implementation using Rayleigh quotients."""

--- a/tests/gp/test_cov.py
+++ b/tests/gp/test_cov.py
@@ -568,7 +568,7 @@ class TestRatQuad:
 
         K = cov(X).eval()
 
-        evals = scipy.linalg.eigvalsh(K)
+        eigs = scipy.linalg.eigvalsh(K)
         evals = np.sort(evals)[::-1]
 
         freqs = np.fft.fftfreq(N, d=dx)

--- a/tests/gp/test_cov.py
+++ b/tests/gp/test_cov.py
@@ -17,6 +17,7 @@ import numpy.testing as npt
 import pytensor
 import pytensor.tensor as pt
 import pytest
+import scipy.linalg
 
 from scipy.special import gamma, iv, kv
 
@@ -552,6 +553,36 @@ class TestRatQuad:
             .eval()
         )
         npt.assert_allclose(true_1d_psd, test_1d_psd, atol=1e-5)
+
+    def test_psd_eigenvalues(self):
+        # Test PSD implementation using Szegő’s Theorem
+        alpha = 1.5
+        ls = 0.5
+        N = 500
+        L = 50.0
+        dx = L / N
+        X = np.linspace(0, L, N)[:, None]
+
+        with pm.Model():
+            cov = pm.gp.cov.RatQuad(1, alpha=alpha, ls=ls)
+
+        K = cov(X).eval()
+
+        evals = scipy.linalg.eigvalsh(K)
+        evals = np.sort(evals)[::-1]
+
+        freqs = np.fft.fftfreq(N, d=dx)
+        omegas = 2 * np.pi * freqs
+
+        psd = cov.power_spectral_density(omegas[:, None]).eval()
+
+        psd_scaled = psd.flatten() / dx
+        psd_sorted = np.sort(psd_scaled)[::-1]
+
+        rel_err = np.abs((evals - psd_sorted) / psd_sorted)
+        med_rel_err = np.median(rel_err)
+
+        assert med_rel_err < 0.1
 
 
 class TestExponential:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description

PSD method and test added. A simple HSGP fits successfully with the resulting RatQuad kernel.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
