### PR TITLE
Fix unvalued measurable rewrite leakage in construct_ir_fgraph

### DIFF
--- a/pymc/logprob/censoring.py
+++ b/pymc/logprob/censoring.py
@@ -49,7 +49,11 @@ from pytensor.tensor.variable import TensorConstant
 
 from pymc.logprob.abstract import MeasurableElemwise, _logccdf_helper, _logcdf, _logprob
 from pymc.logprob.rewriting import measurable_ir_rewrites_db
-from pymc.logprob.utils import CheckParameterValue, filter_measurable_variables
+from pymc.logprob.utils import (
+    CheckParameterValue,
+    filter_measurable_variables,
+    has_valued_path_not_through_rv,
+)
 
 
 class MeasurableClip(MeasurableElemwise):
@@ -66,6 +70,8 @@ def find_measurable_clips(fgraph: FunctionGraph, node: Apply) -> list[TensorVari
     # TODO: Canonicalize x[x>ub] = ub -> clip(x, x, ub)
 
     if not filter_measurable_variables(node.inputs):
+        return None
+    if not has_valued_path_not_through_rv(fgraph, node.outputs[0]):
         return None
 
     base_var, lower_bound, upper_bound = node.inputs

--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -123,6 +123,7 @@ from pymc.logprob.utils import (
     check_potential_measurability,
     filter_measurable_variables,
     find_negated_var,
+    has_valued_path_not_through_rv,
 )
 from pymc.math import logdiffexp
 
@@ -478,6 +479,8 @@ def find_measurable_transforms(fgraph: FunctionGraph, node: Apply) -> list[Varia
     measurable_inputs = filter_measurable_variables(node.inputs)
 
     if len(measurable_inputs) != 1:
+        return None
+    if not has_valued_path_not_through_rv(fgraph, node.outputs[0]):
         return None
 
     [measurable_input] = measurable_inputs

--- a/pymc/logprob/utils.py
+++ b/pymc/logprob/utils.py
@@ -314,6 +314,33 @@ def get_related_valued_nodes(fgraph: FunctionGraph, node: Apply) -> list[Apply]:
     ]
 
 
+def has_valued_path_not_through_rv(fgraph: FunctionGraph, var: TensorVariable) -> bool:
+    """Return True if ``var`` reaches a ValuedRV without crossing another RV node."""
+    from pytensor.tensor.random.op import RandomVariable
+
+    from pymc.distributions.distribution import SymbolicRandomVariable
+
+    clients = fgraph.clients
+    queue = [var]
+    seen = set()
+
+    while queue:
+        current_var = queue.pop()
+        if current_var in seen:
+            continue
+        seen.add(current_var)
+
+        for client, _ in clients[current_var]:
+            op = client.op
+            if isinstance(op, ValuedRV):
+                return True
+            if isinstance(op, RandomVariable | SymbolicRandomVariable):
+                continue
+            queue.extend(client.outputs)
+
+    return False
+
+
 def __getattr__(name):
     if name == "rvs_in_graphs":
         warnings.warn(

--- a/tests/logprob/test_composite_logprob.py
+++ b/tests/logprob/test_composite_logprob.py
@@ -120,7 +120,6 @@ def test_nested_scalar_mixtures():
     assert np.isclose(logp_fn(0, 0, 1, 50), st.norm.logpdf(150) + np.log(0.5) * 3)
 
 
-@pytest.mark.xfail(reason="This is not currently enforced")
 @pytest.mark.parametrize("nested", (False, True))
 def test_unvalued_ir_reversion(nested):
     """Make sure that un-valued IR rewrites are reverted."""


### PR DESCRIPTION
Description
This PR fixes #8146 by preventing measurable IR rewrites from being kept on unvalued intermediate paths.

Changes
- Add `has_valued_path_not_through_rv` helper in `pymc/logprob/utils.py`.
- Gate `find_measurable_clips` and `find_measurable_transforms` rewrites so they only apply when a node reaches a `ValuedRV` without crossing another RV node.
- Un-xfail `test_unvalued_ir_reversion` (now passing).

Files changed
- `pymc/logprob/utils.py`
- `pymc/logprob/censoring.py`
- `pymc/logprob/transforms.py`
- `tests/logprob/test_composite_logprob.py`

Related Issue
- Closes #8146

Checklist
- [x] Checked that pre-commit linting/style checks pass
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a relevant logical change

Type of change
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):

Test Notes
- `python -m pytest tests/logprob/test_composite_logprob.py::test_unvalued_ir_reversion -q`
- `PYTENSOR_FLAGS=cxx= python -m pytest tests/logprob/test_composite_logprob.py::test_scalar_clipped_mixture tests/logprob/test_composite_logprob.py::test_unvalued_ir_reversion tests/logprob/test_composite_logprob.py::test_affine_transform_rv tests/logprob/test_composite_logprob.py::test_affine_log_transform_rv tests/logprob/test_composite_logprob.py::test_double_log_transform_rv tests/logprob/test_composite_logprob.py::test_shifted_cumsum -q`