### PR TITLE
Port nutpie's progress bar for use in notebooks

### DIFF
--- a/pymc/progress_bar.py
+++ b/pymc/progress_bar.py
@@ -307,7 +307,7 @@ class TerminalProgress(Progress):
             return super().add_task(*args, **kwargs)
         return None
 
-    def advance(self, task_id, advance: int = 1) -> None:
+    def advance(self, task_id, advance: float = 1) -> None:
         if self.is_enabled and task_id is not None:
             super().advance(task_id, advance)
 

--- a/pymc/progress_bar.py
+++ b/pymc/progress_bar.py
@@ -398,7 +398,13 @@ class ProgressBarManager:
         progressbar: bool | ProgressBarType = True,
         progressbar_theme=None,  # Kept for backward compatibility, but unused in HTML mode
     ):
-        """Initialize the progress bar manager.
+        """Manage progress bars displayed during sampling.
+
+        When sampling, Step classes are responsible for computing and exposing statistics that can be reported on
+        progress bars. Each Step implements two class methods: :meth:`pymc.step_methods.BlockedStep._progressbar_config`
+        and :meth:`pymc.step_methods.BlockedStep._make_progressbar_update_functions`. `_progressbar_config` reports which
+        columns should be displayed on the progress bar, and `_make_progressbar_update_functions` computes the statistics
+        that will be displayed on the progress bar.
 
         Parameters
         ----------
@@ -407,14 +413,25 @@ class ProgressBarManager:
         chains : int
             Number of chains being sampled
         draws : int
-            Number of draws per chain (excluding tune)
+            Number of draws per chain
         tune : int
             Number of tuning steps per chain
-        progressbar : bool or ProgressBarType
-            Whether and how to display the progress bar.
-        progressbar_theme : optional
-            Theme for Rich progress bars (terminal only).
+        progressbar : bool or ProgressBarType, optional
+            How and whether to display the progress bar. If False, no progress bar is displayed. Otherwise, you can ask
+            for one of the following:
+            - "combined": A single progress bar that displays the total progress across all chains. Only timing
+                information is shown.
+            - "split": A separate progress bar for each chain. Only timing information is shown.
+            - "combined+stats" or "stats+combined": A single progress bar displaying the total progress across all
+                chains. Aggregate sample statistics are also displayed.
+            - "split+stats" or "stats+split": A separate progress bar for each chain. Sample statistics for each chain
+                are also displayed.
+
+            If True, the default is "split+stats" is used.
+        progressbar_theme : Theme, optional
+            The theme to use for the progress bar. Only used in terminal mode.
         """
+        # Parse progressbar argument and set display mode attributes
         self.show_progress, self.combined_progress, self.full_stats = self._parse_progressbar_arg(
             progressbar
         )


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description

This is intended to get the ball rolling on having progress bars that work with marimo, since prospects are not great for getting the rich progress bars working any time soon. I've ported the nutpie progress bars over (since they do work). Rather than using a rust templating library, I'm using jinja2 here (which arviz already uses). 

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
