### PR TITLE
Fix compute_log_prior argument handling

### DIFF
--- a/pymc/stats/log_density.py
+++ b/pymc/stats/log_density.py
@@ -74,6 +74,7 @@ def compute_log_likelihood(
 
 def compute_log_prior(
     idata: InferenceData,
+    *,
     var_names: Sequence[str] | None = None,
     extend_inferencedata: bool = True,
     model: Model | None = None,

--- a/tests/stats/test_log_density.py
+++ b/tests/stats/test_log_density.py
@@ -125,10 +125,8 @@ class TestComputeLogLikelihood:
         sig = inspect.signature(compute_log_prior)
         params = list(sig.parameters.values())
 
-        # idata is positional-or-keyword
         assert params[0].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
 
-        # everything else must be keyword-only
         for p in params[1:]:
             assert p.kind is inspect.Parameter.KEYWORD_ONLY
 

--- a/tests/stats/test_log_density.py
+++ b/tests/stats/test_log_density.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 import scipy.stats as st
+import inspect
 
 from arviz import InferenceData, dict_to_dataset, from_dict
 
@@ -119,6 +120,17 @@ class TestComputeLogLikelihood:
             idata = InferenceData(posterior=dict_to_dataset({"x": np.arange(100).reshape(4, 25)}))
             with pytest.raises(ValueError, match="var_names must refer to observed_RVs"):
                 compute_log_likelihood(idata, var_names=["x"])
+    
+    def test_compute_log_prior_is_keyword_only(self):
+        sig = inspect.signature(compute_log_prior)
+        params = list(sig.parameters.values())
+
+        # idata is positional-or-keyword
+        assert params[0].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+
+        # everything else must be keyword-only
+        for p in params[1:]:
+            assert p.kind is inspect.Parameter.KEYWORD_ONLY
 
     def test_dims_without_coords(self):
         # Issues #6820


### PR DESCRIPTION
compute_log_prior unintentionally accepted positional arguments, unlike
compute_log_likelihood, which enforces keyword-only usage. This could lead to
silent argument mis-binding and confusing errors when arguments are passed
positionally.

This pr makes compute_log_prior keyword-only for consistency and safety, and
adds a regression test that locks the function’s public API contract.

No behavior change for valid usage.

And I added a Test as well.