### PR TITLE
Implement `logccdf` helper for numerically stable log survival function

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -512,6 +512,13 @@ class Normal(Continuous):
             msg="sigma > 0",
         )
 
+    def logccdf(value, mu, sigma):
+        return check_parameters(
+            normal_lccdf(mu, sigma, value),
+            sigma > 0,
+            msg="sigma > 0",
+        )
+
     def icdf(value, mu, sigma):
         res = mu + sigma * -np.sqrt(2.0) * pt.erfcinv(2 * value)
         res = check_icdf_value(res, value)

--- a/pymc/distributions/distribution.py
+++ b/pymc/distributions/distribution.py
@@ -50,7 +50,7 @@ from pymc.distributions.shape_utils import (
     rv_size_is_none,
     shape_from_dims,
 )
-from pymc.logprob.abstract import MeasurableOp, _icdf, _logcdf, _logprob
+from pymc.logprob.abstract import MeasurableOp, _icdf, _logccdf, _logcdf, _logprob
 from pymc.logprob.basic import logp
 from pymc.logprob.rewriting import logprob_rewrites_db
 from pymc.printing import str_for_dist
@@ -149,6 +149,17 @@ class DistributionMeta(ABCMeta):
                     elif params_idxs:
                         dist_params = [dist_params[i] for i in params_idxs]
                     return class_logcdf(value, *dist_params)
+
+            class_logccdf = clsdict.get("logccdf")
+            if class_logccdf:
+
+                @_logccdf.register(rv_type)
+                def logccdf(op, value, *dist_params, **kwargs):
+                    if isinstance(op, RandomVariable):
+                        rng, size, *dist_params = dist_params
+                    elif params_idxs:
+                        dist_params = [dist_params[i] for i in params_idxs]
+                    return class_logccdf(value, *dist_params)
 
             class_icdf = clsdict.get("icdf")
             if class_icdf:

--- a/pymc/distributions/truncated.py
+++ b/pymc/distributions/truncated.py
@@ -418,7 +418,6 @@ def truncated_logprob(op, values, *inputs, **kwargs):
     if is_lower_bounded and is_upper_bounded:
         lognorm = logdiffexp(upper_logcdf, lower_logcdf)
     elif is_lower_bounded:
-        # Use numerically stable logccdf instead of log(1 - exp(logcdf))
         lognorm = TruncatedRV._create_lower_logccdf_expr(base_rv, value, lower)
     elif is_upper_bounded:
         lognorm = upper_logcdf
@@ -456,7 +455,6 @@ def truncated_logcdf(op: TruncatedRV, value, *inputs, **kwargs):
     if is_lower_bounded and is_upper_bounded:
         lognorm = logdiffexp(upper_logcdf, lower_logcdf)
     elif is_lower_bounded:
-        # Use numerically stable logccdf instead of log(1 - exp(logcdf))
         lognorm = TruncatedRV._create_lower_logccdf_expr(base_rv, value, lower)
     elif is_upper_bounded:
         lognorm = upper_logcdf

--- a/pymc/distributions/truncated.py
+++ b/pymc/distributions/truncated.py
@@ -44,7 +44,7 @@ from pymc.distributions.shape_utils import (
 from pymc.distributions.transforms import _default_transform
 from pymc.exceptions import TruncationError
 from pymc.logprob.abstract import _logcdf, _logprob
-from pymc.logprob.basic import icdf, logcdf, logp
+from pymc.logprob.basic import icdf, logccdf, logcdf, logp
 from pymc.math import logdiffexp
 from pymc.pytensorf import collect_default_updates
 from pymc.util import check_dist_not_registered
@@ -210,6 +210,23 @@ class TruncatedRV(SymbolicRandomVariable):
         lower_logcdf = logcdf(base_rv, lower_value, warn_rvs=False)
         upper_logcdf = graph_replace(lower_logcdf, {lower_value: upper_value})
         return lower_logcdf, upper_logcdf
+
+    @staticmethod
+    def _create_lower_logccdf_expr(
+        base_rv: TensorVariable,
+        value: TensorVariable,
+        lower: TensorVariable,
+    ) -> TensorVariable:
+        """Create logccdf expression at lower bound for base_rv.
+
+        Uses `value` as a template for broadcasting. This is numerically more
+        stable than computing log(1 - exp(logcdf)) for distributions that have
+        a registered logccdf method.
+        """
+        # For left truncated discrete RVs, we need to include the whole lower bound.
+        lower_value = lower - 1 if base_rv.type.dtype.startswith("int") else lower
+        lower_value = pt.full_like(value, lower_value, dtype=config.floatX)
+        return logccdf(base_rv, lower_value, warn_rvs=False)
 
     def update(self, node: Apply):
         """Return the update mapping for the internal RNGs.
@@ -401,7 +418,8 @@ def truncated_logprob(op, values, *inputs, **kwargs):
     if is_lower_bounded and is_upper_bounded:
         lognorm = logdiffexp(upper_logcdf, lower_logcdf)
     elif is_lower_bounded:
-        lognorm = pt.log1mexp(lower_logcdf)
+        # Use numerically stable logccdf instead of log(1 - exp(logcdf))
+        lognorm = TruncatedRV._create_lower_logccdf_expr(base_rv, value, lower)
     elif is_upper_bounded:
         lognorm = upper_logcdf
 
@@ -438,7 +456,8 @@ def truncated_logcdf(op: TruncatedRV, value, *inputs, **kwargs):
     if is_lower_bounded and is_upper_bounded:
         lognorm = logdiffexp(upper_logcdf, lower_logcdf)
     elif is_lower_bounded:
-        lognorm = pt.log1mexp(lower_logcdf)
+        # Use numerically stable logccdf instead of log(1 - exp(logcdf))
+        lognorm = TruncatedRV._create_lower_logccdf_expr(base_rv, value, lower)
     elif is_upper_bounded:
         lognorm = upper_logcdf
 

--- a/pymc/logprob/__init__.py
+++ b/pymc/logprob/__init__.py
@@ -39,6 +39,7 @@
 from pymc.logprob.basic import (
     conditional_logp,
     icdf,
+    logccdf,
     logcdf,
     logp,
     transformed_conditional_logp,
@@ -59,6 +60,7 @@ import pymc.logprob.transforms
 
 __all__ = (
     "icdf",
+    "logccdf",
     "logcdf",
     "logp",
 )

--- a/pymc/logprob/abstract.py
+++ b/pymc/logprob/abstract.py
@@ -40,6 +40,8 @@ import warnings
 from collections.abc import Sequence
 from functools import singledispatch
 
+import pytensor.tensor as pt
+
 from pytensor.graph import Apply, Op, Variable
 from pytensor.graph.utils import MetaType
 from pytensor.tensor import TensorVariable
@@ -129,8 +131,17 @@ def _logccdf(
 
 
 def _logccdf_helper(rv, value, **kwargs):
-    """Helper that calls `_logccdf` dispatcher."""
-    logccdf = _logccdf(rv.owner.op, value, *rv.owner.inputs, name=rv.name, **kwargs)
+    """Helper that calls `_logccdf` dispatcher with fallback to log1mexp(logcdf).
+
+    If a numerically stable `_logccdf` implementation is registered for the
+    distribution, it will be used. Otherwise, falls back to computing
+    `log(1 - exp(logcdf))` which may be numerically unstable in the tails.
+    """
+    try:
+        logccdf = _logccdf(rv.owner.op, value, *rv.owner.inputs, name=rv.name, **kwargs)
+    except NotImplementedError:
+        logcdf = _logcdf_helper(rv, value, **kwargs)
+        logccdf = pt.log1mexp(logcdf)
 
     if rv.name:
         logccdf.name = f"{rv.name}_logccdf"

--- a/pymc/logprob/abstract.py
+++ b/pymc/logprob/abstract.py
@@ -40,11 +40,9 @@ import warnings
 from collections.abc import Sequence
 from functools import singledispatch
 
-import pytensor.tensor as pt
-
 from pytensor.graph import Apply, Op, Variable
 from pytensor.graph.utils import MetaType
-from pytensor.tensor import TensorVariable
+from pytensor.tensor import TensorVariable, log1mexp
 from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.random.op import RandomVariable
@@ -141,7 +139,7 @@ def _logccdf_helper(rv, value, **kwargs):
         logccdf = _logccdf(rv.owner.op, value, *rv.owner.inputs, name=rv.name, **kwargs)
     except NotImplementedError:
         logcdf = _logcdf_helper(rv, value, **kwargs)
-        logccdf = pt.log1mexp(logcdf)
+        logccdf = log1mexp(logcdf)
 
     if rv.name:
         logccdf.name = f"{rv.name}_logccdf"

--- a/pymc/logprob/abstract.py
+++ b/pymc/logprob/abstract.py
@@ -109,6 +109,36 @@ def _logcdf_helper(rv, value, **kwargs):
 
 
 @singledispatch
+def _logccdf(
+    op: Op,
+    value: TensorVariable,
+    *inputs: TensorVariable,
+    **kwargs,
+):
+    """Create a graph for the log complementary CDF (log survival function) of a ``RandomVariable``.
+
+    This function dispatches on the type of ``op``, which should be a subclass
+    of ``RandomVariable``.  If you want to implement new logccdf graphs
+    for a ``RandomVariable``, register a new function on this dispatcher.
+
+    The log complementary CDF is defined as log(1 - CDF(x)), also known as the
+    log survival function. For distributions with a numerically stable implementation,
+    this should be used instead of computing log(1 - exp(logcdf)).
+    """
+    raise NotImplementedError(f"LogCCDF method not implemented for {op}")
+
+
+def _logccdf_helper(rv, value, **kwargs):
+    """Helper that calls `_logccdf` dispatcher."""
+    logccdf = _logccdf(rv.owner.op, value, *rv.owner.inputs, name=rv.name, **kwargs)
+
+    if rv.name:
+        logccdf.name = f"{rv.name}_logccdf"
+
+    return logccdf
+
+
+@singledispatch
 def _icdf(
     op: Op,
     value: TensorVariable,

--- a/pymc/logprob/basic.py
+++ b/pymc/logprob/basic.py
@@ -357,9 +357,10 @@ def logccdf(rv: TensorVariable, value: TensorLike, warn_rvs=True, **kwargs) -> T
         return _logccdf_helper(rv, value, **kwargs)
     except NotImplementedError:
         # Try to rewrite rv
-        fgraph, _, _ = construct_ir_fgraph({rv: value})
-        [ir_rv] = fgraph.outputs
-        expr = _logccdf_helper(ir_rv, value, **kwargs)
+        fgraph = construct_ir_fgraph({rv: value})
+        [ir_valued_rv] = fgraph.outputs
+        [ir_rv, ir_value] = ir_valued_rv.owner.inputs
+        expr = _logccdf_helper(ir_rv, ir_value, **kwargs)
         [expr] = cleanup_ir([expr])
         if warn_rvs:
             _warn_rvs_in_inferred_graph([expr])

--- a/pymc/logprob/basic.py
+++ b/pymc/logprob/basic.py
@@ -53,6 +53,7 @@ from pytensor.tensor.variable import TensorVariable
 from pymc.logprob.abstract import (
     MeasurableOp,
     _icdf_helper,
+    _logccdf_helper,
     _logcdf_helper,
     _logprob,
     _logprob_helper,
@@ -296,6 +297,69 @@ def logcdf(rv: TensorVariable, value: TensorLike, warn_rvs=True, **kwargs) -> Te
         [ir_valued_rv] = fgraph.outputs
         [ir_rv, ir_value] = ir_valued_rv.owner.inputs
         expr = _logcdf_helper(ir_rv, ir_value, **kwargs)
+        [expr] = cleanup_ir([expr])
+        if warn_rvs:
+            _warn_rvs_in_inferred_graph([expr])
+        return expr
+
+
+def logccdf(rv: TensorVariable, value: TensorLike, warn_rvs=True, **kwargs) -> TensorVariable:
+    """Create a graph for the log complementary CDF (log survival function) of a random variable.
+
+    The log complementary CDF is defined as log(1 - CDF(x)), also known as the
+    log survival function. For distributions with a numerically stable implementation,
+    this is more accurate than computing log(1 - exp(logcdf)).
+
+    Parameters
+    ----------
+    rv : TensorVariable
+    value : tensor_like
+        Should be the same type (shape and dtype) as the rv.
+    warn_rvs : bool, default True
+        Warn if RVs were found in the logccdf graph.
+        This can happen when a variable has other random variables as inputs.
+        In that case, those random variables should be replaced by their respective values.
+
+    Returns
+    -------
+    logccdf : TensorVariable
+
+    Raises
+    ------
+    RuntimeError
+        If the logccdf cannot be derived.
+
+    Examples
+    --------
+    Create a compiled function that evaluates the logccdf of a variable
+
+    .. code-block:: python
+
+        import pymc as pm
+        import pytensor.tensor as pt
+
+        mu = pt.scalar("mu")
+        rv = pm.Normal.dist(mu, 1.0)
+
+        value = pt.scalar("value")
+        rv_logccdf = pm.logccdf(rv, value)
+
+        # Use .eval() for debugging
+        print(rv_logccdf.eval({value: 0.9, mu: 0.0}))  # -1.5272506
+
+        # Compile a function for repeated evaluations
+        rv_logccdf_fn = pm.compile_pymc([value, mu], rv_logccdf)
+        print(rv_logccdf_fn(value=0.9, mu=0.0))  # -1.5272506
+
+    """
+    value = pt.as_tensor_variable(value, dtype=rv.dtype)
+    try:
+        return _logccdf_helper(rv, value, **kwargs)
+    except NotImplementedError:
+        # Try to rewrite rv
+        fgraph, _, _ = construct_ir_fgraph({rv: value})
+        [ir_rv] = fgraph.outputs
+        expr = _logccdf_helper(ir_rv, value, **kwargs)
         [expr] = cleanup_ir([expr])
         if warn_rvs:
             _warn_rvs_in_inferred_graph([expr])

--- a/pymc/logprob/binary.py
+++ b/pymc/logprob/binary.py
@@ -25,6 +25,7 @@ from pytensor.tensor.math import ge, gt, invert, le, lt
 
 from pymc.logprob.abstract import (
     MeasurableElemwise,
+    _logccdf,
     _logcdf_helper,
     _logprob,
     _logprob_helper,
@@ -95,7 +96,12 @@ def comparison_logprob(op, values, base_rv, operand, **kwargs):
     base_rv_op = base_rv.owner.op
 
     logcdf = _logcdf_helper(base_rv, operand, **kwargs)
-    logccdf = pt.log1mexp(logcdf)
+    # Try to use a numerically stable logccdf if available, otherwise fall back
+    # to computing log(1 - exp(logcdf)) which can be unstable in the tails
+    try:
+        logccdf = _logccdf(base_rv_op, operand, *base_rv.owner.inputs, **kwargs)
+    except NotImplementedError:
+        logccdf = pt.log1mexp(logcdf)
 
     condn_exp = pt.eq(value, np.array(True))
 

--- a/pymc/logprob/binary.py
+++ b/pymc/logprob/binary.py
@@ -25,7 +25,7 @@ from pytensor.tensor.math import ge, gt, invert, le, lt
 
 from pymc.logprob.abstract import (
     MeasurableElemwise,
-    _logccdf,
+    _logccdf_helper,
     _logcdf_helper,
     _logprob,
     _logprob_helper,
@@ -96,12 +96,7 @@ def comparison_logprob(op, values, base_rv, operand, **kwargs):
     base_rv_op = base_rv.owner.op
 
     logcdf = _logcdf_helper(base_rv, operand, **kwargs)
-    # Try to use a numerically stable logccdf if available, otherwise fall back
-    # to computing log(1 - exp(logcdf)) which can be unstable in the tails
-    try:
-        logccdf = _logccdf(base_rv_op, operand, *base_rv.owner.inputs, **kwargs)
-    except NotImplementedError:
-        logccdf = pt.log1mexp(logcdf)
+    logccdf = _logccdf_helper(base_rv, operand, **kwargs)
 
     condn_exp = pt.eq(value, np.array(True))
 

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -119,7 +119,6 @@ def clip_logprob(op, values, base_rv, lower_bound, upper_bound, **kwargs):
     if not (isinstance(upper_bound, TensorConstant) and np.all(np.isinf(upper_bound.value))):
         is_upper_bounded = True
 
-        # Use numerically stable logccdf (falls back to log1mexp if not available)
         logccdf = _logccdf_helper(base_rv, value, **kwargs)
 
         # For right clipped discrete RVs, we need to add an extra term

--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -47,7 +47,7 @@ from pytensor.tensor import TensorVariable
 from pytensor.tensor.math import ceil, clip, floor, round_half_to_even
 from pytensor.tensor.variable import TensorConstant
 
-from pymc.logprob.abstract import MeasurableElemwise, _logccdf, _logcdf, _logprob
+from pymc.logprob.abstract import MeasurableElemwise, _logccdf_helper, _logcdf, _logprob
 from pymc.logprob.rewriting import measurable_ir_rewrites_db
 from pymc.logprob.utils import CheckParameterValue, filter_measurable_variables
 
@@ -119,12 +119,8 @@ def clip_logprob(op, values, base_rv, lower_bound, upper_bound, **kwargs):
     if not (isinstance(upper_bound, TensorConstant) and np.all(np.isinf(upper_bound.value))):
         is_upper_bounded = True
 
-        # Try to use a numerically stable logccdf if available, otherwise fall back
-        # to computing log(1 - exp(logcdf)) which can be unstable in the tails
-        try:
-            logccdf = _logccdf(base_rv_op, value, *base_rv_inputs, **kwargs)
-        except NotImplementedError:
-            logccdf = pt.log1mexp(logcdf)
+        # Use numerically stable logccdf (falls back to log1mexp if not available)
+        logccdf = _logccdf_helper(base_rv, value, **kwargs)
 
         # For right clipped discrete RVs, we need to add an extra term
         # corresponding to the pmf at the upper bound

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -249,8 +249,8 @@ def measurable_transform_logcdf(op: MeasurableTransform, value, *inputs, **kwarg
 
     logcdf = _logcdf_helper(measurable_input, backward_value)
     if is_discrete:
-        # For discrete distributions, use the logcdf at the previous value
-        logccdf = pt.log1mexp(_logcdf_helper(measurable_input, backward_value - 1))
+        # For discrete distributions, P(X >= t) = P(X > t-1)
+        logccdf = _logccdf_helper(measurable_input, backward_value - 1)
     else:
         # Use numerically stable logccdf (falls back to log1mexp if not available)
         logccdf = _logccdf_helper(measurable_input, backward_value)

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -252,12 +252,8 @@ def measurable_transform_logcdf(op: MeasurableTransform, value, *inputs, **kwarg
         # For discrete distributions, use the logcdf at the previous value
         logccdf = pt.log1mexp(_logcdf_helper(measurable_input, backward_value - 1))
     else:
-        # Try to use a numerically stable logccdf if available, otherwise fall back
-        # to computing log(1 - exp(logcdf)) which can be unstable in the tails
-        try:
-            logccdf = _logccdf_helper(measurable_input, backward_value)
-        except NotImplementedError:
-            logccdf = pt.log1mexp(logcdf)
+        # Use numerically stable logccdf (falls back to log1mexp if not available)
+        logccdf = _logccdf_helper(measurable_input, backward_value)
 
     if isinstance(op.scalar_op, MONOTONICALLY_INCREASING_OPS):
         pass

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -252,7 +252,6 @@ def measurable_transform_logcdf(op: MeasurableTransform, value, *inputs, **kwarg
         # For discrete distributions, P(X >= t) = P(X > t-1)
         logccdf = _logccdf_helper(measurable_input, backward_value - 1)
     else:
-        # Use numerically stable logccdf (falls back to log1mexp if not available)
         logccdf = _logccdf_helper(measurable_input, backward_value)
 
     if isinstance(op.scalar_op, MONOTONICALLY_INCREASING_OPS):

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -238,34 +238,7 @@ class TestSymbolicRandomVariable:
         assert resized_rv.type.shape == (5,)
 
     def test_logccdf_with_extended_signature(self):
-        """Test logccdf registration for SymbolicRandomVariable with extended_signature.
-
-        What: Tests that a custom Distribution subclass using SymbolicRandomVariable
-        with an extended_signature can define a logccdf method that gets properly
-        registered and dispatched.
-
-        Why: The DistributionMeta metaclass has two code paths for registering
-        distribution methods like logp, logcdf, logccdf:
-        1. For standard RandomVariable ops: unpack (rng, size, *params)
-        2. For SymbolicRandomVariable with extended_signature: use params_idxs
-
-        This test specifically exercises path #2 (the params_idxs branch) to ensure
-        logccdf works for custom distributions that wrap other distributions with
-        additional graph structure.
-
-        How:
-        1. Creates a custom Distribution (TestDistWithLogccdf) that:
-           - Uses a SymbolicRandomVariable with extended_signature
-           - Wraps a Normal distribution internally
-           - Defines a logccdf method using normal_lccdf
-        2. Creates an instance with mu=0, sigma=1
-        3. Evaluates pm.logccdf at value=0.5
-        4. Compares against scipy.stats.norm.logsf reference
-
-        The extended_signature "[rng],[size],(),()->[rng],()" means:
-        - Inputs: rng, size, and two scalar params (mu, sigma)
-        - Outputs: next_rng and scalar draws
-        """
+        """Test logccdf registration for SymbolicRandomVariable with extended_signature."""
         from pymc.distributions.dist_math import normal_lccdf
         from pymc.distributions.distribution import Distribution
 

--- a/tests/logprob/test_abstract.py
+++ b/tests/logprob/test_abstract.py
@@ -45,12 +45,7 @@ from pytensor.scalar import Exp, exp
 
 import pymc as pm
 
-from pymc.logprob.abstract import (
-    MeasurableElemwise,
-    MeasurableOp,
-    _logccdf_helper,
-    _logcdf_helper,
-)
+from pymc.logprob.abstract import MeasurableElemwise, MeasurableOp, _logcdf_helper
 from pymc.logprob.basic import logccdf, logcdf
 
 
@@ -83,17 +78,6 @@ def test_logcdf_helper():
 
     x_logcdf = _logcdf_helper(x, [0, 1])
     np.testing.assert_almost_equal(x_logcdf.eval(), sp.norm(0, 1).logcdf([0, 1]))
-
-
-def test_logccdf_helper():
-    value = pt.vector("value")
-    x = pm.Normal.dist(0, 1)
-
-    x_logccdf = _logccdf_helper(x, value)
-    np.testing.assert_almost_equal(x_logccdf.eval({value: [0, 1]}), sp.norm(0, 1).logsf([0, 1]))
-
-    x_logccdf = _logccdf_helper(x, [0, 1])
-    np.testing.assert_almost_equal(x_logccdf.eval(), sp.norm(0, 1).logsf([0, 1]))
 
 
 def test_logcdf_transformed_argument():
@@ -153,16 +137,6 @@ def test_logccdf_fallback():
     # Normal has logccdf - should NOT use fallback
     normal_logccdf = logccdf(pm.Normal.dist(0, 1), 0.5)
     assert not graph_contains_log1mexp(normal_logccdf)
-
-
-def test_logccdf_helper_discrete():
-    """Test that logccdf computes P(X > x), not P(X >= x), for discrete RVs."""
-    p = 0.7
-    x = pm.Bernoulli.dist(p=p)
-
-    np.testing.assert_almost_equal(_logccdf_helper(x, -1).eval(), 0.0)  # P(X > -1) = 1
-    np.testing.assert_almost_equal(_logccdf_helper(x, 0).eval(), np.log(p))  # P(X > 0) = p
-    assert _logccdf_helper(x, 1).eval() == -np.inf  # P(X > 1) = 0
 
 
 def test_logccdf_discrete():

--- a/tests/logprob/test_abstract.py
+++ b/tests/logprob/test_abstract.py
@@ -155,26 +155,6 @@ def test_logccdf_fallback():
     assert not graph_contains_log1mexp(normal_logccdf)
 
 
-def test_logccdf_transformed_argument():
-    with pm.Model() as m:
-        sigma = pm.HalfFlat("sigma")
-        x = pm.Normal("x", 0, sigma)
-        pm.Potential("norm_term", logccdf(x, 1.0))
-
-    sigma_value_log = -1.0
-    sigma_value = np.exp(sigma_value_log)  # sigma ≈ 0.368
-    x_value = 0.5
-
-    observed = m.compile_logp(jacobian=False)({"sigma_log__": sigma_value_log, "x": x_value})
-
-    # Expected = logp(x | sigma) + logccdf(Normal(0, sigma), 1.0)
-    expected_logp = pm.logp(pm.Normal.dist(0, sigma_value), x_value).eval()
-    expected_logsf = sp.norm(0, sigma_value).logsf(1.0)
-    expected = expected_logp + expected_logsf
-
-    assert np.isclose(observed, expected)
-
-
 def test_logccdf_helper_discrete():
     """Test that logccdf computes P(X > x), not P(X >= x), for discrete RVs."""
     p = 0.7

--- a/tests/logprob/test_abstract.py
+++ b/tests/logprob/test_abstract.py
@@ -159,23 +159,3 @@ def test_logccdf_discrete():
     expected = sp.poisson(mu).logsf(test_values)
 
     np.testing.assert_allclose(result, expected, rtol=1e-6)
-
-
-def test_logccdf_negated_discrete():
-    """Test logccdf on Y = -Bernoulli (decreasing transform)."""
-    p = 0.7
-    rv = -pm.Bernoulli.dist(p=p)
-
-    np.testing.assert_almost_equal(logccdf(rv, -2).eval(), 0.0)  # P(Y > -2) = 1
-    np.testing.assert_almost_equal(logccdf(rv, -1).eval(), np.log(1 - p))  # P(Y > -1) = 1-p
-    assert logccdf(rv, 0).eval() == -np.inf  # P(Y > 0) = 0
-
-
-def test_logccdf_shifted_discrete():
-    """Test logccdf on Y = Bernoulli + 5 (increasing transform)."""
-    p = 0.7
-    rv = pm.Bernoulli.dist(p=p) + 5
-
-    np.testing.assert_almost_equal(logccdf(rv, 4).eval(), 0.0)  # P(Y > 4) = 1
-    np.testing.assert_almost_equal(logccdf(rv, 5).eval(), np.log(p))  # P(Y > 5) = p
-    assert logccdf(rv, 6).eval() == -np.inf  # P(Y > 6) = 0

--- a/tests/logprob/test_abstract.py
+++ b/tests/logprob/test_abstract.py
@@ -117,7 +117,18 @@ def test_logccdf_numerical_stability():
 
 
 def test_logccdf_fallback():
-    """Distributions without logccdf should fall back to log1mexp(logcdf)."""
+    """Distributions without logccdf should fall back to log1mexp(logcdf).
+
+    This test assumes Uniform does not implement logccdf. Implementing one would
+    not be very useful since the logcdf is very simple and there are no numerical
+    stability concerns. If Uniform ever gets a logccdf implementation, this test
+    should be updated to use a different distribution without one.
+
+    Before rewrites, the logccdf graph for Uniform should contain log1mexp.
+
+    Normal implements a specialized logccdf using erfc/erfcx, so its graph, even
+    before rewrites, should not contain log1mexp.
+    """
     from pytensor.graph.traversal import ancestors
     from pytensor.scalar.math import Log1mexp
     from pytensor.tensor.elemwise import Elemwise

--- a/tests/logprob/test_abstract.py
+++ b/tests/logprob/test_abstract.py
@@ -96,27 +96,6 @@ def test_logccdf_helper():
     np.testing.assert_almost_equal(x_logccdf.eval(), sp.norm(0, 1).logsf([0, 1]))
 
 
-def test_logccdf_helper_numerical_stability():
-    """Test that logccdf is numerically stable in the far right tail.
-
-    This is where log(1 - exp(logcdf)) would lose precision because CDF is very close to 1.
-    """
-    x = pm.Normal.dist(0, 1)
-
-    # Test value far in the right tail where CDF is essentially 1
-    far_tail_value = 10.0
-
-    x_logccdf = _logccdf_helper(x, far_tail_value)
-    result = x_logccdf.eval()
-
-    # scipy.stats.norm.logsf uses a numerically stable implementation
-    expected = sp.norm(0, 1).logsf(far_tail_value)
-
-    # The naive computation would give log(1 - 1) = -inf or very wrong values
-    # The stable implementation should match scipy's logsf closely
-    np.testing.assert_almost_equal(result, expected, decimal=6)
-
-
 def test_logcdf_transformed_argument():
     with pm.Model() as m:
         sigma = pm.HalfFlat("sigma")

--- a/tests/logprob/test_abstract.py
+++ b/tests/logprob/test_abstract.py
@@ -45,8 +45,13 @@ from pytensor.scalar import Exp, exp
 
 import pymc as pm
 
-from pymc.logprob.abstract import MeasurableElemwise, MeasurableOp, _logcdf_helper
-from pymc.logprob.basic import logcdf
+from pymc.logprob.abstract import (
+    MeasurableElemwise,
+    MeasurableOp,
+    _logccdf_helper,
+    _logcdf_helper,
+)
+from pymc.logprob.basic import logccdf, logcdf
 
 
 def assert_equal_hash(classA, classB):
@@ -80,6 +85,38 @@ def test_logcdf_helper():
     np.testing.assert_almost_equal(x_logcdf.eval(), sp.norm(0, 1).logcdf([0, 1]))
 
 
+def test_logccdf_helper():
+    value = pt.vector("value")
+    x = pm.Normal.dist(0, 1)
+
+    x_logccdf = _logccdf_helper(x, value)
+    np.testing.assert_almost_equal(x_logccdf.eval({value: [0, 1]}), sp.norm(0, 1).logsf([0, 1]))
+
+    x_logccdf = _logccdf_helper(x, [0, 1])
+    np.testing.assert_almost_equal(x_logccdf.eval(), sp.norm(0, 1).logsf([0, 1]))
+
+
+def test_logccdf_helper_numerical_stability():
+    """Test that logccdf is numerically stable in the far right tail.
+
+    This is where log(1 - exp(logcdf)) would lose precision because CDF is very close to 1.
+    """
+    x = pm.Normal.dist(0, 1)
+
+    # Test value far in the right tail where CDF is essentially 1
+    far_tail_value = 10.0
+
+    x_logccdf = _logccdf_helper(x, far_tail_value)
+    result = x_logccdf.eval()
+
+    # scipy.stats.norm.logsf uses a numerically stable implementation
+    expected = sp.norm(0, 1).logsf(far_tail_value)
+
+    # The naive computation would give log(1 - 1) = -inf or very wrong values
+    # The stable implementation should match scipy's logsf closely
+    np.testing.assert_almost_equal(result, expected, decimal=6)
+
+
 def test_logcdf_transformed_argument():
     with pm.Model() as m:
         sigma = pm.HalfFlat("sigma")
@@ -95,3 +132,31 @@ def test_logcdf_transformed_argument():
         pm.TruncatedNormal.dist(0, sigma_value, lower=None, upper=1.0), x_value
     ).eval()
     assert np.isclose(observed, expected)
+
+
+def test_logccdf():
+    """Test the public logccdf function."""
+    value = pt.vector("value")
+    x = pm.Normal.dist(0, 1)
+
+    x_logccdf = logccdf(x, value)
+    np.testing.assert_almost_equal(x_logccdf.eval({value: [0, 1]}), sp.norm(0, 1).logsf([0, 1]))
+
+
+def test_logccdf_numerical_stability():
+    """Test that pm.logccdf is numerically stable in the extreme right tail.
+
+    For a normal distribution, the log survival function at x=10 is very negative
+    (around -52). Using log(1 - exp(logcdf)) would fail because CDF(10) is essentially 1.
+    """
+    x = pm.Normal.dist(0, 1)
+
+    # Test value far in the right tail
+    far_tail_value = 10.0
+
+    result = logccdf(x, far_tail_value).eval()
+    expected = sp.norm(0, 1).logsf(far_tail_value)
+
+    # Should be around -52, not -inf or nan
+    assert np.isfinite(result)
+    np.testing.assert_almost_equal(result, expected, decimal=6)

--- a/tests/logprob/test_censoring.py
+++ b/tests/logprob/test_censoring.py
@@ -41,6 +41,8 @@ import pytest
 import scipy as sp
 import scipy.stats as st
 
+import pymc as pm
+
 from pymc import logp
 from pymc.logprob import conditional_logp
 from pymc.logprob.transform_value import TransformValuesRewrite
@@ -281,8 +283,6 @@ def test_censored_logprob_numerical_stability(censoring_side, bound_value):
 
     This test uses pm.Censored which is the high-level API for censored distributions.
     """
-    import pymc as pm
-
     ref_scipy = st.norm(0, 1)
 
     with pm.Model() as model:

--- a/tests/logprob/test_censoring.py
+++ b/tests/logprob/test_censoring.py
@@ -268,42 +268,66 @@ def test_rounding(rounding_op):
 @pytest.mark.parametrize(
     "censoring_side,bound_value",
     [
-        ("right", 40.0),  # Far right tail: CDF ≈ 1, need stable log(1-CDF)
-        ("left", -40.0),  # Far left tail: CDF ≈ 0, need stable log(CDF)
+        ("right", 100.0),  # Far right tail: CDF ≈ 1, need stable log(1-CDF)
+        ("left", -100.0),  # Far left tail: CDF ≈ 0, need stable log(CDF)
     ],
 )
 def test_censored_logprob_numerical_stability(censoring_side, bound_value):
-    """Test that censored distributions use numerically stable log-probability computations.
+    """Test numerical stability of pm.Censored at extreme tail values.
 
-    For right-censoring at the upper bound, log(1 - CDF) is computed. When CDF ≈ 1
-    (far right tail), this requires a stable logccdf implementation.
+    What: Verifies that the log-probability of a censored Normal distribution
+    is computed correctly when the censoring bound is far in the tail
+    (100 standard deviations from the mean).
 
-    For left-censoring at the lower bound, log(CDF) is computed. When CDF ≈ 0
-    (far left tail), this requires a stable logcdf implementation.
+    Why: Censored distributions require computing:
+    - Right-censored at upper bound: log(P(X > upper)) = log(1 - CDF(upper)) = logccdf
+    - Left-censored at lower bound: log(P(X < lower)) = log(CDF(lower)) = logcdf
 
-    This test uses pm.Censored which is the high-level API for censored distributions.
+    At extreme tail values (100 sigma):
+    - CDF(100) is indistinguishable from 1.0 in float64
+    - CDF(-100) is indistinguishable from 0.0 in float64
+
+    Naive computation would give:
+    - Right: log(1 - 1) = log(0) = -inf ✗
+    - Left: log(0) = -inf ✗
+
+    With stable logccdf/logcdf:
+    - Right: ≈ -5005.5 ✓
+    - Left: ≈ -5005.5 ✓
+
+    How:
+    1. Creates pm.Censored with Normal(0, 1) base distribution
+    2. Sets censoring bound at ±100 (100 standard deviations)
+    3. Evaluates logp at the bound value
+    4. Compares against scipy.stats.norm.logsf (right) or logcdf (left)
+    5. Verifies result is finite and matches reference within tolerance
+
+    Using 100 sigma future-proofs against any improvements in naive methods.
+    This is the primary integration test for the logccdf feature.
     """
     ref_scipy = st.norm(0, 1)
 
     with pm.Model() as model:
         normal_dist = pm.Normal.dist(mu=0.0, sigma=1.0)
         if censoring_side == "right":
+            # Right-censored: values > upper are censored to upper
+            # logp(y=upper) = log(P(X >= upper)) = logsf(upper)
             pm.Censored("y", normal_dist, lower=None, upper=bound_value)
-            expected_logp = ref_scipy.logsf(bound_value)  # log(1 - CDF)
-        else:  # left
+            expected_logp = ref_scipy.logsf(bound_value)
+        else:
+            # Left-censored: values < lower are censored to lower
+            # logp(y=lower) = log(P(X <= lower)) = logcdf(lower)
             pm.Censored("y", normal_dist, lower=bound_value, upper=None)
-            expected_logp = ref_scipy.logcdf(bound_value)  # log(CDF)
+            expected_logp = ref_scipy.logcdf(bound_value)
 
-    # Compile the logp function
     logp_fn = model.compile_logp()
-
-    # Evaluate at the bound - this is where the log survival/cdf function is used
     logp_at_bound = logp_fn({"y": bound_value})
 
-    # This should be finite and correct, not -inf
+    # Must be finite (not -inf from naive computation)
     assert np.isfinite(logp_at_bound), (
         f"logp at {censoring_side} bound should be finite, got {logp_at_bound}"
     )
+    # Must match scipy reference (≈ -5005.5 for ±100 sigma)
     assert np.isclose(logp_at_bound, expected_logp, rtol=1e-6), (
         f"logp at {censoring_side} bound: got {logp_at_bound}, expected {expected_logp}"
     )

--- a/tests/logprob/test_transforms.py
+++ b/tests/logprob/test_transforms.py
@@ -734,6 +734,10 @@ def test_negated_discrete_rv_transform():
     logcdf_fn = pytensor.function([vv], logcdf(rv, vv))
     np.testing.assert_allclose(logcdf_fn([-2, -1, 0, 1]), [-np.inf, np.log(p), 0, 0])
 
+    # logccdf: P(Y > y)
+    logccdf_fn = pytensor.function([vv], logccdf(rv, vv))
+    np.testing.assert_allclose(logccdf_fn([-2, -1, 0, 1]), [0, np.log(1 - p), -np.inf, -np.inf])
+
     with pytest.raises(NotImplementedError):
         icdf(rv, [-2, -1, 0, 1])
 
@@ -754,6 +758,13 @@ def test_shifted_discrete_rv_transform():
     np.testing.assert_allclose(rv_logcdf_fn(5), np.log(1 - p))
     np.testing.assert_allclose(rv_logcdf_fn(6), 0)
     assert rv_logcdf_fn(7) == 0
+
+    # logccdf: P(Y > y)
+    rv_logccdf_fn = pytensor.function([vv], logccdf(rv, vv))
+    np.testing.assert_allclose(rv_logccdf_fn(4), 0)
+    np.testing.assert_allclose(rv_logccdf_fn(5), np.log(p))
+    assert rv_logccdf_fn(6) == -np.inf
+    assert rv_logccdf_fn(7) == -np.inf
 
     # icdf not supported yet
     with pytest.raises(NotImplementedError):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
**Disclosure:** With assistance from `claude-4.5-opus-high` via Cursor.

This PR adds a `_logccdf` (log complementary CDF / log survival function) dispatcher to fix numerical instability when computing log-probabilities for censored distributions at extreme tail values.

**The Problem:**
For right-censored distributions, the log-probability at the upper bound requires computing `log(1 - CDF)`. The existing implementation uses `log1mexp(logcdf)`, which breaks down when `CDF ≈ 1` (far right tail). For example, a censored `Normal(0, 1)` at 40 standard deviations returns `-inf` instead of the correct `≈ -804.6`.

**The Solution:**
Add a `_logccdf` dispatcher that allows distributions to provide a numerically stable log survival function. For `Normal`, this uses the existing `normal_lccdf` function (based on `erfcx`) which is stable across the entire domain.

**Changes:**
- `pymc/logprob/abstract.py`: Add `_logccdf` singledispatch and `_logccdf_helper`
- `pymc/distributions/distribution.py`: Register `logccdf` methods via metaclass
- `pymc/distributions/continuous.py`: Add `logccdf` to `Normal` using stable `normal_lccdf`
- `pymc/logprob/censoring.py`: Use `_logccdf` for right-censored distributions when available
- `pymc/logprob/binary.py`: Use `_logccdf` for comparison operations
- `pymc/logprob/transforms.py`: Use `_logccdf_helper` for monotonic transforms
- `pymc/logprob/basic.py`: Add public `logccdf()` function
- `pymc/logprob/__init__.py`: Export `logccdf`

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [X] Related to https://github.com/brendanjmeade/celeri/issues/341

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->