### PR TITLE
Only use threadpool_limits when start method is not fork

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -601,6 +601,7 @@ def sample(
         number of blas threads. If `blas_cores` is not divisible by `cores`, it might get rounded
         down. If set to None, this will keep the default behavior of whatever blas implementation
         is used at runtime.
+        Note that this argument is ignored when using fork multiprocessing start method.
     initvals : optional, dict, array of dict
         Dict or list of dicts with initial value strategies to use instead of the defaults from
         `Model.initial_values`. The keys should be names of transformed random variables.

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -113,7 +113,6 @@ class _Process:
         # the rng instance to the child process because pickling (copying) looses
         # the seed sequence state information. For this reason, we send a
         # RandomGeneratorState instead.
-        # The blas_cores argument is ignored when using fork multiprocessing start method
         rng = random_generator_from_state(rng_state)
         self._msg_pipe = msg_pipe
         self._step_method = step_method

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -148,12 +148,11 @@ class _Process:
 
     def run(self):
         # Only apply threadpool_limits for non-fork methods.
-        context = (
+        with = (
             nullcontext()
             if self._mp_start_method == "fork"
             else threadpool_limits(limits=self._blas_cores)
         )
-        with context:
             try:
                 # We do not create this in __init__, as pickling this
                 # would destroy the shared memory.

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -147,7 +147,7 @@ class _Process:
 
     def run(self):
         # Only apply threadpool_limits for non-fork methods.
-        with = (
+        with (
             nullcontext()
             if self._mp_start_method == "fork"
             else threadpool_limits(limits=self._blas_cores)

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -151,7 +151,7 @@ class _Process:
             nullcontext()
             if self._mp_start_method == "fork"
             else threadpool_limits(limits=self._blas_cores)
-        )
+        ):
             try:
                 # We do not create this in __init__, as pickling this
                 # would destroy the shared memory.

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -145,8 +145,7 @@ class _Process:
                 raise ValueError(unpickle_error)
 
     def run(self):
-        # Only apply threadpool_limits for non-fork methods.
-        # With fork, the child inherits the parent's thread pool settings.
+        # Remove condition when fork is no longer supported
         with threadpool_limits(
             limits=self._blas_cores if self._mp_start_method != "fork" else None
         ):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description

Eliminates sampling failure when using "fork" mp start method.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7354
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
