### PR TITLE
 Deprecate SumTo1 transform with warning and test coverage

### DIFF
--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 from functools import singledispatch
+import warnings
 
 import numpy as np
 import pytensor.tensor as pt
@@ -123,14 +124,30 @@ class SumTo1(Transform):
 
     name = "sumto1"
 
+    def __init__(self):
+        self._warned = False
+
+    def _warn_deprecated(self):
+        if not self._warned:
+            warnings.warn(
+                "SumTo1 transform is deprecated and will be removed in a future release. "
+                "Use simplex-based transforms instead.",
+                FutureWarning,
+                stacklevel=3,
+            )
+            self._warned = True
+
     def backward(self, value, *inputs):
+        self._warn_deprecated()
         remaining = 1 - pt.sum(value[..., :], axis=-1, keepdims=True)
         return pt.concatenate([value[..., :], remaining], axis=-1)
 
     def forward(self, value, *inputs):
+        self._warn_deprecated()
         return value[..., :-1]
 
     def log_jac_det(self, value, *inputs):
+        self._warn_deprecated()
         y = pt.zeros(value.shape)
         return pt.sum(y, axis=-1)
 

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -12,8 +12,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from functools import singledispatch
 import warnings
+
+from functools import singledispatch
 
 import numpy as np
 import pytensor.tensor as pt

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -149,7 +149,8 @@ def test_simplex_accuracy():
 
 def test_sum_to_1():
     with pytest.warns(
-        FutureWarning, match="SumTo1 transform is deprecated and will be removed in a future release"
+        FutureWarning,
+        match="SumTo1 transform is deprecated and will be removed in a future release",
     ):
         check_vector_transform(tr.sum_to_1, Simplex(2))
         check_vector_transform(tr.sum_to_1, Simplex(4))

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -148,16 +148,19 @@ def test_simplex_accuracy():
 
 
 def test_sum_to_1():
-    check_vector_transform(tr.sum_to_1, Simplex(2))
-    check_vector_transform(tr.sum_to_1, Simplex(4))
+    with pytest.warns(
+        FutureWarning, match="SumTo1 transform is deprecated and will be removed in a future release"
+    ):
+        check_vector_transform(tr.sum_to_1, Simplex(2))
+        check_vector_transform(tr.sum_to_1, Simplex(4))
 
-    check_jacobian_det(
-        tr.sum_to_1,
-        Vector(Unit, 2),
-        pt.vector,
-        floatX(np.array([0, 0])),
-        lambda x: x[:-1],
-    )
+        check_jacobian_det(
+            tr.sum_to_1,
+            Vector(Unit, 2),
+            pt.vector,
+            floatX(np.array([0, 0])),
+            lambda x: x[:-1],
+        )
 
 
 def test_log():


### PR DESCRIPTION
## Description
This PR starts the deprecation path for `SumTo1` transform (issue #7009).

### Changes
- Add a one-time `FutureWarning` when `SumTo1` is used.
- Keep current transform behavior unchanged.
- Update transform tests to assert deprecation warning behavior.

### Files changed
- `pymc/distributions/transforms.py`
- `tests/distributions/test_transform.py`

## Related Issue
- [ ] Closes #
- [x] Related to #7009

## Checklist
- [ ] Checked that pre-commit linting/style checks pass
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a relevant logical change

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
