### PR TITLE
Add logccdf to LogNormal distribution

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -1758,6 +1758,30 @@ class LogNormal(PositiveContinuous):
             msg="sigma > 0",
         )
 
+    def logccdf(value, mu, sigma):
+        r"""
+        Compute the log complementary CDF (log survival function) of the LogNormal distribution.
+
+        .. math::
+
+            \log S(t) = \log\left(1 - \Phi\!\left(\frac{\log t - \mu}{\sigma}\right)\right)
+                      = \text{normal\_lccdf}(\mu, \sigma, \log t)
+
+        Reuses :func:`~pymc.distributions.dist_math.normal_lccdf`, consistent
+        with :meth:`Normal.logccdf`.
+        """
+        res = pt.switch(
+            pt.le(value, 0),
+            0.0,
+            normal_lccdf(mu, sigma, pt.log(value)),
+        )
+
+        return check_parameters(
+            res,
+            sigma > 0,
+            msg="sigma > 0",
+        )
+
     def icdf(value, mu, sigma):
         res = pt.exp(icdf(Normal.dist(mu, sigma), value))
         return res

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -43,7 +43,7 @@ import pymc as pm
 from pymc.distributions.distribution import Distribution
 from pymc.distributions.shape_utils import change_dist_size
 from pymc.initial_point import make_initial_point_fn
-from pymc.logprob.basic import icdf, logcdf, logp, transformed_conditional_logp
+from pymc.logprob.basic import icdf, logccdf, logcdf, logp, transformed_conditional_logp
 from pymc.logprob.utils import (
     ParameterValueError,
     local_check_parameter_to_ninf_switch,
@@ -529,6 +529,124 @@ def check_logcdf(
         npt.assert_equal(
             pymc_logcdf(**point),
             0,
+            err_msg=str(point),
+        )
+
+
+def check_logccdf(
+    pymc_dist: Distribution,
+    domain: Domain,
+    paramdomains: dict[str, Domain],
+    scipy_logccdf: Callable,
+    decimal: int | None = None,
+    n_samples: int = 100,
+    skip_paramdomain_inside_edge_test: bool = False,
+    skip_paramdomain_outside_edge_test: bool = False,
+) -> None:
+    """
+    Test PyMC logccdf and equivalent scipy logsf methods give similar results.
+
+    The following tests are performed by default:
+        1. Test PyMC logccdf and equivalent scipy logsf methods give similar
+        results for valid values and parameters inside the supported edges.
+        Edges are excluded by default, but can be artificially included by
+        creating a domain with repeated values (e.g., `Domain([0, 0, .5, 1, 1]`)
+        Can be skipped via skip_paramdomain_inside_edge_test
+        2. Test PyMC logccdf method returns -inf for invalid parameter values
+        outside the supported edges. Can be skipped via skip_paramdomain_outside_edge_test
+        3. Test PyMC logccdf method returns 0 for values below the supported
+        lower edge (S(t) = 1 when t is below support) and -inf for values above
+        the upper edge (S(t) = 0 when t exceeds support).
+
+    Parameters
+    ----------
+    pymc_dist: PyMC distribution
+    domain : Domain
+        Supported domain of distribution values
+    paramdomains : Dictionary of Parameter : Domain pairs
+        Supported domains of distribution parameters
+    scipy_logccdf : Callable
+        Scipy logsf method of equivalent pymc_dist distribution
+    decimal : Int
+        Level of precision with which pymc_dist and scipy_logccdf are compared.
+        Defaults to 6 for float64 and 3 for float32
+    n_samples : Int
+        Upper limit on the number of valid domain and value combinations that
+        are compared between pymc and scipy methods. If n_samples is below the
+        total number of combinations, a random subset is evaluated. Setting
+        n_samples = -1, will return all possible combinations. Defaults to 100
+    skip_paramdomain_inside_edge_test : Bool
+        Whether to run test 1., which checks that pymc and scipy distributions
+        match for valid values and parameters inside the respective domain edges
+    skip_paramdomain_outside_edge_test : Bool
+        Whether to run test 2., which checks that pymc distribution logccdf
+        returns -inf for invalid parameter values outside the supported domain edge
+
+    """
+    import pytest
+
+    if decimal is None:
+        decimal = select_by_precision(float64=6, float32=3)
+
+    dist = create_dist_from_paramdomains(pymc_dist, paramdomains)
+    value = dist.type()
+    value.name = "value"
+    dist_logccdf = logccdf(dist, value)
+    pymc_logccdf = pytensor.function(list(inputvars(dist_logccdf)), dist_logccdf)
+
+    # Test pymc and scipy distributions match for values and parameters
+    # within the supported domain edges (excluding edges)
+    if not skip_paramdomain_inside_edge_test:
+        domains = paramdomains.copy()
+        domains["value"] = domain
+        for point in product(domains, n_samples=n_samples):
+            point = dict(point)
+            npt.assert_almost_equal(
+                pymc_logccdf(**point),
+                scipy_logccdf(**point),
+                decimal=decimal,
+                err_msg=str(point),
+            )
+
+    valid_value = domain.vals[0]
+    valid_params = {param: paramdomain.vals[0] for param, paramdomain in paramdomains.items()}
+    valid_params["value"] = valid_value
+
+    # Test pymc distribution raises ParameterValueError for parameters outside the
+    # supported domain edges (excluding edges)
+    if not skip_paramdomain_outside_edge_test:
+        invalid_params = find_invalid_scalar_params(paramdomains)
+
+        for invalid_param, invalid_edges in invalid_params.items():
+            for invalid_edge in invalid_edges:
+                if invalid_edge is None:
+                    continue
+
+                point = valid_params.copy()
+                point[invalid_param] = invalid_edge
+
+                with pytest.raises(ParameterValueError):
+                    pymc_logccdf(**point)
+                    pytest.fail(f"test_params={point}")
+
+    # For logccdf: values below domain lower edge give 0 (S=1, entire distribution
+    # is above t), and values above domain upper edge give -inf (S=0, no mass above t).
+    # This is the inverse of check_logcdf boundary semantics.
+    invalid_lower, invalid_upper = find_invalid_scalar_params({"value": domain})["value"]
+    if invalid_lower is not None:
+        point = valid_params.copy()
+        point["value"] = invalid_lower
+        npt.assert_equal(
+            pymc_logccdf(**point),
+            0,
+            err_msg=str(point),
+        )
+    if invalid_upper is not None:
+        point = valid_params.copy()
+        point["value"] = invalid_upper
+        npt.assert_equal(
+            pymc_logccdf(**point),
+            -np.inf,
             err_msg=str(point),
         )
 

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -43,6 +43,7 @@ from pymc.testing import (
     Unit,
     assert_support_point_is_expected,
     check_icdf,
+    check_logccdf,
     check_logcdf,
     check_logp,
     check_selfconsistency_icdf,
@@ -529,6 +530,14 @@ class TestMatchesScipy:
             {"mu": R, "sigma": custom_rplusbig},
             lambda q, mu, sigma: floatX(st.lognorm.ppf(q, sigma, 0, np.exp(mu))),
             decimal=select_by_precision(float64=4, float32=3),
+        )
+
+    def test_lognormal_logccdf(self):
+        check_logccdf(
+            pm.LogNormal,
+            Rplus,
+            {"mu": R, "sigma": Rplusbig},
+            lambda value, mu, sigma: st.lognorm.logsf(value, sigma, 0, np.exp(mu)),
         )
 
     def test_studentt_logp(self):


### PR DESCRIPTION

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
Adds an explicit `logccdf` (log survival function) to `LogNormal` using `normal_lccdf(mu, sigma, log(t))` from `dist_math.py`, consistent with `Normal.logccdf`.

Unlike Weibull/Exponential, where the direct `logccdf` is just the `logcdf` intermediate minus the `log1mexp` wrapper (which PyTensor's graph optimizer already rewrites), LogNormal's `logccdf` calls a genuinely different function (`normal_lccdf` vs `normal_lcdf`), so an explicit registration is warranted.

Also adds a `check_logccdf` test helper to `pymc/testing.py`, mirroring `check_logcdf`, to support testing `logccdf` across distributions.

### Changes
- `pymc/distributions/continuous.py`: Add `logccdf` to `LogNormal`
- `pymc/testing.py`: Add `check_logccdf` helper and `logccdf` import
- `tests/distributions/test_continuous.py`: Add `test_lognormal_logccdf`

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #8164 
- [x] Related to [Discourse discussion](https://discourse.pymc.io/t/consider-adding-numerically-stable-logccdf-log-survival-function-to-exponential-weibull-and-other-distro/17603)

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

**NOTE** - I have created the PR on the `v6` branch assuming that's the right one, if this should point to `base`, please let me know, and I will rebase accordingly!

TIA, happpy to discuss if there are any concerns!