### PR TITLE
Use bash instead of cmd for Windows CI jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -201,7 +201,7 @@ jobs:
       PYTENSOR_FLAGS: floatX=${{ matrix.floatx }}
     defaults:
       run:
-        shell: cmd /C call {0}
+        shell: bash -leo pipefail {0}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -212,7 +212,7 @@ jobs:
           create-args: >-
             python=${{matrix.python-version}}
           environment-name: pymc-test
-          init-shell: cmd.exe
+          init-shell: bash
           cache-environment: true
       - name: Install-pymc
         run: |
@@ -220,10 +220,8 @@ jobs:
           python --version
           micromamba list
       - name: Run tests
-        # This job uses a cmd shell, therefore the environment variable syntax is different!
-        # The ">-" in the next line replaces newlines with spaces (see https://stackoverflow.com/a/66809682).
-        run: >-
-          python -m pytest -vv --cov=pymc --cov-report=xml --no-cov-on-fail --cov-report term --durations=50 %TEST_SUBSET%
+        run: |
+          python -m pytest -vv --cov=pymc --cov-report=xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
@@ -357,7 +355,7 @@ jobs:
       PYTENSOR_FLAGS: floatX=${{ matrix.floatx }}
     defaults:
       run:
-        shell: cmd /C call {0}
+        shell: bash -leo pipefail {0}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -368,7 +366,7 @@ jobs:
           create-args: >-
             python=${{matrix.python-version}}
           environment-name: pymc-test
-          init-shell: cmd.exe
+          init-shell: bash
           cache-environment: true
       - name: Install-pymc
         run: |
@@ -376,10 +374,8 @@ jobs:
           python --version
           micromamba list
       - name: Run tests
-        # This job uses a cmd shell, therefore the environment variable syntax is different!
-        # The ">-" in the next line replaces newlines with spaces (see https://stackoverflow.com/a/66809682).
-        run: >-
-          python -m pytest -vv --cov=pymc --cov-report=xml --no-cov-on-fail --cov-report term --durations=50 %TEST_SUBSET%
+        run: |
+          python -m pytest -vv --cov=pymc --cov-report=xml --no-cov-on-fail --cov-report term --durations=50 $TEST_SUBSET
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

Using `cmd` was causing zizmor to crash (https://github.com/zizmorcore/zizmor/issues/1414). Given that it's been 5 days and I'm the first one reporting it, I take this as a sign that almost nobody is still using it, and we should switch away.

First noted in https://github.com/pymc-devs/pymc/pull/7973#pullrequestreview-3530169166


## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
