### PR TITLE
Run whole suite with CVM and Numba linkers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,6 @@ on:
     branches:
       - main
 
-
-
 # Cancel running workflows for updated PRs
 # https://turso.tech/blog/simple-trick-to-save-environment-and-money-when-using-github-actions
 concurrency:
@@ -26,7 +24,6 @@ concurrency:
 # enforces that test run just once per OS / floatX setting.
 
 jobs:
-
   changes:
     name: "Check for changes"
     runs-on: ubuntu-latest
@@ -56,8 +53,7 @@ jobs:
     if: ${{ needs.changes.outputs.changes == 'true' }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        floatx: [float64]
+        linker: [cvm, numba]
         python-version: ["3.14"]
         test-subset:
           - |
@@ -145,10 +141,10 @@ jobs:
             tests/dims/test_model.py
 
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     env:
       TEST_SUBSET: ${{ matrix.test-subset }}
-      PYTENSOR_FLAGS: floatX=${{ matrix.floatx }}
+      PYTENSOR_FLAGS: linker=${{ matrix.linker }}
     defaults:
       run:
         shell: bash -leo pipefail {0}
@@ -175,9 +171,9 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }} # use token for more robust uploads
+          token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: TEST_SUBSET
-          name: ${{ matrix.os }} ${{ matrix.floatx }}
+          name: Ubuntu py${{ matrix.python-version }} linker=${{ matrix.linker }}
           fail_ci_if_error: false
 
   windows:
@@ -185,8 +181,7 @@ jobs:
     if: ${{ needs.changes.outputs.changes == 'true' }}
     strategy:
       matrix:
-        os: [windows-latest]
-        floatx: [float64]
+        linker: [cvm, numba]
         python-version: ["3.11"]
         test-subset:
           - tests/variational/test_approximations.py tests/variational/test_callbacks.py tests/variational/test_inference.py tests/variational/test_opvi.py tests/test_initial_point.py
@@ -195,10 +190,10 @@ jobs:
           - tests/step_methods/test_metropolis.py tests/step_methods/test_slicer.py tests/step_methods/hmc/test_nuts.py tests/step_methods/test_compound.py tests/step_methods/hmc/test_hmc.py tests/step_methods/test_state.py
 
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-latest
     env:
       TEST_SUBSET: ${{ matrix.test-subset }}
-      PYTENSOR_FLAGS: floatX=${{ matrix.floatx }}
+      PYTENSOR_FLAGS: linker=${{ matrix.linker }}
     defaults:
       run:
         shell: bash -leo pipefail {0}
@@ -225,9 +220,9 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }} # use token for more robust uploads
+          token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: TEST_SUBSET
-          name: ${{ matrix.os }} ${{ matrix.floatx }}
+          name: Windows py${{ matrix.python-version }} linker=${{ matrix.linker }}
           fail_ci_if_error: false
 
   macos:
@@ -235,8 +230,7 @@ jobs:
     if: ${{ needs.changes.outputs.changes == 'true' }}
     strategy:
       matrix:
-        os: [macos-latest]
-        floatx: [float64]
+        linker: [cvm, numba]
         python-version: ["3.14"]
         test-subset:
           - |
@@ -253,10 +247,10 @@ jobs:
             tests/backends/test_zarr.py
             tests/variational/test_updates.py
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
     env:
       TEST_SUBSET: ${{ matrix.test-subset }}
-      PYTENSOR_FLAGS: floatX=${{ matrix.floatx }}
+      PYTENSOR_FLAGS: linker=${{ matrix.linker }}
     defaults:
       run:
         shell: bash -leo pipefail {0}
@@ -285,7 +279,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # use token for more robust uploads
           env_vars: TEST_SUBSET
-          name: ${{ matrix.os }} ${{ matrix.floatx }}
+          name: MacOS py${{ matrix.python-version }} linker=${{ matrix.linker }}
           fail_ci_if_error: false
 
   alternative_backends:
@@ -293,8 +287,7 @@ jobs:
     if: ${{ needs.changes.outputs.changes == 'true' }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        floatx: [float64]
+        linker: [cvm, numba]
         # nutpie depends on PyMC, and it will require an extra release cycle to support
         # the next PyMC release and therefore Python 3.14.
         python-version: ["3.13"]
@@ -305,10 +298,10 @@ jobs:
             tests/sampling/test_mcmc_external.py
 
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     env:
       TEST_SUBSET: ${{ matrix.test-subset }}
-      PYTENSOR_FLAGS: floatX=${{ matrix.floatx }}
+      PYTENSOR_FLAGS: linker=${{ matrix.linker }}
     defaults:
       run:
         shell: bash -leo pipefail {0}
@@ -337,7 +330,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # use token for more robust uploads
           env_vars: TEST_SUBSET
-          name: Alternative backend tests - ${{ matrix.os }} ${{ matrix.floatx }}
+          name: Alternative backends py${{ matrix.python-version }} linker=${{ matrix.linker }}
           fail_ci_if_error: false
 
   float32:
@@ -345,16 +338,16 @@ jobs:
     if: ${{ needs.changes.outputs.changes == 'true' }}
     strategy:
       matrix:
+        linker: [cvm, numba]
         os: [windows-latest]
-        floatx: [float32]
         python-version: ["3.14"]
         test-subset:
-        - tests/sampling/test_mcmc.py tests/ode/test_ode.py tests/ode/test_utils.py tests/distributions/test_transform.py
+          - tests/sampling/test_mcmc.py tests/ode/test_ode.py tests/ode/test_utils.py tests/distributions/test_transform.py
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
       TEST_SUBSET: ${{ matrix.test-subset }}
-      PYTENSOR_FLAGS: floatX=${{ matrix.floatx }}
+      PYTENSOR_FLAGS: floatX=float32
     defaults:
       run:
         shell: bash -leo pipefail {0}
@@ -383,19 +376,19 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # use token for more robust uploads
           env_vars: TEST_SUBSET
-          name: ${{ matrix.os }} ${{ matrix.floatx }}
+          name: float32 ${{ matrix.os }} py${{ matrix.python-version }} linker=${{ matrix.linker }}
           fail_ci_if_error: false
 
   all_tests:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    needs: [ changes, ubuntu, windows, macos, alternative_backends, float32 ]
+    needs: [changes, ubuntu, windows, macos, alternative_backends, float32]
     steps:
       - name: Check build matrix status
         if: ${{ needs.changes.outputs.changes == 'true' &&
-                ( needs.ubuntu.result != 'success' ||
-                  needs.windows.result != 'success' ||
-                  needs.macos.result != 'success' ||
-                  needs.alternative_backends.result != 'success' ||
-                  needs.float32.result != 'success' ) }}
+          ( needs.ubuntu.result != 'success' ||
+          needs.windows.result != 'success' ||
+          needs.macos.result != 'success' ||
+          needs.alternative_backends.result != 'success' ||
+          needs.float32.result != 'success' ) }}
         run: exit 1

--- a/conda-envs/environment-alternative-backends.yml
+++ b/conda-envs/environment-alternative-backends.yml
@@ -22,7 +22,7 @@ dependencies:
 - numpyro>=0.8.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.36.1,<2.37
+- pytensor>=2.36.2,<2.37
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.36.1,<2.37
+- pytensor>=2.36.2,<2.37
 - python-graphviz
 - networkx
 - scipy>=1.4.1

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -11,7 +11,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.36.1,<2.37
+- pytensor>=2.36.2,<2.37
 - python-graphviz
 - rich>=13.7.1
 - scipy>=1.4.1

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -14,7 +14,7 @@ dependencies:
 - pandas>=0.24.0
 - pip
 - polyagamma
-- pytensor>=2.36.1,<2.37
+- pytensor>=2.36.2,<2.37
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
-- pytensor>=2.36.1,<2.37
+- pytensor>=2.36.2,<2.37
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -15,7 +15,7 @@ dependencies:
 - pandas>=0.24.0
 - pip
 - polyagamma
-- pytensor>=2.36.1,<2.37
+- pytensor>=2.36.2,<2.37
 - python-graphviz
 - networkx
 - rich>=13.7.1

--- a/pymc/dims/distributions/scalar.py
+++ b/pymc/dims/distributions/scalar.py
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 import pytensor.xtensor as ptx
-import pytensor.xtensor.random as pxr
+import pytensor.xtensor.random as ptxr
 
 from pytensor.xtensor import as_xtensor
 
@@ -23,7 +23,7 @@ from pymc.dims.distributions.core import (
 )
 from pymc.distributions.continuous import Beta as RegularBeta
 from pymc.distributions.continuous import Gamma as RegularGamma
-from pymc.distributions.continuous import HalfStudentTRV, flat, halfflat
+from pymc.distributions.continuous import HalfCauchyRV, HalfStudentTRV, flat, halfflat
 
 
 def _get_sigma_from_either_sigma_or_tau(*, sigma, tau):
@@ -40,7 +40,7 @@ def _get_sigma_from_either_sigma_or_tau(*, sigma, tau):
 
 
 class Flat(DimDistribution):
-    xrv_op = pxr.as_xrv(flat)
+    xrv_op = ptxr.as_xrv(flat)
 
     @classmethod
     def dist(cls, **kwargs):
@@ -48,7 +48,7 @@ class Flat(DimDistribution):
 
 
 class HalfFlat(PositiveDimDistribution):
-    xrv_op = pxr.as_xrv(halfflat, [], ())
+    xrv_op = ptxr.as_xrv(halfflat, [], ())
 
     @classmethod
     def dist(cls, **kwargs):
@@ -56,7 +56,7 @@ class HalfFlat(PositiveDimDistribution):
 
 
 class Normal(DimDistribution):
-    xrv_op = pxr.normal
+    xrv_op = ptxr.normal
 
     @classmethod
     def dist(cls, mu=0, sigma=None, *, tau=None, **kwargs):
@@ -65,7 +65,7 @@ class Normal(DimDistribution):
 
 
 class HalfNormal(PositiveDimDistribution):
-    xrv_op = pxr.halfnormal
+    xrv_op = ptxr.halfnormal
 
     @classmethod
     def dist(cls, sigma=None, *, tau=None, **kwargs):
@@ -74,7 +74,7 @@ class HalfNormal(PositiveDimDistribution):
 
 
 class LogNormal(PositiveDimDistribution):
-    xrv_op = pxr.lognormal
+    xrv_op = ptxr.lognormal
 
     @classmethod
     def dist(cls, mu=0, sigma=None, *, tau=None, **kwargs):
@@ -83,7 +83,7 @@ class LogNormal(PositiveDimDistribution):
 
 
 class StudentT(DimDistribution):
-    xrv_op = pxr.t
+    xrv_op = ptxr.t
 
     @classmethod
     def dist(cls, nu, mu=0, sigma=None, *, lam=None, **kwargs):
@@ -102,12 +102,12 @@ class HalfStudentT(PositiveDimDistribution):
         nu = as_xtensor(nu)
         sigma = as_xtensor(sigma)
         core_rv = HalfStudentTRV.rv_op(nu=nu.values, sigma=sigma.values).owner.op
-        xop = pxr.as_xrv(core_rv)
+        xop = ptxr.as_xrv(core_rv)
         return xop(nu, sigma, core_dims=core_dims, extra_dims=extra_dims, rng=rng)
 
 
 class Cauchy(DimDistribution):
-    xrv_op = pxr.cauchy
+    xrv_op = ptxr.cauchy
 
     @classmethod
     def dist(cls, alpha, beta, **kwargs):
@@ -115,15 +115,20 @@ class Cauchy(DimDistribution):
 
 
 class HalfCauchy(PositiveDimDistribution):
-    xrv_op = pxr.halfcauchy
-
     @classmethod
     def dist(cls, beta, **kwargs):
-        return super().dist([0.0, beta], **kwargs)
+        return super().dist([beta], **kwargs)
+
+    @classmethod
+    def xrv_op(self, beta, core_dims, extra_dims=None, rng=None):
+        beta = as_xtensor(beta)
+        core_rv = HalfCauchyRV.rv_op(beta=beta.values).owner.op
+        xop = ptxr.as_xrv(core_rv)
+        return xop(beta, core_dims=core_dims, extra_dims=extra_dims, rng=rng)
 
 
 class Beta(UnitDimDistribution):
-    xrv_op = pxr.beta
+    xrv_op = ptxr.beta
 
     @classmethod
     def dist(cls, alpha=None, beta=None, *, mu=None, sigma=None, nu=None, **kwargs):
@@ -132,7 +137,7 @@ class Beta(UnitDimDistribution):
 
 
 class Laplace(DimDistribution):
-    xrv_op = pxr.laplace
+    xrv_op = ptxr.laplace
 
     @classmethod
     def dist(cls, mu=0, b=1, **kwargs):
@@ -140,7 +145,7 @@ class Laplace(DimDistribution):
 
 
 class Exponential(PositiveDimDistribution):
-    xrv_op = pxr.exponential
+    xrv_op = ptxr.exponential
 
     @classmethod
     def dist(cls, lam=None, *, scale=None, **kwargs):
@@ -154,7 +159,7 @@ class Exponential(PositiveDimDistribution):
 
 
 class Gamma(PositiveDimDistribution):
-    xrv_op = pxr.gamma
+    xrv_op = ptxr.gamma
 
     @classmethod
     def dist(cls, alpha=None, beta=None, *, mu=None, sigma=None, **kwargs):
@@ -173,7 +178,7 @@ class Gamma(PositiveDimDistribution):
 
 
 class InverseGamma(PositiveDimDistribution):
-    xrv_op = pxr.invgamma
+    xrv_op = ptxr.invgamma
 
     @classmethod
     def dist(cls, alpha=None, beta=None, *, mu=None, sigma=None, **kwargs):

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -27,10 +27,11 @@ from numpy import random as nr
 from numpy import testing as npt
 from numpy.typing import NDArray
 from pytensor.compile import SharedVariable
-from pytensor.compile.mode import Mode
+from pytensor.compile.mode import Mode, get_default_mode
 from pytensor.graph.basic import Constant, Variable, equal_computations
 from pytensor.graph.rewriting.basic import in2out
 from pytensor.graph.traversal import graph_inputs
+from pytensor.link.numba import NumbaLinker
 from pytensor.tensor import TensorVariable
 from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.random.type import RandomType
@@ -947,6 +948,15 @@ class BaseTestDistributionRandom:
     def check_pymc_draws_match_reference(self):
         # need to re-instantiate it to make sure that the order of drawings match the reference distribution one
         # self._instantiate_pymc_rv()
+        npt.assert_array_almost_equal(
+            self.pymc_rv.eval(), self.reference_dist_draws, decimal=self.decimal
+        )
+
+    def check_pymc_draws_match_reference_not_numba(self):
+        # This calls `check_pymc_draws_match_reference` but only if the default linker is NOT numba.
+        # It's used when the draws aren't expected to match in that backend.
+        if isinstance(get_default_mode().linker, NumbaLinker):
+            return
         npt.assert_array_almost_equal(
             self.pymc_rv.eval(), self.reference_dist_draws, decimal=self.decimal
         )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ pandas>=0.24.0
 polyagamma
 pre-commit>=2.8.0
 pymc-sphinx-theme>=0.16.0
-pytensor>=2.36.1,<2.37
+pytensor>=2.36.2,<2.37
 pytest-cov>=2.5
 pytest>=3.0
 rich>=13.7.1

--- a/tests/backends/test_arviz.py
+++ b/tests/backends/test_arviz.py
@@ -39,6 +39,7 @@ pytestmark = pytest.mark.filterwarnings(
     "error",
     # Related to https://github.com/arviz-devs/arviz/issues/2327
     "ignore:datetime.datetime.utcnow():DeprecationWarning",
+    r"ignore::numba.NumbaPerformanceWarning",
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,8 @@ import numpy as np
 import pytensor
 import pytest
 
+from numba.core.errors import NumbaPerformanceWarning, NumbaWarning
+
 
 @pytest.fixture(scope="function", autouse=True)
 def pytensor_config():
@@ -51,4 +53,6 @@ def seeded_test():
 def fail_on_warning():
     with warnings.catch_warnings():
         warnings.simplefilter("error")
+        warnings.filterwarnings("ignore", category=NumbaPerformanceWarning)
+        warnings.filterwarnings("ignore", ".*Cannot cache.*", NumbaWarning)
         yield

--- a/tests/dims/distributions/test_core.py
+++ b/tests/dims/distributions/test_core.py
@@ -20,7 +20,10 @@ import pymc as pm
 
 from pymc import dims as pmx
 
-pytestmark = pytest.mark.filterwarnings("error")
+pytestmark = pytest.mark.filterwarnings(
+    "error",
+    "ignore::numba.core.errors.NumbaPerformanceWarning",
+)
 
 
 def test_distribution_dims():

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -2326,11 +2326,14 @@ class TestCauchy(BaseTestDistributionRandom):
 
 
 class TestHalfCauchy(BaseTestDistributionRandom):
+    def halfcauchy_rng_fn(self, scale, size, rng):
+        return np.abs(st.cauchy.rvs(scale=scale, size=size, random_state=rng))
+
     pymc_dist = pm.HalfCauchy
     pymc_dist_params = {"beta": 5.0}
-    expected_rv_op_params = {"alpha": 0.0, "beta": 5.0}
-    reference_dist_params = {"loc": 0.0, "scale": 5.0}
-    reference_dist = seeded_scipy_distribution_builder("halfcauchy")
+    expected_rv_op_params = {"beta": 5.0}
+    reference_dist_params = {"scale": 5.0}
+    reference_dist = lambda self: ft.partial(self.halfcauchy_rng_fn, rng=self.get_random_state())  # noqa: E731
     checks_to_run = [
         "check_pymc_params_match_rv_op",
         "check_pymc_draws_match_reference",

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -1924,7 +1924,7 @@ class TestGumbel(BaseTestDistributionRandom):
     reference_dist = seeded_scipy_distribution_builder("gumbel_r")
     checks_to_run = [
         "check_pymc_params_match_rv_op",
-        "check_pymc_draws_match_reference",
+        "check_pymc_draws_match_reference_not_numba",
     ]
 
 
@@ -2321,7 +2321,7 @@ class TestCauchy(BaseTestDistributionRandom):
     reference_dist = seeded_scipy_distribution_builder("cauchy")
     checks_to_run = [
         "check_pymc_params_match_rv_op",
-        "check_pymc_draws_match_reference",
+        "check_pymc_draws_match_reference_not_numba",
     ]
 
 
@@ -2336,7 +2336,7 @@ class TestHalfCauchy(BaseTestDistributionRandom):
     reference_dist = lambda self: ft.partial(self.halfcauchy_rng_fn, rng=self.get_random_state())  # noqa: E731
     checks_to_run = [
         "check_pymc_params_match_rv_op",
-        "check_pymc_draws_match_reference",
+        "check_pymc_draws_match_reference_not_numba",
     ]
 
 

--- a/tests/distributions/test_custom.py
+++ b/tests/distributions/test_custom.py
@@ -55,7 +55,10 @@ from pymc.step_methods import Metropolis
 from pymc.testing import assert_support_point_is_expected
 
 # Raise for any warnings in this file
-pytestmark = pytest.mark.filterwarnings("error")
+pytestmark = pytest.mark.filterwarnings(
+    "error",
+    r"ignore:^Numba will use object mode to run.*perform method\.:UserWarning",
+)
 
 
 class TestCustomDist:

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -769,7 +769,7 @@ class TestBernoulli(BaseTestDistributionRandom):
     reference_dist = seeded_scipy_distribution_builder("bernoulli")
     checks_to_run = [
         "check_pymc_params_match_rv_op",
-        "check_pymc_draws_match_reference",
+        "check_pymc_draws_match_reference_not_numba",
     ]
 
 

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -1413,7 +1413,7 @@ class TestMvNormalChol(BaseTestDistributionRandom):
     }
     expected_rv_op_params = {
         "mu": np.array([1.0, 2.0]),
-        "cov": quaddist_matrix(chol=pymc_dist_params["chol"]).eval(),
+        "cov": quaddist_matrix(chol=pymc_dist_params["chol"]).eval(mode="FAST_COMPILE"),
     }
     checks_to_run = ["check_pymc_params_match_rv_op"]
 
@@ -1426,7 +1426,7 @@ class TestMvNormalTau(BaseTestDistributionRandom):
     }
     expected_rv_op_params = {
         "mu": np.array([1.0, 2.0]),
-        "cov": quaddist_matrix(tau=pymc_dist_params["tau"]).eval(),
+        "cov": quaddist_matrix(tau=pymc_dist_params["tau"]).eval(mode="FAST_COMPILE"),
     }
     checks_to_run = ["check_pymc_params_match_rv_op"]
 
@@ -1839,7 +1839,7 @@ class TestMvStudentTChol(BaseTestDistributionRandom):
     expected_rv_op_params = {
         "nu": 5,
         "mu": np.array([1.0, 2.0]),
-        "scale": quaddist_matrix(chol=pymc_dist_params["chol"]).eval(),
+        "scale": quaddist_matrix(chol=pymc_dist_params["chol"]).eval(mode="FAST_COMPILE"),
     }
     checks_to_run = ["check_pymc_params_match_rv_op"]
 
@@ -1854,7 +1854,7 @@ class TestMvStudentTTau(BaseTestDistributionRandom):
     expected_rv_op_params = {
         "nu": 5,
         "mu": np.array([1.0, 2.0]),
-        "cov": quaddist_matrix(tau=pymc_dist_params["tau"]).eval(),
+        "cov": quaddist_matrix(tau=pymc_dist_params["tau"]).eval(mode="FAST_COMPILE"),
     }
     checks_to_run = ["check_pymc_params_match_rv_op"]
 

--- a/tests/distributions/test_simulator.py
+++ b/tests/distributions/test_simulator.py
@@ -20,7 +20,9 @@ import pytensor
 import pytest
 import scipy.stats as st
 
+from pytensor.compile.mode import get_default_mode
 from pytensor.graph import ancestors
+from pytensor.link.numba import NumbaLinker
 from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.random.var import RandomGeneratorSharedVariable
 from pytensor.tensor.sort import SortOp
@@ -96,7 +98,9 @@ class TestSimulator:
             pytest.param(
                 "float32",
                 marks=pytest.mark.xfail(
-                    condition=sys.version_info.minor == 14, reason="Needs investigation"
+                    condition=sys.version_info.minor == 14
+                    and not isinstance(get_default_mode().linker, NumbaLinker),
+                    reason="Needs investigation",
                 ),
             ),
             "float64",

--- a/tests/distributions/test_timeseries.py
+++ b/tests/distributions/test_timeseries.py
@@ -51,6 +51,8 @@ pytestmark = pytest.mark.filterwarnings(
     "error",
     # Related to https://github.com/arviz-devs/arviz/issues/2327
     "ignore:datetime.datetime.utcnow():DeprecationWarning",
+    "ignore:.*Cannot cache.*:numba.core.errors.NumbaWarning",
+    "ignore::numba.NumbaPerformanceWarning",
 )
 
 

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -241,7 +241,8 @@ def test_interval_near_boundary():
     with pm.Model() as model:
         pm.Uniform("x", initval=x0, lower=lb, upper=ub)
 
-    log_prob = model.point_logps()
+    with pytensor.config.change_flags(numba__fastmath=False):
+        log_prob = model.point_logps()
     assert_allclose(list(log_prob.values()), floatX(np.array([-52.68])))
 
 

--- a/tests/logprob/test_transform_value.py
+++ b/tests/logprob/test_transform_value.py
@@ -135,11 +135,15 @@ def test_original_values_output_dict():
             lambda mu, sigma: sp.stats.lognorm(s=sigma, scale=np.exp(mu)),
             (),
         ),
-        (
+        pytest.param(
             pt.random.halfcauchy,
             (1.5, 10.5),
             lambda alpha, beta: sp.stats.halfcauchy(loc=alpha, scale=beta),
             (),
+            marks=pytest.mark.xfail(
+                reason="We don't use PyTensor's HalfCauchy operator",
+                raises=NotImplementedError,
+            ),
         ),
         (
             pt.random.gamma,

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -257,7 +257,7 @@ def test_model_latex_repr_three_levels_model():
         "$$",
         "\\begin{array}{rcl}",
         "\\text{mu} &\\sim & \\operatorname{Normal}(0,~5)\\\\\\text{sigma} &\\sim & "
-        "\\operatorname{HalfCauchy}(0,~2.5)\\\\\\text{censored\\_normal} &\\sim & "
+        "\\operatorname{HalfCauchy}(2.5)\\\\\\text{censored\\_normal} &\\sim & "
         "\\operatorname{Censored}(\\operatorname{Normal}(\\text{mu},~\\text{sigma}),~-2,~2)",
         "\\end{array}",
         "$$",


### PR DESCRIPTION
Related to https://github.com/pymc-devs/pymc/issues/7926
Related to https://github.com/orgs/pymc-devs/projects/9

Relies on next PyTensor release

PyMC will now be tested on both C and Numba backends, antecipating the switch to Numba as the default backend from PyTensor