### PR TITLE
Fix NaN gradients in Hurdle distributions for continuous components

### DIFF
--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -1717,3 +1717,49 @@ class TestHurdleDistributions:
                 return np.log(psi) + st.lognorm.logpdf(value, sigma, 0, np.exp(mu))
 
         check_logp(HurdleLogNormal, Rplus, {"psi": Unit, "mu": R, "sigma": Rplusbig}, logp_fn)
+
+    def test_hurdle_gamma_dlogp_no_nan(self):
+        """Test that dlogp does not return NaN for HurdleGamma.
+
+        Regression test for issue #8053. The gradient of pt.where evaluates both
+        branches, so logp(dist, 0) would produce invalid gradients for continuous
+        distributions like Gamma. The fix uses a safe value for the logp computation.
+        """
+        psi_true, alpha_true, beta_true = 0.3, 2.0, 1.5
+
+        dist = HurdleGamma.dist(psi=psi_true, alpha=alpha_true, beta=beta_true)
+        y = draw(dist, draws=50, random_seed=1)
+
+        with pm.Model() as model:
+            alpha = pm.HalfNormal("alpha", sigma=2.0)
+            beta = pm.HalfNormal("beta", sigma=2.0)
+            psi = pm.Beta("psi", alpha=2.0, beta=2.0)
+            HurdleGamma("y_obs", psi=psi, alpha=alpha, beta=beta, observed=y)
+
+        dlogp_fn = model.compile_dlogp()
+        ip = model.initial_point()
+        dlogp_val = dlogp_fn(ip)
+
+        assert not np.any(np.isnan(dlogp_val)), f"dlogp contains NaN: {dlogp_val}"
+
+    def test_hurdle_lognormal_dlogp_no_nan(self):
+        """Test that dlogp does not return NaN for HurdleLogNormal.
+
+        Regression test for issue #8053.
+        """
+        psi_true, mu_true, sigma_true = 0.3, 0.0, 1.0
+
+        dist = HurdleLogNormal.dist(psi=psi_true, mu=mu_true, sigma=sigma_true)
+        y = draw(dist, draws=50, random_seed=1)
+
+        with pm.Model() as model:
+            mu = pm.Normal("mu", mu=0.0, sigma=1.0)
+            sigma = pm.HalfNormal("sigma", sigma=1.0)
+            psi = pm.Beta("psi", alpha=2.0, beta=2.0)
+            HurdleLogNormal("y_obs", psi=psi, mu=mu, sigma=sigma, observed=y)
+
+        dlogp_fn = model.compile_dlogp()
+        ip = model.initial_point()
+        dlogp_val = dlogp_fn(ip)
+
+        assert not np.any(np.isnan(dlogp_val)), f"dlogp contains NaN: {dlogp_val}"

--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -1719,45 +1719,33 @@ class TestHurdleDistributions:
 
         check_logp(HurdleLogNormal, Rplus, {"psi": Unit, "mu": R, "sigma": Rplusbig}, logp_fn)
 
-    def test_hurdle_gamma_dlogp_no_nan(self):
-        """Test that dlogp does not return NaN for HurdleGamma.
+    @pytest.mark.parametrize(
+        "hurdle_cls,dist_params",
+        [
+            (HurdleGamma, {"psi": 0.3, "alpha": 2.0, "beta": 1.5}),
+            (HurdleLogNormal, {"psi": 0.3, "mu": 0.0, "sigma": 1.0}),
+        ],
+    )
+    def test_hurdle_dlogp_no_nan(self, hurdle_cls, dist_params):
+        """Test that dlogp does not return NaN for Hurdle distributions.
 
         Regression test for issue #8053. The gradient of pt.where evaluates both
         branches, so logp(dist, 0) would produce invalid gradients for continuous
         distributions like Gamma. The fix uses a safe value for the logp computation.
         """
-        psi_true, alpha_true, beta_true = 0.3, 2.0, 1.5
-
-        dist = HurdleGamma.dist(psi=psi_true, alpha=alpha_true, beta=beta_true)
+        dist = hurdle_cls.dist(**dist_params)
         y = draw(dist, draws=50, random_seed=1)
 
         with Model() as model:
-            alpha = HalfNormal("alpha", sigma=2.0)
-            beta = HalfNormal("beta", sigma=2.0)
             psi = Beta("psi", alpha=2.0, beta=2.0)
-            HurdleGamma("y_obs", psi=psi, alpha=alpha, beta=beta, observed=y)
-
-        dlogp_fn = model.compile_dlogp()
-        ip = model.initial_point()
-        dlogp_val = dlogp_fn(ip)
-
-        assert not np.any(np.isnan(dlogp_val)), f"dlogp contains NaN: {dlogp_val}"
-
-    def test_hurdle_lognormal_dlogp_no_nan(self):
-        """Test that dlogp does not return NaN for HurdleLogNormal.
-
-        Regression test for issue #8053.
-        """
-        psi_true, mu_true, sigma_true = 0.3, 0.0, 1.0
-
-        dist = HurdleLogNormal.dist(psi=psi_true, mu=mu_true, sigma=sigma_true)
-        y = draw(dist, draws=50, random_seed=1)
-
-        with Model() as model:
-            mu = Normal("mu", mu=0.0, sigma=1.0)
-            sigma = HalfNormal("sigma", sigma=1.0)
-            psi = Beta("psi", alpha=2.0, beta=2.0)
-            HurdleLogNormal("y_obs", psi=psi, mu=mu, sigma=sigma, observed=y)
+            if hurdle_cls == HurdleGamma:
+                alpha = HalfNormal("alpha", sigma=2.0)
+                beta = HalfNormal("beta", sigma=2.0)
+                hurdle_cls("y_obs", psi=psi, alpha=alpha, beta=beta, observed=y)
+            else:  # HurdleLogNormal
+                mu = Normal("mu", mu=0.0, sigma=1.0)
+                sigma = HalfNormal("sigma", sigma=1.0)
+                hurdle_cls("y_obs", psi=psi, mu=mu, sigma=sigma, observed=y)
 
         dlogp_fn = model.compile_dlogp()
         ip = model.initial_point()

--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -26,6 +26,7 @@ from pytensor.tensor.random.op import RandomVariable
 from scipy.special import logsumexp
 
 from pymc.distributions import (
+    Beta,
     Categorical,
     DiracDelta,
     Dirichlet,
@@ -1730,10 +1731,10 @@ class TestHurdleDistributions:
         dist = HurdleGamma.dist(psi=psi_true, alpha=alpha_true, beta=beta_true)
         y = draw(dist, draws=50, random_seed=1)
 
-        with pm.Model() as model:
-            alpha = pm.HalfNormal("alpha", sigma=2.0)
-            beta = pm.HalfNormal("beta", sigma=2.0)
-            psi = pm.Beta("psi", alpha=2.0, beta=2.0)
+        with Model() as model:
+            alpha = HalfNormal("alpha", sigma=2.0)
+            beta = HalfNormal("beta", sigma=2.0)
+            psi = Beta("psi", alpha=2.0, beta=2.0)
             HurdleGamma("y_obs", psi=psi, alpha=alpha, beta=beta, observed=y)
 
         dlogp_fn = model.compile_dlogp()
@@ -1752,10 +1753,10 @@ class TestHurdleDistributions:
         dist = HurdleLogNormal.dist(psi=psi_true, mu=mu_true, sigma=sigma_true)
         y = draw(dist, draws=50, random_seed=1)
 
-        with pm.Model() as model:
-            mu = pm.Normal("mu", mu=0.0, sigma=1.0)
-            sigma = pm.HalfNormal("sigma", sigma=1.0)
-            psi = pm.Beta("psi", alpha=2.0, beta=2.0)
+        with Model() as model:
+            mu = Normal("mu", mu=0.0, sigma=1.0)
+            sigma = HalfNormal("sigma", sigma=1.0)
+            psi = Beta("psi", alpha=2.0, beta=2.0)
             HurdleLogNormal("y_obs", psi=psi, mu=mu, sigma=sigma, observed=y)
 
         dlogp_fn = model.compile_dlogp()


### PR DESCRIPTION
## Summary

Fixes the `dlogp` function returning NaN for `HurdleGamma` and `HurdleLogNormal` when observed data contains zeros.

## Problem

The gradient computation (`dlogp`) was failing because `pt.where` evaluates both branches before selecting one. When computing `logp(dist, 0)` for continuous distributions like Gamma, this produces `-inf`, which results in NaN gradients - even though that branch is not selected for zero values.

## Solution

Replace zero values with a safe dummy value (1.0) before computing the logp of the continuous distribution:

```python
safe_value = pt.switch(pt.eq(value, 0), 1.0, value)
hurdle_logp = pt.where(
    pt.eq(value, 0),
    pt.log(1 - psi),
    pt.log(psi) + logp(dist, safe_value),  # Use safe_value instead of value
)
```

Since `pt.where` still selects the correct branch based on the condition, the final logp result is unchanged, but the gradient computation is now well-defined.

## Testing

Added regression tests for both `HurdleGamma` and `HurdleLogNormal` that verify `dlogp` does not return NaN values.

Fixes #8053