### PR TITLE
Clarify ImportError location for as_xtensor in dims error message

### DIFF
--- a/pymc/dims/distributions/core.py
+++ b/pymc/dims/distributions/core.py
@@ -134,7 +134,7 @@ class DimDistribution:
             raise ValueError(
                 f"Variable {x} must have dims associated with it.\n"
                 "To avoid subtle bugs, PyMC does not make any assumptions about the dims of parameters.\n"
-                "Use `as_xtensor` with the `dims` keyword argument to specify the dims explicitly."
+                "Use `pytensor.xtensor.as_xtensor` with the `dims` keyword argument to specify the dims explicitly."
             )
 
     def __new__(


### PR DESCRIPTION
MAINT: Clarify import path for as_xtensor in dims error message

## Description
Updated the `ValueError` message in `pymc/dims/distributions/core.py` to explicitly suggest using `pytensor.xtensor.as_xtensor`. 

Previously, the error message only suggested `as_xtensor`, which could be confusing for users trying to locate the correct import. This change points directly to the PyTensor location, improving the debugging experience.

## Related Issue
- [x] Closes #8009

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):