### PR TITLE
BUG: Validate target_accept is in (0, 1) range

### DIFF
--- a/pymc/distributions/timeseries.py
+++ b/pymc/distributions/timeseries.py
@@ -122,9 +122,28 @@ class RandomWalkRV(SymbolicRandomVariable):
 
 
 class RandomWalk(Distribution):
-    r"""RandomWalk Distribution.
+    r"""
+    Random Walk distribution.
 
-    TODO: Expand docstrings
+        A random walk is a stochastic process where the position at    time :math:`t`
+        is the sum of the position at time :math:`t-1` and a random step (innovation).
+
+        .. math::
+            X_t = X_{t-1} + \epsilon_t
+
+        where :math:`\epsilon_t` follows the distribution specified by `innovation_dist`.
+
+    Parameters
+    ----------
+        innovation_dist : Distribution
+            The distribution of the innovations (steps). This should be an instance
+            of a PyMC distribution (created via `.dist()`), describing the random
+            noise added at each step.
+        steps : int, optional
+            The number of steps in the random walk.
+        kwargs
+            Additional arguments passed to the distribution, such as `init_dist`
+            (distribution of the initial state) or dimensions.
     """
 
     rv_type = RandomWalkRV

--- a/pymc/distributions/timeseries.py
+++ b/pymc/distributions/timeseries.py
@@ -122,28 +122,27 @@ class RandomWalkRV(SymbolicRandomVariable):
 
 
 class RandomWalk(Distribution):
-    r"""
-    Random Walk distribution.
+    r"""Random Walk distribution.
 
-        A random walk is a stochastic process where the position at    time :math:`t`
-        is the sum of the position at time :math:`t-1` and a random step (innovation).
+    A random walk is a stochastic process where the position at    time :math:`t`
+    is the sum of the position at time :math:`t-1` and a random step (innovation).
 
-        .. math::
-            X_t = X_{t-1} + \epsilon_t
+    .. math::
+       X_t = X_{t-1} + \epsilon_t
 
-        where :math:`\epsilon_t` follows the distribution specified by `innovation_dist`.
+    where :math:`\epsilon_t` follows the distribution specified by `innovation_dist`.
 
     Parameters
     ----------
-        innovation_dist : Distribution
-            The distribution of the innovations (steps). This should be an instance
-            of a PyMC distribution (created via `.dist()`), describing the random
-            noise added at each step.
-        steps : int, optional
-            The number of steps in the random walk.
-        kwargs
-            Additional arguments passed to the distribution, such as `init_dist`
-            (distribution of the initial state) or dimensions.
+    innovation_dist : Distribution
+        The distribution of the innovations (steps). This should be an instance
+        of a PyMC distribution (created via `.dist()`), describing the random
+        noise added at each step.
+    steps : int, optional
+        The number of steps in the random walk.
+    **kwargs
+       Additional arguments passed to the distribution, such as `init_dist`
+       (distribution of the initial state) or dimensions.
     """
 
     rv_type = RandomWalkRV

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -309,6 +309,9 @@ def _sample_external_nuts(
     if nuts_sampler_kwargs is None:
         nuts_sampler_kwargs = {}
 
+    if not 0 < target_accept < 1:
+        raise ValueError(f"target_accept must be a float in (0, 1), got {target_accept!r}.")
+
     if sampler == "nutpie":
         try:
             import nutpie

--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -158,6 +158,9 @@ class BaseHMC(GradientSharedStep):
         nuts_vars = [initial_point[v.name] for v in vars]
         size = sum(v.size for v in nuts_vars)
 
+        if not 0 < target_accept < 1:
+            raise ValueError(f"target_accept must be a float in (0, 1), got {target_accept!r}.")
+
         self.step_size = step_scale / (size**0.25)
         self.step_adapt = DualAverageAdaptation(self.step_size, target_accept, gamma, k, t0)
         self.target_accept = target_accept

--- a/tests/step_methods/hmc/test_nuts.py
+++ b/tests/step_methods/hmc/test_nuts.py
@@ -207,6 +207,22 @@ class TestRVsAssignmentNUTS(RVsAssignmentStepsTester):
         self.continuous_steps(step, step_kwargs)
 
 
+def test_nuts_target_accept_out_of_range():
+    with pm.Model():
+        pm.Normal("x")
+        for bad_value in [0, 1, 1.5, -0.1]:
+            with pytest.raises(ValueError, match="target_accept must be a float in"):
+                pm.NUTS(target_accept=bad_value)
+
+
+def test_nuts_target_accept_out_of_range_via_sample():
+    with pm.Model():
+        pm.Normal("x")
+        for bad_value in [0, 1, 1.5, -0.1]:
+            with pytest.raises(ValueError, match="target_accept must be a float in"):
+                pm.sample(draws=1, tune=1, target_accept=bad_value, progressbar=False)
+
+
 def test_nuts_step_legacy_value_grad_function():
     # This test can be removed once ravel_inputs=False is deprecated
     with pm.Model() as m:


### PR DESCRIPTION
## Description

Added input validation for `target_accept` parameter to ensure it's within the `(0, 1)` range.

Previously, values like `target_accept=121195` were silently accepted, causing the step size to shrink to near-zero and sampling to stall indefinitely. This happened because the dual averaging algorithm formally works with any real number, driving the step size toward zero for large values.

### Changes
- **`pymc/step_methods/hmc/base_hmc.py`**: Validation in `BaseHMC.__init__()` — covers `pm.NUTS()` and `pm.HMC()` directly
- **`pymc/sampling/mcmc.py`**: Validation in `_sample_external_nuts()` — covers external samplers (nutpie, numpyro, blackjax)
- **`tests/step_methods/hmc/test_nuts.py`**: Two new tests verifying `ValueError` is raised for invalid values `{0, 1, 1.5, -0.1}` both via `pm.NUTS()` and `pm.sample()`

Boundaries are exclusive (`0 < target_accept < 1`) since both `0` and `1` would cause degenerate behavior in the dual averaging adaptation.

## Related Issue

- [x] Closes #7460
- [ ] Related to #

## Checklist

- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change

- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):