### PR TITLE
Emit scalar `DEMetropolis` "scaling" stat

### DIFF
--- a/pymc/step_methods/metropolis.py
+++ b/pymc/step_methods/metropolis.py
@@ -993,7 +993,7 @@ class DEMetropolis(PopulationArrayStepShared):
         self.steps_until_tune -= 1
 
         stats = {
-            "scaling": self.scaling,
+            "scaling": np.mean(self.scaling),
             "lambda": self.lamb,
             "accept": np.exp(accept),
             "accepted": accepted,


### PR DESCRIPTION
Replaces #8172 by doing the same fix already done in #7871, closing #8169.

~Follow-up to https://github.com/pymc-devs/pymc/pull/8015 that tracks warmup information independent of stats on `IBaseTrace`/`NDarray` backends:~

* ~`IBaseTrace.warmup_count()` for counting the total number of warmup steps~
* ~`_sample_return` switches  to using `warmup_count()` instead of relying on `tune` parameter. This works also when chains do not have the same number of warmup iterations.~

not worth it I guess

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
