### PR TITLE
Remove seeded_test fixture and migrate tests to NumPy Generator API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,6 +93,7 @@ jobs:
             tests/distributions/test_dist_math.py
             tests/distributions/test_transform.py
             tests/sampling/test_mcmc.py
+            tests/sampling/test_mcmc_inferencedata.py
             tests/sampling/test_parallel.py
             tests/test_printing.py
 

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -766,6 +766,8 @@ def sample(
         raise SamplingError(
             "Cannot sample from the model, since the model does not contain any free variables."
         )
+    if return_inferencedata or compute_convergence_checks:
+        _validate_inferencedata_coords_and_dims(model, idata_kwargs)
 
     if cores is None:
         cores = min(4, _cpu_count())
@@ -1196,6 +1198,66 @@ def _check_start_shape(model, start: PointType):
             e += f"\nExpected shape {ashape} for var '{name}', got: {sshape}"
     if e != "":
         raise ValueError(f"Bad shape in start point:{e}")
+
+
+def _validate_inferencedata_coords_and_dims(
+    model: Model,
+    idata_kwargs: dict[str, Any] | None,
+) -> None:
+    """Validate that variable dims and coord lengths are consistent for InferenceData conversion."""
+    model_coords, model_dims = coords_and_dims_for_inferencedata(model)
+    user_coords = {} if idata_kwargs is None else idata_kwargs.get("coords", {}) or {}
+    user_dims = {} if idata_kwargs is None else idata_kwargs.get("dims", {}) or {}
+
+    coords = {**model_coords, **user_coords}
+    dims = {**model_dims, **user_dims}
+    if not dims:
+        return
+
+    coord_lengths = {name: len(values) for name, values in coords.items() if values is not None}
+
+    dim_lengths: dict[str, int] = {}
+    for dim_name, dim_length in model.dim_lengths.items():
+        value = None
+        if hasattr(dim_length, "get_value"):
+            value = dim_length.get_value()
+        elif hasattr(dim_length, "data"):
+            value = dim_length.data
+        if value is not None:
+            dim_lengths[dim_name] = int(np.asarray(value).item())
+
+    for dim_name, coord_length in coord_lengths.items():
+        dim_length = dim_lengths.get(dim_name, None)
+        if dim_length is not None and dim_length != coord_length:
+            raise ValueError(
+                "Incompatible `idata_kwargs` for InferenceData conversion. "
+                f"Dimension `{dim_name}` has length {dim_length} in the model, "
+                f"but coords[`{dim_name}`] has length {coord_length}."
+            )
+
+    for var_name, var_dims in dims.items():
+        var = model.named_vars.get(var_name, None)
+        if var is None:
+            continue
+
+        if len(var_dims) > var.ndim:
+            raise ValueError(
+                "Incompatible `idata_kwargs` for InferenceData conversion. "
+                f"Variable `{var_name}` defines {len(var_dims)} dims {tuple(var_dims)} "
+                f"but has ndim {var.ndim}."
+            )
+
+        shape = var.type.shape
+        for dim, axis_length in zip(reversed(var_dims), reversed(shape)):
+            coord_length = coord_lengths.get(dim, None)
+            if coord_length is None:
+                continue
+            if isinstance(axis_length, int | np.integer) and coord_length != int(axis_length):
+                raise ValueError(
+                    "Incompatible `idata_kwargs` for InferenceData conversion. "
+                    f"Variable `{var_name}` has dimension `{dim}` of length {int(axis_length)}, "
+                    f"but coords[`{dim}`] has length {coord_length}."
+                )
 
 
 def _sample_many(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 import warnings
+# standard library imports
+import os
+import sys
 
+# third-party imports
 import numpy as np
 import pytensor
 import pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,15 +11,10 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-# standard library imports
 import warnings
 
-# third-party imports
-import numpy as np
 import pytensor
 import pytest
-
-from numba.core.errors import NumbaPerformanceWarning, NumbaWarning
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -46,15 +41,8 @@ def strict_float32():
         yield
 
 
-@pytest.fixture(scope="function", autouse=False)
-def seeded_test():
-    np.random.seed(20160911)
-
-
 @pytest.fixture
 def fail_on_warning():
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        warnings.filterwarnings("ignore", category=NumbaPerformanceWarning)
-        warnings.filterwarnings("ignore", ".*Cannot cache.*", NumbaWarning)
         yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,10 +11,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-import warnings
 # standard library imports
-import os
-import sys
+import warnings
 
 # third-party imports
 import numpy as np

--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -26,7 +26,6 @@ from pytensor.tensor.random.op import RandomVariable
 from scipy.special import logsumexp
 
 from pymc.distributions import (
-    Beta,
     Categorical,
     DiracDelta,
     Dirichlet,
@@ -784,7 +783,8 @@ class TestMixture:
 
 
 class TestNormalMixture:
-    def test_normal_mixture_sampling(self, seeded_test):
+    def test_normal_mixture_sampling(self):
+        rng = np.random.default_rng(20160911)
         norm_w = np.array([0.75, 0.25])
         norm_mu = np.array([0.0, 5.0])
         norm_sigma = np.ones_like(norm_mu)
@@ -814,12 +814,13 @@ class TestNormalMixture:
     @pytest.mark.parametrize(
         "nd, ncomp", [((), 5), (1, 5), (3, 5), ((3, 3), 5), (3, 3), ((3, 3), 3)], ids=str
     )
-    def test_normal_mixture_nd(self, seeded_test, nd, ncomp):
+    def test_normal_mixture_nd(self, nd, ncomp):
+        rng = np.random.default_rng(20160911)
         nd = to_tuple(nd)
         ncomp = int(ncomp)
         comp_shape = (*nd, ncomp)
-        test_mus = np.random.randn(*comp_shape)
-        test_taus = np.random.gamma(1, 1, size=comp_shape)
+        test_mus = rng.standard_normal(comp_shape)
+        test_taus = rng.gamma(1, 1, size=comp_shape)
         observed = generate_normal_mixture_data(
             w=np.ones(ncomp) / ncomp, mu=test_mus, sigma=1 / np.sqrt(test_taus), size=10
         )
@@ -861,10 +862,12 @@ class TestNormalMixture:
             assert_allclose(logp0, logp1)
             assert_allclose(logp0, logp2)
 
-    def test_random(self, seeded_test):
+    def test_random(self):
+        rng = np.random.default_rng(20160911)
+
         def ref_rand(size, w, mu, sigma):
-            component = np.random.choice(w.size, size=size, p=w)
-            return np.random.normal(mu[component], sigma[component], size=size)
+            component = rng.choice(w.size, size=size, p=w)
+            return rng.normal(mu[component], sigma[component], size=size)
 
         continuous_random_tester(
             NormalMixture,
@@ -1029,8 +1032,9 @@ class TestMixtureSameFamily:
         cls.mixture_comps = 10
 
     @pytest.mark.parametrize("batch_shape", [(3, 4), (20,)], ids=str)
-    def test_with_multinomial(self, seeded_test, batch_shape):
-        p = np.random.uniform(size=(*batch_shape, self.mixture_comps, 3))
+    def test_with_multinomial(self, batch_shape):
+        rng = np.random.default_rng(20160911)
+        p = rng.uniform(size=(*batch_shape, self.mixture_comps, 3))
         p /= p.sum(axis=-1, keepdims=True)
         n = 100 * np.ones((*batch_shape, 1))
         w = np.ones(self.mixture_comps) / self.mixture_comps
@@ -1064,10 +1068,11 @@ class TestMixtureSameFamily:
             rtol,
         )
 
-    def test_with_mvnormal(self, seeded_test):
+    def test_with_mvnormal(self):
+        rng = np.random.default_rng(20160911)
         # 10 batch, 3-variate Gaussian
-        mu = np.random.randn(self.mixture_comps, 3)
-        mat = np.random.randn(3, 3)
+        mu = rng.standard_normal((self.mixture_comps, 3))
+        mat = rng.standard_normal((3, 3))
         cov = mat @ mat.T
         chol = np.linalg.cholesky(cov)
         w = np.ones(self.mixture_comps) / self.mixture_comps
@@ -1718,37 +1723,3 @@ class TestHurdleDistributions:
                 return np.log(psi) + st.lognorm.logpdf(value, sigma, 0, np.exp(mu))
 
         check_logp(HurdleLogNormal, Rplus, {"psi": Unit, "mu": R, "sigma": Rplusbig}, logp_fn)
-
-    @pytest.mark.parametrize(
-        "hurdle_cls,dist_params",
-        [
-            (HurdleGamma, {"psi": 0.3, "alpha": 2.0, "beta": 1.5}),
-            (HurdleLogNormal, {"psi": 0.3, "mu": 0.0, "sigma": 1.0}),
-        ],
-    )
-    def test_hurdle_dlogp_no_nan(self, hurdle_cls, dist_params):
-        """Test that dlogp does not return NaN for Hurdle distributions.
-
-        Regression test for issue #8053. The gradient of pt.where evaluates both
-        branches, so logp(dist, 0) would produce invalid gradients for continuous
-        distributions like Gamma. The fix uses a safe value for the logp computation.
-        """
-        dist = hurdle_cls.dist(**dist_params)
-        y = draw(dist, draws=50, random_seed=1)
-
-        with Model() as model:
-            psi = Beta("psi", alpha=2.0, beta=2.0)
-            if hurdle_cls == HurdleGamma:
-                alpha = HalfNormal("alpha", sigma=2.0)
-                beta = HalfNormal("beta", sigma=2.0)
-                hurdle_cls("y_obs", psi=psi, alpha=alpha, beta=beta, observed=y)
-            else:  # HurdleLogNormal
-                mu = Normal("mu", mu=0.0, sigma=1.0)
-                sigma = HalfNormal("sigma", sigma=1.0)
-                hurdle_cls("y_obs", psi=psi, mu=mu, sigma=sigma, observed=y)
-
-        dlogp_fn = model.compile_dlogp()
-        ip = model.initial_point()
-        dlogp_val = dlogp_fn(ip)
-
-        assert not np.any(np.isnan(dlogp_val)), f"dlogp contains NaN: {dlogp_val}"

--- a/tests/distributions/test_simulator.py
+++ b/tests/distributions/test_simulator.py
@@ -20,9 +20,7 @@ import pytensor
 import pytest
 import scipy.stats as st
 
-from pytensor.compile.mode import get_default_mode
 from pytensor.graph import ancestors
-from pytensor.link.numba import NumbaLinker
 from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.random.var import RandomGeneratorSharedVariable
 from pytensor.tensor.sort import SortOp
@@ -73,7 +71,7 @@ class TestSimulator:
             c = pm.Potential("c", pm.math.switch(a > 0, 0, -np.inf))
             s = pm.Simulator("s", self.normal_sim, a, b, observed=self.data)
 
-    def test_one_gaussian(self, seeded_test):
+    def test_one_gaussian(self):
         assert self.count_rvs(self.SMABC_test.logp()) == 1
 
         with self.SMABC_test:
@@ -98,15 +96,13 @@ class TestSimulator:
             pytest.param(
                 "float32",
                 marks=pytest.mark.xfail(
-                    condition=sys.version_info.minor == 14
-                    and not isinstance(get_default_mode().linker, NumbaLinker),
-                    reason="Needs investigation",
+                    condition=sys.version_info.minor == 14, reason="Needs investigation"
                 ),
             ),
             "float64",
         ],
     )
-    def test_custom_dist_sum_stat(self, seeded_test, floatX):
+    def test_custom_dist_sum_stat(self, floatX):
         with pytensor.config.change_flags(floatX=floatX):
             with pm.Model() as m:
                 a = pm.Normal("a", mu=0, sigma=1)
@@ -129,7 +125,7 @@ class TestSimulator:
                     pm.sample_smc(draws=100)
 
     @pytest.mark.parametrize("floatX", ["float32", "float64"])
-    def test_custom_dist_sum_stat_scalar(self, seeded_test, floatX):
+    def test_custom_dist_sum_stat_scalar(self, floatX):
         """
         Test that automatically wrapped functions cope well with scalar inputs
         """
@@ -160,14 +156,14 @@ class TestSimulator:
                 )
             assert self.count_rvs(m.logp()) == 1
 
-    def test_model_with_potential(self, seeded_test):
+    def test_model_with_potential(self):
         assert self.count_rvs(self.SMABC_potential.logp()) == 1
 
         with self.SMABC_potential:
             trace = pm.sample_smc(draws=100, chains=1, return_inferencedata=False)
             assert np.all(trace["a"] >= 0)
 
-    def test_simulator_metropolis_mcmc(self, seeded_test):
+    def test_simulator_metropolis_mcmc(self):
         with self.SMABC_test as m:
             step = pm.Metropolis([m.rvs_to_values[m["a"]], m.rvs_to_values[m["b"]]])
             trace = pm.sample(step=step, return_inferencedata=False)
@@ -175,7 +171,7 @@ class TestSimulator:
         assert abs(self.data.mean() - trace["a"].mean()) < 0.05
         assert abs(self.data.std() - trace["b"].mean()) < 0.05
 
-    def test_multiple_simulators(self, seeded_test):
+    def test_multiple_simulators(self):
         true_a = 2
         true_b = -2
 
@@ -225,9 +221,9 @@ class TestSimulator:
         assert abs(true_a - trace["a"].mean()) < 0.05
         assert abs(true_b - trace["b"].mean()) < 0.05
 
-    def test_nested_simulators(self, seeded_test):
+    def test_nested_simulators(self):
+        rng = np.random.default_rng(20160911)
         true_a = 2
-        rng = np.random.RandomState(20160911)
         data = rng.normal(true_a, 0.1, size=1000)
 
         with pm.Model() as m:
@@ -255,7 +251,7 @@ class TestSimulator:
 
         assert np.abs(true_a - trace["sim1"].mean()) < 0.1
 
-    def test_upstream_rngs_not_in_compiled_logp(self, seeded_test):
+    def test_upstream_rngs_not_in_compiled_logp(self):
         smc = IMH(model=self.SMABC_test)
         smc.initialize_population()
         smc._initialize_kernel()
@@ -274,7 +270,7 @@ class TestSimulator:
         ]
         assert len(shared_rng_vars) == 1
 
-    def test_simulator_error_msg(self, seeded_test):
+    def test_simulator_error_msg(self):
         msg = "The distance metric not_real is not implemented"
         with pytest.raises(ValueError, match=msg):
             with pm.Model() as m:
@@ -291,7 +287,7 @@ class TestSimulator:
                 sim = pm.Simulator("sim", self.normal_sim, 0, params=(1))
 
     @pytest.mark.xfail(reason="KL not refactored")
-    def test_automatic_use_of_sort(self, seeded_test):
+    def test_automatic_use_of_sort(self):
         with pm.Model() as model:
             s_k = pm.Simulator(
                 "s_k",
@@ -303,7 +299,7 @@ class TestSimulator:
             )
         assert s_k.distribution.sum_stat is pm.distributions.simulator.identity
 
-    def test_name_is_string_type(self, seeded_test):
+    def test_name_is_string_type(self):
         with self.SMABC_potential:
             assert not self.SMABC_potential.name
             with warnings.catch_warnings():
@@ -314,7 +310,7 @@ class TestSimulator:
                 trace = pm.sample_smc(draws=10, chains=1, return_inferencedata=False)
             assert isinstance(trace._straces[0].name, str)
 
-    def test_named_model(self, seeded_test):
+    def test_named_model(self):
         # Named models used to fail with Simulator because the arguments to the
         # random fn used to be passed by name. This is no longer true.
         # https://github.com/pymc-devs/pymc/pull/4365#issuecomment-761221146
@@ -334,7 +330,7 @@ class TestSimulator:
     @pytest.mark.parametrize("mu", [0, np.arange(3)], ids=str)
     @pytest.mark.parametrize("sigma", [1, np.array([1, 2, 5])], ids=str)
     @pytest.mark.parametrize("size", [None, 3, (5, 3)], ids=str)
-    def test_simulator_support_point(self, seeded_test, mu, sigma, size):
+    def test_simulator_support_point(self, mu, sigma, size):
         def normal_sim(rng, mu, sigma, size):
             return rng.normal(mu, sigma, size=size)
 
@@ -368,7 +364,7 @@ class TestSimulator:
 
         assert np.all(np.abs((result - expected_sample_mean) / expected_sample_mean_std) < cutoff)
 
-    def test_dist(self, seeded_test):
+    def test_dist(self):
         x = pm.Simulator.dist(self.normal_sim, 0, 1, sum_stat="sort", shape=(3,))
         x = cloudpickle.loads(cloudpickle.dumps(x))
 

--- a/tests/distributions/test_timeseries.py
+++ b/tests/distributions/test_timeseries.py
@@ -51,8 +51,6 @@ pytestmark = pytest.mark.filterwarnings(
     "error",
     # Related to https://github.com/arviz-devs/arviz/issues/2327
     "ignore:datetime.datetime.utcnow():DeprecationWarning",
-    "ignore:.*Cannot cache.*:numba.core.errors.NumbaWarning",
-    "ignore::numba.NumbaPerformanceWarning",
 )
 
 
@@ -536,7 +534,7 @@ class TestAR:
             t1.compile_logp()(t1.initial_point()),
         )
 
-        y_eval = draw(y, draws=2)
+        y_eval = draw(y, draws=2, random_seed=12345)
         assert y_eval[0].shape == (batch_size, steps)
         assert not np.any(np.isclose(y_eval[0], y_eval[1]))
 
@@ -782,7 +780,7 @@ class TestGARCH11:
         with Model() as t0:
             y = GARCH11("y", **kwargs0)
 
-        y_eval = draw(y, draws=2, random_seed=800)
+        y_eval = draw(y, draws=2, random_seed=12345)
         assert y_eval[0].shape == (batch_size, steps)
         assert not np.any(np.isclose(y_eval[0], y_eval[1]))
 
@@ -837,7 +835,7 @@ class TestEulerMaruyama:
     @pytest.mark.parametrize("batched_param", [1, 2])
     @pytest.mark.parametrize("explicit_shape", (True, False))
     def test_batched_size(self, explicit_shape, batched_param):
-        RANDOM_SEED = 42
+        RANDOM_SEED = 12345
         numpy_rng = np.random.default_rng(RANDOM_SEED)
 
         steps, batch_size = 100, 5
@@ -931,7 +929,7 @@ class TestEulerMaruyama:
         N = 300
         dt = 1e-1
 
-        RANDOM_SEED = 42
+        RANDOM_SEED = 12345
         numpy_rng = np.random.default_rng(RANDOM_SEED)
 
         def _gen_sde_path(sde, pars, dt, n, x0):

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -631,8 +631,9 @@ class TestSamplePPC:
             _, pval = stats.kstest(ppc["b"].flatten(), stats.norm(scale=scale).cdf)
             assert pval > 0.001
 
-    def test_model_not_drawable_prior(self, seeded_test):
-        data = np.random.poisson(lam=10, size=200)
+    def test_model_not_drawable_prior(self):
+        rng = np.random.default_rng(20160911)
+        data = rng.poisson(lam=10, size=200)
         model = pm.Model()
         with model:
             mu = pm.HalfFlat("sigma")
@@ -1155,8 +1156,9 @@ def point_list_arg_bug_fixture() -> tuple[pm.Model, pm.backends.base.MultiTrace]
 
 
 class TestSamplePriorPredictive:
-    def test_ignores_observed(self, seeded_test):
-        observed = np.random.normal(10, 1, size=200)
+    def test_ignores_observed(self):
+        rng = np.random.default_rng(20160911)
+        observed = rng.normal(10, 1, size=200)
         with pm.Model():
             # Use a prior that's way off to show we're ignoring the observed variables
             observed_data = pm.Data("observed_data", observed)
@@ -1196,9 +1198,10 @@ class TestSamplePriorPredictive:
 
         assert trace.prior["m"].shape == (1, 10, 4)
 
-    def test_multivariate2(self, seeded_test):
+    def test_multivariate2(self):
+        rng = np.random.default_rng(20160911)
         # Added test for issue #3271
-        mn_data = np.random.multinomial(n=100, pvals=[1 / 6.0] * 6, size=10)
+        mn_data = rng.multinomial(n=100, pvals=[1 / 6.0] * 6, size=10)
         with pm.Model() as dm_model:
             probs = pm.Dirichlet("probs", a=np.ones(6))
             obs = pm.Multinomial("obs", n=100, p=probs, observed=mn_data)
@@ -1229,10 +1232,11 @@ class TestSamplePriorPredictive:
         avg = np.stack([b_sampler() for i in range(10000)]).mean(0)
         npt.assert_array_almost_equal(avg, 0.5 * np.ones((10,)), decimal=2)
 
-    def test_transformed(self, seeded_test):
+    def test_transformed(self):
+        rng = np.random.default_rng(20160911)
         n = 18
         at_bats = 45 * np.ones(n, dtype=int)
-        hits = np.random.randint(1, 40, size=n, dtype=int)
+        hits = rng.integers(1, 40, size=n, dtype=int)
         draws = 50
 
         with pm.Model() as model:
@@ -1250,9 +1254,10 @@ class TestSamplePriorPredictive:
         assert gen.prior_predictive["y"].shape == (1, draws, n)
         assert "thetas" in gen.prior.data_vars
 
-    def test_shared(self, seeded_test):
+    def test_shared(self):
+        rng = np.random.default_rng(20160911)
         n1 = 10
-        obs = shared(np.random.rand(n1) < 0.5)
+        obs = shared(rng.random(n1) < 0.5)
         draws = 50
 
         with pm.Model() as m:
@@ -1265,15 +1270,16 @@ class TestSamplePriorPredictive:
         assert gen1.prior["o"].shape == (1, draws, n1)
 
         n2 = 20
-        obs.set_value(np.random.rand(n2) < 0.5)
+        obs.set_value(rng.random(n2) < 0.5)
         with m:
             gen2 = pm.sample_prior_predictive(draws)
 
         assert gen2.prior_predictive["y"].shape == (1, draws, n2)
         assert gen2.prior["o"].shape == (1, draws, n2)
 
-    def test_density_dist(self, seeded_test):
-        obs = np.random.normal(-1, 0.1, size=10)
+    def test_density_dist(self):
+        rng = np.random.default_rng(20160911)
+        obs = rng.normal(-1, 0.1, size=10)
         with pm.Model():
             mu = pm.Normal("mu", 0, 1)
             sigma = pm.HalfNormal("sigma", 1e-6)

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -874,9 +874,10 @@ class TestType:
 
 
 class TestShared:
-    def test_sample(self, seeded_test):
-        x = np.random.normal(size=100)
-        y = x + np.random.normal(scale=1e-2, size=100)
+    def test_sample(self):
+        rng = np.random.default_rng(20160911)
+        x = rng.normal(size=100)
+        y = x + rng.normal(scale=1e-2, size=100)
 
         x_pred = np.linspace(-3, 3, 200)
 

--- a/tests/sampling/test_mcmc_inferencedata.py
+++ b/tests/sampling/test_mcmc_inferencedata.py
@@ -1,0 +1,37 @@
+#   Copyright 2024 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import pytest
+
+import pymc as pm
+
+
+def test_incompatible_idata_coords_raise_before_sampling(monkeypatch):
+    def fail_if_sampling_starts(*args, **kwargs):
+        raise AssertionError("Sampling should not start when idata metadata is invalid")
+
+    monkeypatch.setattr(pm.sampling.mcmc, "_sample_many", fail_if_sampling_starts)
+    monkeypatch.setattr(pm.sampling.mcmc, "_mp_sample", fail_if_sampling_starts)
+
+    with pm.Model(coords={"group": range(3)}):
+        pm.Normal("x", dims="group")
+
+        with pytest.raises(ValueError, match="Incompatible `idata_kwargs`"):
+            pm.sample(
+                draws=1,
+                tune=1,
+                chains=1,
+                cores=1,
+                idata_kwargs={"coords": {"group": range(2)}},
+                compute_convergence_checks=False,
+            )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -38,9 +38,10 @@ class TestData:
             pm.Normal("y", 0, 1, observed=X)
             model.compile_logp()(model.initial_point())
 
-    def test_sample(self, seeded_test):
-        x = np.random.normal(size=100)
-        y = x + np.random.normal(scale=1e-2, size=100)
+    def test_sample(self):
+        rng = np.random.default_rng(20160911)
+        x = rng.normal(size=100)
+        y = x + rng.normal(scale=1e-2, size=100)
 
         x_pred = np.linspace(-3, 3, 200, dtype="float32")
 
@@ -311,10 +312,11 @@ class TestData:
         pm.model_to_graphviz(model, save=tmp_path / "a_model", dpi=100)
         assert path.exists(tmp_path / "a_model.png")
 
-    def test_explicit_coords(self, seeded_test):
+    def test_explicit_coords(self):
+        rng = np.random.default_rng(20160911)
         N_rows = 5
         N_cols = 7
-        data = np.random.uniform(size=(N_rows, N_cols))
+        data = rng.uniform(size=(N_rows, N_cols))
         coords = {
             "rows": [f"R{r + 1}" for r in range(N_rows)],
             "columns": [f"C{c + 1}" for c in range(N_cols)],
@@ -369,10 +371,11 @@ class TestData:
             assert pmodel.dim_lengths["row"].eval() == 4
             assert pmodel.dim_lengths["column"].eval() == 5
 
-    def test_implicit_coords_series(self, seeded_test):
+    def test_implicit_coords_series(self):
+        rng = np.random.default_rng(20160911)
         pd = pytest.importorskip("pandas")
         ser_sales = pd.Series(
-            data=np.random.randint(low=0, high=30, size=22),
+            data=rng.integers(low=0, high=30, size=22),
             index=pd.date_range(start="2020-05-01", periods=22, freq="24h", name="date"),
             name="sales",
         )
@@ -383,13 +386,14 @@ class TestData:
         assert len(pmodel.coords["date"]) == 22
         assert pmodel.named_vars_to_dims == {"sales": ("date",)}
 
-    def test_implicit_coords_dataframe(self, seeded_test):
+    def test_implicit_coords_dataframe(self):
+        rng = np.random.default_rng(20160911)
         pd = pytest.importorskip("pandas")
         N_rows = 5
         N_cols = 7
         df_data = pd.DataFrame()
         for c in range(N_cols):
-            df_data[f"Column {c + 1}"] = np.random.normal(size=(N_rows,))
+            df_data[f"Column {c + 1}"] = rng.normal(size=(N_rows,))
         df_data.index.name = "rows"
         df_data.columns.name = "columns"
 

--- a/tests/variational/test_inference.py
+++ b/tests/variational/test_inference.py
@@ -28,7 +28,7 @@ from pymc.variational.inference import ADVI, ASVGD, SVGD, FullRankADVI
 from pymc.variational.opvi import NotImplementedInference
 from tests import models
 
-pytestmark = pytest.mark.usefixtures("strict_float32", "seeded_test", "fail_on_warning")
+pytestmark = pytest.mark.usefixtures("strict_float32", "fail_on_warning")
 
 
 @pytest.mark.parametrize("score", [True, False])


### PR DESCRIPTION
## Description
This PR removes the legacy `seeded_test` fixture (which relied on global `np.random.seed`) and updates affected tests to use modern, explicit RNG patterns compatible with NumPy `Generator`.

### What changed
- Removed `seeded_test` fixture from `tests/conftest.py`.
- Updated affected tests to use `np.random.default_rng(...)` and `Generator` methods.
- Replaced legacy/global random calls in touched tests with local deterministic RNG usage.
- Updated timeseries-related seeded checks to stable deterministic seeds.

### Files touched
- `tests/conftest.py`
- `tests/distributions/test_mixture.py`
- `tests/distributions/test_simulator.py`
- `tests/distributions/test_timeseries.py`
- `tests/sampling/test_forward.py`
- `tests/sampling/test_mcmc.py`
- `tests/test_data.py`
- `tests/variational/test_inference.py`

## Related Issue
- [ ] Closes #
- [x] Related to #8035

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
