### PR TITLE
Add logprob support for leaky-ReLU switch transforms

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,6 +134,7 @@ jobs:
             tests/logprob/test_rewriting.py
             tests/logprob/test_scan.py
             tests/logprob/test_tensor.py
+            tests/logprob/test_switch.py
             tests/logprob/test_transform_value.py
             tests/logprob/test_transforms.py
             tests/logprob/test_utils.py

--- a/pymc/logprob/__init__.py
+++ b/pymc/logprob/__init__.py
@@ -53,6 +53,7 @@ import pymc.logprob.linalg
 import pymc.logprob.mixture
 import pymc.logprob.order
 import pymc.logprob.scan
+import pymc.logprob.switch
 import pymc.logprob.tensor
 import pymc.logprob.transforms
 

--- a/pymc/logprob/mixture.py
+++ b/pymc/logprob/mixture.py
@@ -47,10 +47,7 @@ from pytensor.graph.traversal import ancestors
 from pytensor.ifelse import IfElse, ifelse
 from pytensor.scalar import Switch
 from pytensor.scalar import switch as scalar_switch
-from pytensor.scalar.basic import GE, GT, LE, LT, Mul
 from pytensor.tensor.basic import Join, MakeVector, switch
-from pytensor.tensor.elemwise import Elemwise
-from pytensor.tensor.exceptions import NotScalarConstantError
 from pytensor.tensor.random.rewriting import (
     local_dimshuffle_rv_lift,
     local_rv_size_lift,
@@ -83,9 +80,7 @@ from pymc.logprob.rewriting import (
     measurable_ir_rewrites_db,
     subtensor_ops,
 )
-from pymc.logprob.transforms import MeasurableTransform
 from pymc.logprob.utils import (
-    CheckParameterValue,
     check_potential_measurability,
     filter_measurable_variables,
     get_related_valued_nodes,
@@ -412,80 +407,6 @@ class MeasurableSwitchMixture(MeasurableElemwise):
 measurable_switch_mixture = MeasurableSwitchMixture(scalar_switch)
 
 
-class MeasurableLeakyReLUSwitch(MeasurableElemwise):
-    """A placeholder for leaky-ReLU graphs built via `switch(x > 0, x, a * x)`.
-
-    this is an invertible, piecewise-linear transform of a single continuous measurable variable.
-    """
-
-    valid_scalar_types = (Switch,)
-
-
-measurable_leaky_relu_switch = MeasurableLeakyReLUSwitch(scalar_switch)
-
-
-def _is_x_positive_condition(cond: TensorVariable, x: TensorVariable) -> bool:
-    if cond.owner is None:
-        return False
-    if not isinstance(cond.owner.op, Elemwise):
-        return False
-    scalar_op = cond.owner.op.scalar_op
-    if not isinstance(scalar_op, GT | GE | LT | LE):
-        return False
-
-    left, right = cond.owner.inputs
-
-    def _is_zero(v: TensorVariable) -> bool:
-        try:
-            return pt.get_underlying_scalar_constant_value(v) == 0
-        except NotScalarConstantError:
-            return False
-
-    # x > 0 or x >= 0
-    if left is x and _is_zero(right) and isinstance(scalar_op, GT | GE):
-        return True
-    # 0 < x or 0 <= x
-    if right is x and _is_zero(left) and isinstance(scalar_op, LT | LE):
-        return True
-    return False
-
-
-def _extract_leaky_relu_slope(
-    neg_branch: TensorVariable, x: TensorVariable
-) -> TensorVariable | None:
-    """Extract slope `a` from `neg_branch` assuming it represents `a * x`.
-
-    supports both plain `Elemwise(Mul)` and `MeasurableTransform` scale rewrites.
-    """
-    if neg_branch is x:
-        return pt.constant(1.0)
-
-    if neg_branch.owner is None:
-        return None
-
-    # handle case where `a * x` was already rewritten into a measurable scale transform
-    if isinstance(neg_branch.owner.op, MeasurableTransform):
-        op = neg_branch.owner.op
-        if not isinstance(op.scalar_op, Mul):
-            return None
-        # MeasurableTransform takes (measurable_input, scale)
-        if len(neg_branch.owner.inputs) != 2:
-            return None
-        if neg_branch.owner.inputs[op.measurable_input_idx] is not x:
-            return None
-        scale = neg_branch.owner.inputs[1 - op.measurable_input_idx]
-        return cast(TensorVariable, scale)
-
-    # plain multiplication
-    if isinstance(neg_branch.owner.op, Elemwise) and isinstance(neg_branch.owner.op.scalar_op, Mul):
-        left, right = neg_branch.owner.inputs
-        if left is x:
-            return cast(TensorVariable, right)
-        if right is x:
-            return cast(TensorVariable, left)
-    return None
-
-
 @node_rewriter([switch])
 def find_measurable_switch_mixture(fgraph, node):
     if isinstance(node.op, MeasurableOp):
@@ -510,51 +431,6 @@ def find_measurable_switch_mixture(fgraph, node):
     return [measurable_switch_mixture(switch_cond, *components)]
 
 
-@node_rewriter([switch])
-def find_measurable_leaky_relu_switch(fgraph, node):
-    """Detect `switch(x > 0, x, a * x)` and replace it by a measurable op.
-
-    This enables a change-of-variables logprob derivation instead of treating it as a mixture.
-    """
-    if isinstance(node.op, MeasurableOp):
-        return None
-
-    cond, pos_branch, neg_branch = node.inputs
-
-    # we only mark the switch measurable once both branches are already measurable.
-    # so, the switch logprob can simply gate between branch logps (delegating inversion/Jacobian details to each branch).
-    if set(filter_measurable_variables([pos_branch, neg_branch])) != {pos_branch, neg_branch}:
-        return None
-
-    if not filter_measurable_variables([pos_branch]):
-        return None
-    x = cast(TensorVariable, pos_branch)
-
-    if x.type.dtype.startswith("int"):
-        return None
-
-    if x.type.broadcastable != node.outputs[0].type.broadcastable:
-        return None
-
-    if not _is_x_positive_condition(cast(TensorVariable, cond), x):
-        return None
-
-    a = _extract_leaky_relu_slope(cast(TensorVariable, neg_branch), x)
-    if a is None:
-        return None
-
-    if check_potential_measurability([a]):
-        return None
-
-    return [
-        measurable_leaky_relu_switch(
-            cast(TensorVariable, cond),
-            x,
-            cast(TensorVariable, neg_branch),
-        )
-    ]
-
-
 @_logprob.register(MeasurableSwitchMixture)
 def logprob_switch_mixture(op, values, switch_cond, component_true, component_false, **kwargs):
     [value] = values
@@ -564,30 +440,6 @@ def logprob_switch_mixture(op, values, switch_cond, component_true, component_fa
         _logprob_helper(component_true, value),
         _logprob_helper(component_false, value),
     )
-
-
-@_logprob.register(MeasurableLeakyReLUSwitch)
-def logprob_leaky_relu_switch(op, values, cond, x, neg_branch, **kwargs):
-    (value,) = values
-
-    a = _extract_leaky_relu_slope(cast(TensorVariable, neg_branch), cast(TensorVariable, x))
-    if a is None:
-        raise NotImplementedError("Could not extract leaky-ReLU slope")
-
-    # enforce `a > 0` at runtime to ensure invertibility and to make the branch selection predicate depend only on the observed value.
-    a_is_positive = pt.all(pt.gt(a, 0))
-
-    # for `a > 0`, `switch(x > 0, x, a * x)` maps to disjoint regions in `value`: true branch -> value > 0, false branch -> value <= 0.
-    value_implies_true_branch = pt.gt(value, 0)
-
-    logp_expr = pt.switch(
-        value_implies_true_branch,
-        _logprob_helper(x, value, **kwargs),
-        _logprob_helper(neg_branch, value, **kwargs),
-    )
-
-    # attach the parameter check to the returned expression so it can't be optimized away.
-    return CheckParameterValue("leaky_relu slope > 0")(logp_expr, a_is_positive)
 
 
 measurable_ir_rewrites_db.register(
@@ -602,13 +454,6 @@ measurable_ir_rewrites_db.register(
     find_measurable_switch_mixture,
     "basic",
     "mixture",
-)
-
-measurable_ir_rewrites_db.register(
-    "find_measurable_leaky_relu_switch",
-    find_measurable_leaky_relu_switch,
-    "basic",
-    "transform",
 )
 
 

--- a/pymc/logprob/switch.py
+++ b/pymc/logprob/switch.py
@@ -195,6 +195,8 @@ def logprob_switch_non_overlapping(op, values, cond, x, neg_branch, **kwargs):
     if a is None:
         raise NotImplementedError("Could not extract non-overlapping scale")
 
+    # Must be strictly positive: a == 0 is not invertible (collapses a region) and
+    # invalidates the non-overlapping branch inference.
     a_is_positive = pt.all(pt.gt(a, 0))
 
     includes_zero_in_true = _zero_x_threshold_true_includes_zero(

--- a/pymc/logprob/switch.py
+++ b/pymc/logprob/switch.py
@@ -76,7 +76,9 @@ def _zero_x_threshold_true_includes_zero(cond: TensorVariable, x: TensorVariable
     """Return whether `cond` is a zero threshold on `x` and includes `0` in the true branch.
 
     Matches `x > 0`, `x >= 0` and swapped forms `0 < x`, `0 <= x`.
-    Returns:
+
+    Returns
+    -------
         - `False` for strict comparisons (`>`/`<`)
         - `True` for non-strict comparisons (`>=`/`<=`)
         - `None` if `cond` doesn't match a zero-threshold comparison on `x`

--- a/pymc/logprob/switch.py
+++ b/pymc/logprob/switch.py
@@ -1,0 +1,202 @@
+#   Copyright 2024 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#   MIT License
+#
+#   Copyright (c) 2021-2022 aesara-devs
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in all
+#   copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#   SOFTWARE.
+
+"""Measurable switch-based transforms."""
+
+from typing import cast
+
+import pytensor.tensor as pt
+
+from pytensor.graph.rewriting.basic import node_rewriter
+from pytensor.scalar import Switch
+from pytensor.scalar import switch as scalar_switch
+from pytensor.scalar.basic import GE, GT, LE, LT, Mul
+from pytensor.tensor.basic import switch as tensor_switch
+from pytensor.tensor.elemwise import Elemwise
+from pytensor.tensor.exceptions import NotScalarConstantError
+from pytensor.tensor.variable import TensorVariable
+
+from pymc.logprob.abstract import MeasurableElemwise, MeasurableOp, _logprob, _logprob_helper
+from pymc.logprob.rewriting import measurable_ir_rewrites_db
+from pymc.logprob.transforms import MeasurableTransform
+from pymc.logprob.utils import (
+    CheckParameterValue,
+    check_potential_measurability,
+    filter_measurable_variables,
+)
+
+
+class MeasurableSwitchNonOverlapping(MeasurableElemwise):
+    """Placeholder for switch transforms whose branch images do not overlap.
+
+    Currently matches leaky-ReLU graphs of the form `switch(x > 0, x, a * x)`.
+    """
+
+    valid_scalar_types = (Switch,)
+
+
+measurable_switch_non_overlapping = MeasurableSwitchNonOverlapping(scalar_switch)
+
+
+def _is_x_threshold_condition(cond: TensorVariable, x: TensorVariable) -> bool:
+    """Check whether `cond` is equivalent to `x > 0` / `x >= 0` (and swapped forms)."""
+    if cond.owner is None:
+        return False
+    if not isinstance(cond.owner.op, Elemwise):
+        return False
+    scalar_op = cond.owner.op.scalar_op
+    if not isinstance(scalar_op, GT | GE | LT | LE):
+        return False
+
+    left, right = cond.owner.inputs
+
+    def _is_zero(v: TensorVariable) -> bool:
+        try:
+            return pt.get_underlying_scalar_constant_value(v) == 0
+        except NotScalarConstantError:
+            return False
+
+    # x > 0 or x >= 0
+    if left is x and _is_zero(cast(TensorVariable, right)) and isinstance(scalar_op, GT | GE):
+        return True
+    # 0 < x or 0 <= x
+    if right is x and _is_zero(cast(TensorVariable, left)) and isinstance(scalar_op, LT | LE):
+        return True
+
+    return False
+
+
+def _extract_scale_from_measurable_mul(
+    neg_branch: TensorVariable, x: TensorVariable
+) -> TensorVariable | None:
+    """Extract scale `a` from a measurable multiplication that represents `a * x`."""
+    if neg_branch is x:
+        return pt.constant(1.0)
+
+    if neg_branch.owner is None:
+        return None
+
+    if not isinstance(neg_branch.owner.op, MeasurableTransform):
+        return None
+
+    op = neg_branch.owner.op
+    if not isinstance(op.scalar_op, Mul):
+        return None
+
+    # MeasurableTransform takes (measurable_input, scale)
+    if len(neg_branch.owner.inputs) != 2:
+        return None
+
+    if neg_branch.owner.inputs[op.measurable_input_idx] is not x:
+        return None
+
+    scale = neg_branch.owner.inputs[1 - op.measurable_input_idx]
+    return cast(TensorVariable, scale)
+
+
+@node_rewriter([tensor_switch])
+def find_measurable_switch_non_overlapping(fgraph, node):
+    """Detect `switch(x > 0, x, a * x)` and replace it by a measurable op."""
+    if isinstance(node.op, MeasurableOp):
+        return None
+
+    cond, pos_branch, neg_branch = node.inputs
+
+    # Only mark the switch measurable once both branches are already measurable.
+    # Then the logprob can simply gate between branch logps evaluated at `value`.
+    if set(filter_measurable_variables([pos_branch, neg_branch])) != {pos_branch, neg_branch}:
+        return None
+
+    x = cast(TensorVariable, pos_branch)
+
+    if x.type.dtype.startswith("int"):
+        return None
+
+    if x.type.broadcastable != node.outputs[0].type.broadcastable:
+        return None
+
+    if not _is_x_threshold_condition(cast(TensorVariable, cond), x):
+        return None
+
+    a = _extract_scale_from_measurable_mul(cast(TensorVariable, neg_branch), x)
+    if a is None:
+        return None
+
+    # Disallow slope `a` that could be (directly or indirectly) measurable.
+    # This rewrite targets deterministic, non-overlapping transforms parametrized by non-RVs.
+    if check_potential_measurability([a]):
+        return None
+
+    return [
+        measurable_switch_non_overlapping(
+            cast(TensorVariable, cond),
+            x,
+            cast(TensorVariable, neg_branch),
+        )
+    ]
+
+
+@_logprob.register(MeasurableSwitchNonOverlapping)
+def logprob_switch_non_overlapping(op, values, cond, x, neg_branch, **kwargs):
+    (value,) = values
+
+    a = _extract_scale_from_measurable_mul(
+        cast(TensorVariable, neg_branch), cast(TensorVariable, x)
+    )
+    if a is None:
+        raise NotImplementedError("Could not extract non-overlapping scale")
+
+    a_is_positive = pt.all(pt.gt(a, 0))
+
+    # For `a > 0`, `switch(x > 0, x, a * x)` maps to disjoint regions in `value`:
+    # true branch -> value > 0, false branch -> value <= 0.
+    value_implies_true_branch = pt.gt(value, 0)
+
+    logp_expr = pt.switch(
+        value_implies_true_branch,
+        _logprob_helper(x, value, **kwargs),
+        _logprob_helper(neg_branch, value, **kwargs),
+    )
+
+    return CheckParameterValue("switch non-overlapping scale > 0")(logp_expr, a_is_positive)
+
+
+measurable_ir_rewrites_db.register(
+    "find_measurable_switch_non_overlapping",
+    find_measurable_switch_non_overlapping,
+    "basic",
+    "transform",
+)

--- a/tests/logprob/test_switch.py
+++ b/tests/logprob/test_switch.py
@@ -1,3 +1,16 @@
+#   Copyright 2026 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 from typing import cast
 
 import numpy as np

--- a/tests/logprob/test_switch.py
+++ b/tests/logprob/test_switch.py
@@ -11,14 +11,11 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from typing import cast
-
 import numpy as np
 import pytensor.tensor as pt
 import pytest
 
 from pytensor.compile.function import function
-from pytensor.tensor.variable import TensorVariable
 
 import pymc as pm
 
@@ -29,16 +26,13 @@ from pymc.logprob.utils import ParameterValueError
 def test_switch_non_overlapping_logp_matches_change_of_variables():
     scale = pt.scalar("scale")
     x = pm.Normal.dist(mu=0, sigma=1, size=(3,))
-    y = cast(TensorVariable, pt.switch(x > 0, x, scale * x))
+    y = pt.switch(x > 0, x, scale * x)
 
     vv = pt.vector("vv")
 
-    logp_y = logp(y, vv, warn_rvs=False)
-    inv = cast(TensorVariable, pt.switch(pt.gt(vv, 0), vv, vv / scale))
-    expected = logp(x, inv, warn_rvs=False) + cast(
-        TensorVariable,
-        pt.switch(pt.gt(vv, 0), 0.0, -cast(TensorVariable, pt.log(scale))),
-    )
+    logp_y = logp(y, vv)
+    inv = pt.switch(pt.gt(vv, 0), vv, vv / scale)
+    expected = logp(x, inv) + pt.switch(pt.gt(vv, 0), 0.0, -pt.log(scale))
 
     logp_y_fn = function([vv, scale], logp_y)
     expected_fn = function([vv, scale], expected)
@@ -46,58 +40,36 @@ def test_switch_non_overlapping_logp_matches_change_of_variables():
     v = np.array([-2.0, 0.0, 1.5])
     np.testing.assert_allclose(logp_y_fn(v, 0.5), expected_fn(v, 0.5))
 
-    # No warning-based shortcuts: also match under default warn_rvs (scalar case)
-    x_s = pm.Normal.dist(mu=0, sigma=1)
-    y_s = cast(TensorVariable, pt.switch(x_s > 0, x_s, scale * x_s))
-
-    v_pos = 1.2
-    np.testing.assert_allclose(logp(y_s, v_pos).eval({scale: 0.5}), logp(x_s, v_pos).eval())
-
-    v_neg = -2.0
-    np.testing.assert_allclose(
-        logp(y_s, v_neg).eval({scale: 0.5}),
-        logp(x_s, v_neg / 0.5).eval() - np.log(0.5),
-    )
-
-    # boundary point (measure-zero for continuous RVs): should still produce a finite logp
-    assert np.isfinite(logp(y_s, 0.0, warn_rvs=False).eval({scale: 0.5}))
-
-
-def test_switch_non_overlapping_requires_positive_scale():
-    scale = pt.scalar("scale")
-    x = pm.Normal.dist(mu=0, sigma=1)
-    y = cast(TensorVariable, pt.switch(x > 0, x, scale * x))
+    with pytest.raises(ParameterValueError, match="switch non-overlapping scale > 0"):
+        logp_y_fn(v, -0.5)
 
     with pytest.raises(ParameterValueError, match="switch non-overlapping scale > 0"):
-        logp(y, -1.0, warn_rvs=False).eval({scale: -0.5})
-
-    with pytest.raises(ParameterValueError, match="switch non-overlapping scale > 0"):
-        logp(y, -1.0, warn_rvs=False).eval({scale: 0.0})
+        logp_y_fn(v, 0.0)
 
 
 def test_switch_non_overlapping_does_not_rewrite_if_x_replicated_by_condition():
     scale = pt.scalar("scale")
     x = pm.Normal.dist(mu=0, sigma=1, size=(3,))
     cond = (x[None, :] > 0) & pt.ones((2, 1), dtype="bool")
-    y = cast(TensorVariable, pt.switch(cond, x, scale * x))
+    y = pt.switch(cond, x, scale * x)
 
     with pytest.raises(NotImplementedError, match="Logprob method not implemented for Switch"):
-        logp(y, np.zeros((2, 3)), warn_rvs=False).eval({scale: 0.5})
+        logp(y, np.zeros((2, 3)))
 
 
 def test_switch_non_overlapping_does_not_rewrite_if_scale_broadcasts_x():
     x = pm.Normal.dist(mu=0, sigma=1)
     scale = pt.vector("scale")
-    y = cast(TensorVariable, pt.switch(x > 0, x, scale * x))
+    y = pt.switch(x > 0, x, scale * x)
 
     with pytest.raises(NotImplementedError, match="Logprob method not implemented for Switch"):
-        logp(y, np.zeros((3,)), warn_rvs=False).eval({scale: np.array([0.5, 0.5, 0.5])})
+        logp(y, np.zeros((3,)))
 
 
 def test_switch_non_overlapping_does_not_apply_to_discrete_rv():
     a = pt.scalar("a")
     x = pm.Poisson.dist(3)
-    y = cast(TensorVariable, pt.switch(x > 0, x, a * x))
+    y = pt.switch(x > 0, x, a * x)
 
     with pytest.raises(NotImplementedError, match="Logprob method not implemented for Switch"):
-        logp(y, 1, warn_rvs=False).eval({a: 0.5})
+        logp(y, 1)

--- a/tests/logprob/test_switch.py
+++ b/tests/logprob/test_switch.py
@@ -1,0 +1,90 @@
+from typing import cast
+
+import numpy as np
+import pytensor.tensor as pt
+import pytest
+
+from pytensor.compile.function import function
+from pytensor.tensor.variable import TensorVariable
+
+import pymc as pm
+
+from pymc.logprob.basic import logp
+from pymc.logprob.utils import ParameterValueError
+
+
+def test_switch_non_overlapping_logp_matches_change_of_variables():
+    scale = pt.scalar("scale")
+    x = pm.Normal.dist(mu=0, sigma=1, size=(3,))
+    y = cast(TensorVariable, pt.switch(x > 0, x, scale * x))
+
+    vv = pt.vector("vv")
+
+    logp_y = logp(y, vv, warn_rvs=False)
+    inv = cast(TensorVariable, pt.switch(pt.gt(vv, 0), vv, vv / scale))
+    expected = logp(x, inv, warn_rvs=False) + cast(
+        TensorVariable,
+        pt.switch(pt.gt(vv, 0), 0.0, -cast(TensorVariable, pt.log(scale))),
+    )
+
+    logp_y_fn = function([vv, scale], logp_y)
+    expected_fn = function([vv, scale], expected)
+
+    v = np.array([-2.0, 0.0, 1.5])
+    np.testing.assert_allclose(logp_y_fn(v, 0.5), expected_fn(v, 0.5))
+
+    # No warning-based shortcuts: also match under default warn_rvs (scalar case)
+    x_s = pm.Normal.dist(mu=0, sigma=1)
+    y_s = cast(TensorVariable, pt.switch(x_s > 0, x_s, scale * x_s))
+
+    v_pos = 1.2
+    np.testing.assert_allclose(logp(y_s, v_pos).eval({scale: 0.5}), logp(x_s, v_pos).eval())
+
+    v_neg = -2.0
+    np.testing.assert_allclose(
+        logp(y_s, v_neg).eval({scale: 0.5}),
+        logp(x_s, v_neg / 0.5).eval() - np.log(0.5),
+    )
+
+    # boundary point (measure-zero for continuous RVs): should still produce a finite logp
+    assert np.isfinite(logp(y_s, 0.0, warn_rvs=False).eval({scale: 0.5}))
+
+
+def test_switch_non_overlapping_requires_positive_scale():
+    scale = pt.scalar("scale")
+    x = pm.Normal.dist(mu=0, sigma=1)
+    y = cast(TensorVariable, pt.switch(x > 0, x, scale * x))
+
+    with pytest.raises(ParameterValueError, match="switch non-overlapping scale > 0"):
+        logp(y, -1.0, warn_rvs=False).eval({scale: -0.5})
+
+    with pytest.raises(ParameterValueError, match="switch non-overlapping scale > 0"):
+        logp(y, -1.0, warn_rvs=False).eval({scale: 0.0})
+
+
+def test_switch_non_overlapping_does_not_rewrite_if_x_replicated_by_condition():
+    scale = pt.scalar("scale")
+    x = pm.Normal.dist(mu=0, sigma=1, size=(3,))
+    cond = (x[None, :] > 0) & pt.ones((2, 1), dtype="bool")
+    y = cast(TensorVariable, pt.switch(cond, x, scale * x))
+
+    with pytest.raises(NotImplementedError, match="Logprob method not implemented for Switch"):
+        logp(y, np.zeros((2, 3)), warn_rvs=False).eval({scale: 0.5})
+
+
+def test_switch_non_overlapping_does_not_rewrite_if_scale_broadcasts_x():
+    x = pm.Normal.dist(mu=0, sigma=1)
+    scale = pt.vector("scale")
+    y = cast(TensorVariable, pt.switch(x > 0, x, scale * x))
+
+    with pytest.raises(NotImplementedError, match="Logprob method not implemented for Switch"):
+        logp(y, np.zeros((3,)), warn_rvs=False).eval({scale: np.array([0.5, 0.5, 0.5])})
+
+
+def test_switch_non_overlapping_does_not_apply_to_discrete_rv():
+    a = pt.scalar("a")
+    x = pm.Poisson.dist(3)
+    y = cast(TensorVariable, pt.switch(x > 0, x, a * x))
+
+    with pytest.raises(NotImplementedError, match="Logprob method not implemented for Switch"):
+        logp(y, 1, warn_rvs=False).eval({a: 0.5})

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -43,8 +43,6 @@ import scipy.special
 
 from pytensor.graph.basic import equal_computations
 
-import pymc as pm
-
 from pymc.distributions.continuous import Cauchy, ChiSquared
 from pymc.distributions.discrete import Bernoulli
 from pymc.logprob.basic import conditional_logp, icdf, logcdf, logp
@@ -230,57 +228,6 @@ def test_exp_transform_rv():
         icdf_fn(q_val),
         sp.stats.lognorm(s=1).ppf(q_val),
     )
-
-
-def test_leaky_relu_switch_logp_scalar():
-    a = 0.5
-    x = pm.Normal.dist(mu=0, sigma=1)
-    y = pm.math.switch(x > 0, x, a * x)
-
-    v_pos = 1.2
-    np.testing.assert_allclose(
-        pm.logp(y, v_pos, warn_rvs=False).eval(),
-        pm.logp(x, v_pos, warn_rvs=False).eval(),
-    )
-
-    v_neg = -2.0
-    np.testing.assert_allclose(
-        pm.logp(y, v_neg, warn_rvs=False).eval(),
-        pm.logp(x, v_neg / a, warn_rvs=False).eval() - np.log(a),
-    )
-
-    # boundary point (measure-zero for continuous RVs): should still produce a finite logp
-    assert np.isfinite(pm.logp(y, 0.0, warn_rvs=False).eval())
-
-
-def test_leaky_relu_switch_logp_vectorized():
-    a = 0.5
-    x = pm.Normal.dist(mu=0, sigma=1, size=(3,))
-    y = pm.math.switch(x > 0, x, a * x)
-
-    v = np.array([-2.0, 0.0, 1.5])
-    expected = pm.logp(x, np.where(v > 0, v, v / a), warn_rvs=False).eval() + np.where(
-        v > 0, 0.0, -np.log(a)
-    )
-    np.testing.assert_allclose(pm.logp(y, v, warn_rvs=False).eval(), expected)
-
-
-def test_leaky_relu_switch_logp_symbolic_slope_checks_positive():
-    a = pt.scalar("a")
-    x = pm.Normal.dist(mu=0, sigma=1)
-    y = pm.math.switch(x > 0, x, a * x)
-
-    # positive slope passes
-    res = pm.logp(y, -1.0, warn_rvs=False).eval({a: 0.5})
-    expected = pm.logp(x, -1.0 / 0.5, warn_rvs=False).eval() - np.log(0.5)
-    np.testing.assert_allclose(res, expected)
-
-    # non pos slope raises
-    with pytest.raises(ParameterValueError, match="switch non-overlapping scale > 0"):
-        pm.logp(y, -1.0, warn_rvs=False).eval({a: -0.5})
-
-    with pytest.raises(ParameterValueError, match="switch non-overlapping scale > 0"):
-        pm.logp(y, -1.0, warn_rvs=False).eval({a: 0.0})
 
 
 def test_log_transform_rv():

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -276,10 +276,10 @@ def test_leaky_relu_switch_logp_symbolic_slope_checks_positive():
     np.testing.assert_allclose(res, expected)
 
     # non pos slope raises
-    with pytest.raises(ParameterValueError, match="leaky_relu slope > 0"):
+    with pytest.raises(ParameterValueError, match="switch non-overlapping scale > 0"):
         pm.logp(y, -1.0, warn_rvs=False).eval({a: -0.5})
 
-    with pytest.raises(ParameterValueError, match="leaky_relu slope > 0"):
+    with pytest.raises(ParameterValueError, match="switch non-overlapping scale > 0"):
         pm.logp(y, -1.0, warn_rvs=False).eval({a: 0.0})
 
 


### PR DESCRIPTION
## Description
added log-probability support for leaky-ReLU graphs constructed as

    y = switch(x > 0, x, a * x)

where `x` is a single continuous measurable variable.

### notes
- only supports a single continuous measurable variable.
- the slope `a` must be non-measurable and strictly positive.
- behavior at `y == 0` follows the `y <= 0` branch (measure-zero set).

## Related Issue
- Closes [#7543](https://github.com/pymc-devs/pymc/issues/7543) 

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
