### PR TITLE
Strengthen metropolis broadcasting test with explicit assertions

### DIFF
--- a/tests/test_pytensorf.py
+++ b/tests/test_pytensorf.py
@@ -107,8 +107,19 @@ class TestBroadcasting:
             test2 = pm.Normal("test2", mu=test1, sigma=1.0, size=(10, 10))
 
             step = pm.Metropolis()
-            # TODO FIXME: Assert whatever it is we're testing
-            pm.sample(tune=5, draws=7, cores=1, step=step, compute_convergence_checks=False)
+            idata = pm.sample(
+                tune=5,
+                draws=7,
+                chains=1,
+                cores=1,
+                random_seed=1123,
+                step=step,
+                compute_convergence_checks=False,
+                progressbar=False,
+            )
+
+        assert idata.posterior["test1"].shape == (1, 7, 1, 10)
+        assert idata.posterior["test2"].shape == (1, 7, 10, 10)
 
 
 def _make_along_axis_idx(arr_shape, indices, axis):


### PR DESCRIPTION
Description
Strengthens `TestBroadcasting.test_metropolis_sampling` by replacing placeholder TODO/FIXME behavior with explicit assertions.

Changes
- Capture returned `InferenceData` from sampling.
- Use deterministic sampling settings (`chains=1`, `random_seed`, `progressbar=False`).
- Assert posterior shapes for both broadcasted variables.

Files changed
- `tests/test_pytensorf.py`

Checklist
- [x] Checked that pre-commit linting/style checks pass
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a relevant logical change

Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify): Test quality improvement

Test Notes
- `PYTENSOR_FLAGS=cxx= python -m pytest tests/test_pytensorf.py::TestBroadcasting::test_metropolis_sampling -q`