### PR TITLE
Remove deprecated samples argument in sample_prior_predictive

### DIFF
--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -368,7 +368,6 @@ def sample_prior_predictive(
     return_inferencedata: Literal[True] = True,
     idata_kwargs: dict | None = None,
     compile_kwargs: dict | None = None,
-    samples: int | None = None,
 ) -> InferenceData: ...
 @overload
 def sample_prior_predictive(
@@ -379,7 +378,6 @@ def sample_prior_predictive(
     return_inferencedata: Literal[False] = False,
     idata_kwargs: dict | None = None,
     compile_kwargs: dict | None = None,
-    samples: int | None = None,
 ) -> dict[str, np.ndarray]: ...
 def sample_prior_predictive(
     draws: int = 500,
@@ -389,7 +387,6 @@ def sample_prior_predictive(
     return_inferencedata: bool = True,
     idata_kwargs: dict | None = None,
     compile_kwargs: dict | None = None,
-    samples: int | None = None,
 ) -> InferenceData | dict[str, np.ndarray]:
     """Generate samples from the prior predictive distribution.
 
@@ -411,8 +408,6 @@ def sample_prior_predictive(
         Keyword arguments for :func:`pymc.to_inference_data`
     compile_kwargs: dict, optional
         Keyword arguments for :func:`pymc.pytensorf.compile`.
-    samples : int
-        Number of samples from the prior predictive to generate. Deprecated in favor of `draws`.
 
     Returns
     -------
@@ -420,15 +415,6 @@ def sample_prior_predictive(
         An ArviZ ``InferenceData`` object containing the prior and prior predictive samples (default),
         or a dictionary with variable names as keys and samples as numpy arrays.
     """
-    if samples is not None:
-        warnings.warn(
-            f"The samples argument has been deprecated in favor of draws. Use draws={samples} going forward.",
-            DeprecationWarning,
-            stacklevel=1,
-        )
-
-        draws = samples
-
     model = modelcontext(model)
 
     if model.potentials:

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -1775,13 +1775,11 @@ class TestModelCopy:
         copy_simple_model = copy_method(simple_model)
 
         with simple_model:
-            simple_model_prior_predictive = pm.sample_prior_predictive(samples=1, random_seed=42)
+            simple_model_prior_predictive = pm.sample_prior_predictive(draws=1, random_seed=42)
 
         with copy_simple_model:
             z = pm.Deterministic("z", copy_simple_model["y"] + 1)
-            copy_simple_model_prior_predictive = pm.sample_prior_predictive(
-                samples=1, random_seed=42
-            )
+            copy_simple_model_prior_predictive = pm.sample_prior_predictive(draws=1, random_seed=42)
 
         assert (
             simple_model_prior_predictive["prior"]["y"].values

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -1798,15 +1798,6 @@ def test_observed_dependent_deterministics():
     assert set(observed_dependent_deterministics(m)) == {det_obs, det_obs2, det_mixed}
 
 
-def test_sample_prior_predictive_samples_deprecated_warns() -> None:
-    with pm.Model() as m:
-        pm.Normal("a")
-
-    match = "The samples argument has been deprecated"
-    with pytest.warns(DeprecationWarning, match=match):
-        pm.sample_prior_predictive(model=m, samples=10)
-
-
 @pytest.fixture(params=["deterministic", "observed", "conditioned_on_observed"])
 def variable_to_vectorize(request):
     if request.param == "deterministic":


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

`pm.sample_prior_predictive` 's sample deprecation is 2 years old. Fully removing.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
