### PR TITLE
Replace assert checks in logprob.scan with explicit error handling

### DIFF
--- a/pymc/logprob/scan.py
+++ b/pymc/logprob/scan.py
@@ -112,8 +112,18 @@ def convert_outer_out_to_in(
             oo_var, field_filter=lambda x: x.startswith("outer_out")
         )
 
-        assert var_info is not None
-        assert oo_var in new_outer_input_vars
+        if var_info is None:
+            raise RuntimeError(
+                "Failed to compute log-probability for Scan: "
+                "could not match an outer output to an inner output. "
+                "This usually indicates an unsupported Scan structure."
+            )
+
+        if oo_var not in new_outer_input_vars:
+            raise RuntimeError(
+                "Failed to compute log-probability for Scan: "
+                "no value was provided for a required random output."
+            )
 
         io_var = output_scan_args.get_alt_field(var_info, "inner_out")
         old_inner_outs_to_outer_outs[io_var] = oo_var
@@ -328,6 +338,12 @@ def logprob_scan(op, values, *inputs, name=None, **kwargs):
     new_node = op.make_node(*inputs)
     scan_args = ScanArgs.from_node(new_node)
     rv_outer_outs = get_random_outer_outputs(scan_args)
+    if len(rv_outer_outs) > 1:
+        raise RuntimeError(
+            "Log-probability for Scan with multiple random outputs "
+            "is not supported."
+        )
+
 
     # values = (pt.zeros(11)[1:].set(values[0]),)
     # For random variable sequences with taps, we need to place the value variable in the


### PR DESCRIPTION
## Summary

This PR replaces internal `assert` checks in `logprob.scan` with explicit, user-facing errors and adds early validation to prevent reaching those assertions.

## Motivation

Users working with time series models that rely on `Scan` (e.g. via `CustomDist`) have reported hitting internal assertions during log-probability computation, resulting in uninformative `AssertionError`s. This makes it difficult to understand why log-probability derivation failed.

A concrete example is discussed in the PyMC Discourse thread:
https://discourse.pymc.io/t/smooth-local-linear-trend-with-customdist/16968

## What this PR does

- Adds an early guard in `logprob_scan` to explicitly reject scans with multiple random outputs, which are currently unsupported.
- Replaces internal `assert` statements in `convert_outer_out_to_in` with explicit `RuntimeError`s that explain why log-probability derivation failed.

## What this PR does NOT do

- This PR does **not** attempt to support multi-output scans.
- It does **not** change Scan semantics or PyTensor internals.
- It does **not** alter any supported behavior; it only improves failure modes.

## Related issue

addresses #7780