### PR TITLE
Fix dims Censored resizing when nested with extra dims

### DIFF
--- a/pymc/dims/distributions/core.py
+++ b/pymc/dims/distributions/core.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from pytensor.graph import node_rewriter
 from pytensor.graph.basic import Variable
+from pytensor.scalar.basic import Clip
 from pytensor.tensor import TensorVariable
 from pytensor.tensor import expand_dims as pt_expand_dims
 from pytensor.tensor.elemwise import DimShuffle
@@ -27,7 +28,7 @@ from pytensor.xtensor import as_xtensor
 from pytensor.xtensor.basic import XTensorFromTensor, xtensor_from_tensor
 from pytensor.xtensor.shape import Transpose
 from pytensor.xtensor.type import XTensorVariable
-from pytensor.xtensor.vectorization import XRV
+from pytensor.xtensor.vectorization import XElemwise, XRV
 
 from pymc import SymbolicRandomVariable, modelcontext
 from pymc.dims.distributions.transforms import DimTransform, log_odds_transform, log_transform
@@ -367,5 +368,8 @@ def expand_dist_dims(dist: XTensorVariable, extra_dims: dict[str, Any]) -> XTens
             return expand_dist_dims(dist.owner.inputs[0], extra_dims=extra_dims).transpose(
                 ..., *dist.dims
             )
+        case XElemwise(scalar_op=Clip()):
+            base, lower, upper = dist.owner.inputs
+            return expand_dist_dims(base, extra_dims=extra_dims).clip(lower, upper)
         case _:
             raise NotImplementedError(f"expand_dist_dims not implemented for {dist} with op {op}")

--- a/pymc/dims/distributions/core.py
+++ b/pymc/dims/distributions/core.py
@@ -28,7 +28,7 @@ from pytensor.xtensor import as_xtensor
 from pytensor.xtensor.basic import XTensorFromTensor, xtensor_from_tensor
 from pytensor.xtensor.shape import Transpose
 from pytensor.xtensor.type import XTensorVariable
-from pytensor.xtensor.vectorization import XElemwise, XRV
+from pytensor.xtensor.vectorization import XRV, XElemwise
 
 from pymc import SymbolicRandomVariable, modelcontext
 from pymc.dims.distributions.transforms import DimTransform, log_odds_transform, log_transform

--- a/tests/dims/distributions/test_censored.py
+++ b/tests/dims/distributions/test_censored.py
@@ -86,3 +86,12 @@ def test_censored_dims():
         c3_dist = c3.owner.inputs[0]
         assert isinstance(c3_dist.owner.op, XRV)
         assert c3_dist.dims == ("d", "c", "a", "b")
+
+
+def test_nested_censored_with_new_dims():
+    coords = {"a": range(3), "d": range(2)}
+    with Model(coords=coords):
+        dist = Normal.dist(mu=as_xtensor([0, 1, 2], dims=("a",)), sigma=1)
+        c1 = Censored.dist(dist, lower=0, dim_lengths={})
+        lower = as_xtensor(np.zeros((2,)), dims=("d",))
+        Censored.dist(c1, lower=lower, dim_lengths={})


### PR DESCRIPTION
Description
This PR fixes a `pymc.dims.Censored` composition bug (issue #8138) where nested censoring with newly introduced dims failed during dim expansion.

Changes
- Add support for expanding clipped XTensors in `expand_dist_dims` (handle `XElemwise(Clip)`).
- Keep existing `dims.Censored` API and semantics unchanged.
- Add regression test for nested `dims.Censored` with new dims.

Files changed
- `pymc/dims/distributions/core.py`
- `tests/dims/distributions/test_censored.py`

Related Issue
- Related to: #8138 (`dims.Censored is not a regular RV`)

Checklist
- [x] Checked that pre-commit linting/style checks pass
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a relevant logical change

Type of change
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):