### PR TITLE
Fix mypy in zarr.py: handle StatShape int|None in np.arange

### DIFF
--- a/pymc/backends/zarr.py
+++ b/pymc/backends/zarr.py
@@ -683,7 +683,8 @@ class ZarrTrace:
                 for i, shape_i in enumerate(shape):
                     dim = f"{name}_dim_{i}"
                     dims.append(dim)
-                    group_coords[dim] = np.arange(shape_i, dtype="int")
+                    size = shape_i if shape_i is not None else 0
+                    group_coords[dim] = np.arange(size, dtype="int")
             dims = ("chain", "draw", *dims)
             attrs = extra_var_attrs[name] if extra_var_attrs is not None else {}
             attrs.update({"_ARRAY_DIMENSIONS": dims})


### PR DESCRIPTION
## Description
Fixes mypy CI failure in `pymc/backends/zarr.py` (line 686). 

## Related Issue
- [ ] Closes #
- [x] Related to #8118

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change]

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
