### PR TITLE
Validate coordinate and variables don't have the same names

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -963,6 +963,10 @@ class Model(WithMemoization, metaclass=ContextMeta):
                 "Dimensions can not be named `draw`, `chain` or `__sample__`, "
                 "as those are reserved for use in `InferenceData`."
             )
+        if self.named_vars.tree_contains(name):
+            raise ValueError(
+                f"Dimension name '{name}' conflicts with an existing model variable name."
+            )
         if values is None and length is None:
             raise ValueError(
                 f"Either `values` or `length` must be specified for the '{name}' dimension."
@@ -1466,6 +1470,10 @@ class Model(WithMemoization, metaclass=ContextMeta):
             raise ValueError("Variable is unnamed.")
         if self.named_vars.tree_contains(var.name):
             raise ValueError(f"Variable name {var.name} already exists.")
+        if var.name in self.coords:
+            raise ValueError(
+                f"Variable name '{var.name}' conflicts with an existing dimension name."
+            )
 
         if dims is not None:
             if isinstance(dims, str):
@@ -1473,8 +1481,6 @@ class Model(WithMemoization, metaclass=ContextMeta):
             for dim in dims:
                 if dim not in self.coords and dim is not None:
                     raise ValueError(f"Dimension {dim} is not specified in `coords`.")
-            if any(var.name == dim for dim in dims if dim is not None):
-                raise ValueError(f"Variable `{var.name}` has the same name as its dimension label.")
             # This check implicitly states that only vars with .ndim attribute can have dims
             if var.ndim != len(dims):
                 raise ValueError(

--- a/tests/backends/test_arviz.py
+++ b/tests/backends/test_arviz.py
@@ -15,7 +15,6 @@ import re
 import warnings
 
 import numpy as np
-import pytensor.tensor as pt
 import pytest
 import xarray
 
@@ -702,12 +701,6 @@ class TestDataPyMC:
                 },
             )
             assert isinstance(converter.coords["city"], pd.MultiIndex)
-
-    def test_variable_dimension_name_collision(self):
-        with pytest.raises(ValueError, match="same name as its dimension"):
-            with pm.Model() as pmodel:
-                var = pt.as_tensor([1, 2, 3])
-                pmodel.register_rv(var, name="time", dims=("time",))
 
     def test_include_transformed(self):
         with pm.Model():

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -942,7 +942,7 @@ class TestSetUpdateCoords:
             pmodel.add_coord("nomnom", [1, 2])
 
             # No name collisions
-            with pytest.raises(ValueError, match="same name as"):
+            with pytest.raises(ValueError, match="conflicts with an existing dimension name"):
                 pmodel.add_named_variable(rv, dims="nomnom")
 
             # This should work (regression test against #6335)
@@ -1806,3 +1806,32 @@ class TestModelCopy:
             match="Detected variables likely created by GP objects. Further use of these old GP objects should be avoided as it may reintroduce variables from the old model. See issue: https://github.com/pymc-devs/pymc/issues/6883",
         ):
             copy_method(gaussian_process_model)
+
+
+class TestCoordVariableCollision:
+    def test_variable_name_conflicts_with_existing_coord(self):
+        with pm.Model(coords={"a": [0, 1]}):
+            with pytest.raises(ValueError, match="conflicts with an existing dimension name"):
+                pm.Data("a", [5, 10])
+
+            with pytest.raises(ValueError, match="conflicts with an existing dimension name"):
+                pm.Normal("a", dims="a")
+
+            with pytest.raises(ValueError, match="conflicts with an existing dimension name"):
+                pm.Deterministic("a", pt.ones(2))
+
+            with pytest.raises(ValueError, match="conflicts with an existing dimension name"):
+                pm.Potential("a", pt.ones(2))
+
+    def test_add_coord_conflicts_with_existing_variable_name(self):
+        with pm.Model() as m:
+            pm.Data("a", [5, 10])
+
+            with pytest.raises(ValueError, match="conflicts with an existing model variable name"):
+                m.add_coord("a", [0, 1])
+
+    def test_register_rv_with_dim_matching_name(self):
+        with pytest.raises(ValueError, match="conflicts with an existing dimension name"):
+            with pm.Model() as pmodel:
+                var = pt.as_tensor([1, 2, 3])
+                pmodel.register_rv(var, name="time", dims=("time",))


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #7788
- [x] Related to #7788

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


Description

It adds explicit validation checks in:
Model.add_coord: raises if a coord name already exists in Model.named_vars
Model.add_named_variable: raises if a variable name already exists in Model.coords
This ensures invalid models fail early and avoids silent downstream issues .

