### PR TITLE
Added quiet argument to sample() to suppress all output

### DIFF
--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -517,6 +517,7 @@ def sample_jax_nuts(
     var_names: Sequence[str] | None = None,
     nuts_kwargs: dict | None = None,
     progressbar: bool = True,
+    quiet: bool = False,
     keep_untransformed: bool = False,
     chain_method: Literal["parallel", "vectorized"] = "parallel",
     postprocessing_backend: Literal["cpu", "gpu"] | None = None,
@@ -613,6 +614,9 @@ def sample_jax_nuts(
         postprocessing_vectorize = "vmap"
 
     model = modelcontext(model)
+
+    if quiet:
+        progress_bar = False
 
     if var_names is not None:
         filtered_var_names = [v for v in model.unobserved_value_vars if v.name in var_names]
@@ -719,8 +723,9 @@ def sample_jax_nuts(
 
     if compute_convergence_checks:
         warns = run_convergence_checks(az_trace, model)
-        log_warnings(warns)
-
+        if not quiet:
+            log_warnings(warns)
+            
     return az_trace
 
 


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description

Adds a `quiet=` argument to `sample()` that completely suppresses all logging output and progress bars during sampling. This is done by temporarily raising PyMC logger levels above CRITICAL and forcing `progressbar=False`, making it ideal for sampling in loops or automated pipelines. A couple of minimal test cases included.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7683 
- [x] Replaces #8023 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
