### PR TITLE
dims: optional XTensorSharedVariable and idempotent rewrite registration

### DIFF
--- a/pymc/dims/__init__.py
+++ b/pymc/dims/__init__.py
@@ -36,15 +36,18 @@ def __init__():
 
     # Make PyMC aware of xtensor functionality
     MeasurableOp.register(XRV)
-    logprob_rewrites_db.register(
-        "pre_lower_xtensor", optdb.query("+lower_xtensor"), "basic", position=0.1
-    )
-    logprob_rewrites_db.register(
-        "post_lower_xtensor", optdb.query("+lower_xtensor"), "cleanup", position=5.1
-    )
-    initial_point_rewrites_db.register(
-        "lower_xtensor", optdb.query("+lower_xtensor"), "basic", position=0.1
-    )
+    # Query a fresh rewriter per registration so each has its own identity (same
+    # rewriter object cannot be registered twice in the same db).
+    for name, db, tag, pos in [
+        ("pre_lower_xtensor", logprob_rewrites_db, "basic", 0.1),
+        ("post_lower_xtensor", logprob_rewrites_db, "cleanup", 5.1),
+        ("lower_xtensor", initial_point_rewrites_db, "basic", 0.1),
+    ]:
+        try:
+            db.register(name, optdb.query("+lower_xtensor"), tag, position=pos)
+        except ValueError as e:
+            if "already present" not in str(e):
+                raise
 
     # TODO: Better model of probability of bugs
     day_of_conception = datetime.date(2025, 6, 17)

--- a/pymc/dims/model.py
+++ b/pymc/dims/model.py
@@ -11,11 +11,22 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from __future__ import annotations
+
 from collections.abc import Callable
 
 from pytensor.tensor import TensorVariable
 from pytensor.xtensor import as_xtensor
-from pytensor.xtensor.type import XTensorSharedVariable, XTensorVariable, xtensor_shared
+from pytensor.xtensor.type import XTensorVariable
+
+try:
+    from pytensor.xtensor.type import (  # type: ignore[attr-defined]
+        XTensorSharedVariable,
+        xtensor_shared,
+    )
+except ImportError:
+    XTensorSharedVariable = None  # type: ignore[misc, assignment]
+    xtensor_shared = None  # type: ignore[assignment]
 
 from pymc.distributions.shape_utils import (
     Dims,
@@ -36,6 +47,11 @@ def Data(
     Dimensions are required if the input is not a scalar.
     These are always forwarded to the model object.
     """
+    if xtensor_shared is None:
+        raise ImportError(
+            "pymc.dims.Data requires pytensor >= 2.38 with XTensorSharedVariable support. "
+            "Please upgrade: conda install 'pytensor>=2.38.0,<2.39'"
+        )
     model = modelcontext(model)
     dims = convert_dims(dims)  # type: ignore[assignment]
     value = xtensor_shared(value, dims=dims, **kwargs, name=name)

--- a/tests/dims/test_model.py
+++ b/tests/dims/test_model.py
@@ -14,7 +14,13 @@
 import numpy as np
 import pytest
 
-from pytensor.xtensor.type import XTensorConstant, XTensorSharedVariable, XTensorType
+try:
+    from pytensor.xtensor.type import XTensorConstant, XTensorSharedVariable, XTensorType
+except ImportError:
+    pytest.skip(
+        "Requires pytensor >= 2.38 with XTensorSharedVariable",
+        allow_module_level=True,
+    )
 from xarray import DataArray
 
 import pymc as pm


### PR DESCRIPTION
- Make XTensorSharedVariable/xtensor_shared import optional for pytensor < 2.38
- Data() raises clear ImportError when xtensor_shared not available
- Register lower_xtensor rewrite per-call and catch 'already present' for idempotency
- Skip test_model when XTensorSharedVariable not available

Made-with: Cursor

## Description
dims: optional XTensorSharedVariable and idempotent rewrite registration

## Related Issue
- [ ] Closes #
- [x] Related to #8118 

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Excluded tests when `XTensorSharedVariable` is not available
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change]

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
