### PR TITLE
Skip slow tests issue workflow on forks

### DIFF
--- a/.github/workflows/update-test-issues.yml
+++ b/.github/workflows/update-test-issues.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   update-comment:
+    if: github.repository == 'pymc-devs/pymc'
     runs-on: ubuntu-latest
     steps:
       - name: Install ZSH


### PR DESCRIPTION
## Summary

- The "Slow Tests Issue Body" workflow fails on forks because `gh run list` returns fork-local run IDs, but subsequent `gh api` calls use the hardcoded `pymc-devs/pymc` repo path where those IDs don't exist (HTTP 404).
- Added `if: github.repository == 'pymc-devs/pymc'` guard to skip the job on forks, where it is inherently non-functional.
- The workflow only triggers on `schedule` and `workflow_dispatch` (no `pull_request` trigger), so PRs are unaffected.

## Test plan

- [x] Verified the workflow has no `pull_request` or `push` triggers
- [x] Confirmed via `gh run view` logs that the fork failure is caused by 404s from mismatched run IDs
- [ ] Verify the workflow shows as "skipped" (not "failed") when triggered on a fork

Made with [Cursor](https://cursor.com)