### PR TITLE
Richer textual representation: show Data variables, fold constants, and use semantic separators

### DIFF
--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -111,14 +111,14 @@ def str_for_data_var(
         latex_name = r"\text{" + _latex_escape(print_name.strip("$")) + "}"
         latex_name = _format_underscore(latex_name)
         if value_str is not None:
-            return rf"${latex_name} \sim \operatorname{{Data}}({value_str.strip('$')})$"
+            return rf"${latex_name} = \operatorname{{Data}}({value_str.strip('$')})$"
         else:
-            return rf"${latex_name} \sim \operatorname{{Data}}$"
+            return rf"${latex_name} = \operatorname{{Data}}$"
     else:
         if value_str is not None:
-            return rf"{print_name} ~ Data({value_str})"
+            return rf"{print_name} = Data({value_str})"
         else:
-            return rf"{print_name} ~ Data"
+            return rf"{print_name} = Data"
 
 
 def str_for_model(model: Model, formatting: str = "plain", include_params: bool = True) -> str:
@@ -146,25 +146,34 @@ def str_for_model(model: Model, formatting: str = "plain", include_params: bool 
         return ""
     if "latex" in formatting:
         var_reprs = [_format_underscore(x) for x in var_reprs]
-        var_reprs = [
-            var_repr.replace(r"\sim", r"&\sim &").strip("$")
-            for var_repr in var_reprs
-            if var_repr is not None
-        ]
+        formatted = []
+        for var_repr in var_reprs:
+            if var_repr is None:
+                continue
+            s = var_repr.strip("$")
+            if r"\sim" in s:
+                s = s.replace(r"\sim", r"&\sim &", 1)
+            else:
+                s = s.replace(" = ", " &= &", 1)
+            formatted.append(s)
         return r"""$$
             \begin{{array}}{{rcl}}
             {}
             \end{{array}}
-            $$""".format("\\\\".join(var_reprs))
+            $$""".format("\\\\".join(formatted))
     else:
-        # align vars on their ~
-        names = [s[: s.index("~") - 1] for s in var_reprs]
-        distrs = [s[s.index("~") + 2 :] for s in var_reprs]
-        maxlen = str(max(len(x) for x in names))
-        var_reprs = [
-            ("{name:>" + maxlen + "} ~ {distr}").format(name=n, distr=d)
-            for n, d in zip(names, distrs)
-        ]
+        sep_pattern = re.compile(r" ([~=]) ")
+        names = []
+        seps = []
+        distrs = []
+        for s in var_reprs:
+            m = sep_pattern.search(s)
+            assert m is not None
+            names.append(s[: m.start()])
+            seps.append(m.group(1))
+            distrs.append(s[m.end() :])
+        maxlen = max(len(n) for n in names)
+        var_reprs = [f"{n:>{maxlen}} {sep} {d}" for n, sep, d in zip(names, seps, distrs)]
         return "\n".join(var_reprs)
 
 
@@ -180,17 +189,19 @@ def str_for_potential_or_deterministic(
     values included.
     """
     print_name = var.name if var.name is not None else "<unnamed>"
+    sep_plain = "~" if dist_name == "Potential" else "="
+    sep_latex = r"\sim" if dist_name == "Potential" else "="
     if "latex" in formatting:
         print_name = r"\text{" + _latex_escape(print_name.strip("$")) + "}"
         if include_params:
-            return rf"${print_name} \sim \operatorname{{{dist_name}}}({_str_for_expression(var, formatting=formatting)})$"
+            return rf"${print_name} {sep_latex} \operatorname{{{dist_name}}}({_str_for_expression(var, formatting=formatting)})$"
         else:
-            return rf"${print_name} \sim \operatorname{{{dist_name}}}$"
+            return rf"${print_name} {sep_latex} \operatorname{{{dist_name}}}$"
     else:  # plain
         if include_params:
-            return rf"{print_name} ~ {dist_name}({_str_for_expression(var, formatting=formatting)})"
+            return rf"{print_name} {sep_plain} {dist_name}({_str_for_expression(var, formatting=formatting)})"
         else:
-            return rf"{print_name} ~ {dist_name}"
+            return rf"{print_name} {sep_plain} {dist_name}"
 
 
 def _str_for_input_var(var: Variable, formatting: str) -> str:

--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -96,9 +96,7 @@ def str_for_dist(dist: Variable, formatting: str = "plain", include_params: bool
                 return dist_name
 
 
-def str_for_data_var(
-    var: Variable, formatting: str = "plain", include_params: bool = True
-) -> str:
+def str_for_data_var(var: Variable, formatting: str = "plain", include_params: bool = True) -> str:
     """Make a human-readable string representation of a Data variable in a model."""
     print_name = var.name if var.name is not None else "<unnamed>"
 
@@ -278,11 +276,7 @@ def _str_for_expression(var: Variable, formatting: str) -> str:
                     xname = rf"<{opname}>"
             assert xname is not None
             names.append(xname)
-        elif (
-            isinstance(x, SharedVariable)
-            and x.name
-            and not isinstance(x.type, RandomType)
-        ):
+        elif isinstance(x, SharedVariable) and x.name and not isinstance(x.type, RandomType):
             parents.append(x)
             names.append(x.name)
 

--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -96,7 +96,9 @@ def str_for_dist(dist: Variable, formatting: str = "plain", include_params: bool
                 return dist_name
 
 
-def str_for_data_var(var: Variable, formatting: str = "plain", include_params: bool = True) -> str:
+def str_for_data_var(
+    var: Constant | SharedVariable, formatting: str = "plain", include_params: bool = True
+) -> str:
     """Make a human-readable string representation of a Data variable in a model."""
     print_name = var.name if var.name is not None else "<unnamed>"
 
@@ -210,11 +212,14 @@ def _str_for_input_var(var: Variable, formatting: str) -> str:
     elif isinstance(var.owner.op, DimShuffle):
         return _str_for_input_var(var.owner.inputs[0], formatting)
     else:
+        if not isinstance(var, TensorVariable):
+            return _str_for_expression(var, formatting)
         try:
             from pymc.exceptions import NotConstantValueError
             from pymc.pytensorf import constant_fold
 
             [folded] = constant_fold([var], raise_not_constant=True)
+            assert isinstance(folded, np.ndarray)
             return _str_for_constant_value(folded, formatting)
         except NotConstantValueError:
             return _str_for_expression(var, formatting)

--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -17,6 +17,8 @@ import re
 
 from functools import partial
 
+import numpy as np
+
 from pytensor.compile import SharedVariable
 from pytensor.graph.basic import Constant, Variable
 from pytensor.graph.traversal import walk
@@ -29,6 +31,7 @@ from pymc.logprob.abstract import MeasurableOp
 from pymc.model import Model
 
 __all__ = [
+    "str_for_data_var",
     "str_for_dist",
     "str_for_model",
     "str_for_potential_or_deterministic",
@@ -93,6 +96,31 @@ def str_for_dist(dist: Variable, formatting: str = "plain", include_params: bool
                 return dist_name
 
 
+def str_for_data_var(
+    var: Variable, formatting: str = "plain", include_params: bool = True
+) -> str:
+    """Make a human-readable string representation of a Data variable in a model."""
+    print_name = var.name if var.name is not None else "<unnamed>"
+
+    if include_params:
+        value_str = _str_for_constant(var, formatting)
+    else:
+        value_str = None
+
+    if "latex" in formatting:
+        latex_name = r"\text{" + _latex_escape(print_name.strip("$")) + "}"
+        latex_name = _format_underscore(latex_name)
+        if value_str is not None:
+            return rf"${latex_name} \sim \operatorname{{Data}}({value_str.strip('$')})$"
+        else:
+            return rf"${latex_name} \sim \operatorname{{Data}}$"
+    else:
+        if value_str is not None:
+            return rf"{print_name} ~ Data({value_str})"
+        else:
+            return rf"{print_name} ~ Data"
+
+
 def str_for_model(model: Model, formatting: str = "plain", include_params: bool = True) -> str:
     """Make a human-readable string representation of Model.
 
@@ -104,13 +132,15 @@ def str_for_model(model: Model, formatting: str = "plain", include_params: bool 
     sfp = partial(
         str_for_potential_or_deterministic, formatting=formatting, include_params=include_params
     )
+    sfdv = partial(str_for_data_var, formatting=formatting, include_params=include_params)
 
+    data_reprs = [sfdv(dv) for dv in model.data_vars]
     free_rv_reprs = [sfd(dist) for dist in model.free_RVs]
     observed_rv_reprs = [sfd(rv) for rv in model.observed_RVs]
     det_reprs = [sfp(dist, dist_name="Deterministic") for dist in model.deterministics]
     potential_reprs = [sfp(pot, dist_name="Potential") for pot in model.potentials]
 
-    var_reprs = free_rv_reprs + det_reprs + observed_rv_reprs + potential_reprs
+    var_reprs = data_reprs + free_rv_reprs + det_reprs + observed_rv_reprs + potential_reprs
 
     if not var_reprs:
         return ""
@@ -178,13 +208,18 @@ def _str_for_input_var(var: Variable, formatting: str) -> str:
     if isinstance(var, Constant | SharedVariable):
         return _str_for_constant(var, formatting)
     elif isinstance(var.owner.op, MeasurableOp) or _is_potential_or_deterministic(var):
-        # show the names for RandomVariables, Deterministics, and Potentials, rather
-        # than the full expression
         return _str_for_input_rv(var, formatting)
     elif isinstance(var.owner.op, DimShuffle):
         return _str_for_input_var(var.owner.inputs[0], formatting)
     else:
-        return _str_for_expression(var, formatting)
+        try:
+            from pymc.exceptions import NotConstantValueError
+            from pymc.pytensorf import constant_fold
+
+            [folded] = constant_fold([var], raise_not_constant=True)
+            return _str_for_constant_value(folded, formatting)
+        except NotConstantValueError:
+            return _str_for_expression(var, formatting)
 
 
 def _str_for_input_rv(var: Variable, formatting: str) -> str:
@@ -207,6 +242,12 @@ def _str_for_constant(var: Constant | SharedVariable, formatting: str) -> str:
         var_data = var.get_value()
         var_type = "shared"
 
+    return _str_for_constant_value(var_data, formatting, var_type=var_type)
+
+
+def _str_for_constant_value(
+    var_data: np.ndarray, formatting: str, var_type: str = "constant"
+) -> str:
     if len(var_data.shape) == 0:
         return f"{var_data:.3g}"
     elif len(var_data.shape) == 1 and var_data.shape[0] == 1:
@@ -220,7 +261,7 @@ def _str_for_constant(var: Constant | SharedVariable, formatting: str) -> str:
 def _str_for_expression(var: Variable, formatting: str) -> str:
     # Avoid circular import
 
-    # construct a string like f(a1, ..., aN) listing all random variables a as arguments
+    # construct a string like f(a1, ..., aN) listing all named variables as arguments
     def _expand(x):
         if x.owner and not isinstance(x.owner.op, MeasurableOp):
             return reversed(x.owner.inputs)
@@ -233,12 +274,17 @@ def _str_for_expression(var: Variable, formatting: str) -> str:
             parents.append(x)
             xname = x.name
             if xname is None:
-                # If the variable is unnamed, we show the op's name as we do
-                # with constants
                 if (opname := getattr(x.owner.op, "name", None)) is not None:
                     xname = rf"<{opname}>"
             assert xname is not None
             names.append(xname)
+        elif (
+            isinstance(x, SharedVariable)
+            and x.name
+            and not isinstance(x.type, RandomType)
+        ):
+            parents.append(x)
+            names.append(x.name)
 
     if "latex" in formatting:
         return (

--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -38,7 +38,12 @@ __all__ = [
 ]
 
 
-def str_for_dist(dist: Variable, formatting: str = "plain", include_params: bool = True) -> str:
+def str_for_dist(
+    dist: Variable,
+    formatting: str = "plain",
+    include_params: bool = True,
+    named_vars: set[Variable] | None = None,
+) -> str:
     """Make a human-readable string representation of a Distribution in a model.
 
     This can be either LaTeX or plain, optionally with distribution parameter
@@ -55,7 +60,9 @@ def str_for_dist(dist: Variable, formatting: str = "plain", include_params: bool
                 x for x in dist.owner.inputs if not isinstance(x.type, RandomType | NoneTypeT)
             ]
 
-        dist_args_str = [_str_for_input_var(a, formatting=formatting) for a in dist_args]
+        dist_args_str = [
+            _str_for_input_var(a, formatting=formatting, named_vars=named_vars) for a in dist_args
+        ]
 
     if (print_name := getattr(dist_op, "_print_name", None)) is not None:
         dist_name = print_name[formatting == "latex"]
@@ -127,10 +134,22 @@ def str_for_model(model: Model, formatting: str = "plain", include_params: bool 
     This lists all random variables and their distributions, optionally
     including parameter values.
     """
+    named_vars: set[Variable] = set()
+    named_vars.update(model.data_vars)
+    named_vars.update(model.free_RVs)
+    named_vars.update(model.observed_RVs)
+    named_vars.update(model.deterministics)
+    named_vars.update(model.potentials)
+
     # Wrap functions to avoid confusing typecheckers
-    sfd = partial(str_for_dist, formatting=formatting, include_params=include_params)
+    sfd = partial(
+        str_for_dist, formatting=formatting, include_params=include_params, named_vars=named_vars
+    )
     sfp = partial(
-        str_for_potential_or_deterministic, formatting=formatting, include_params=include_params
+        str_for_potential_or_deterministic,
+        formatting=formatting,
+        include_params=include_params,
+        named_vars=named_vars,
     )
     sfdv = partial(str_for_data_var, formatting=formatting, include_params=include_params)
 
@@ -182,6 +201,7 @@ def str_for_potential_or_deterministic(
     formatting: str = "plain",
     include_params: bool = True,
     dist_name: str = "Deterministic",
+    named_vars: set[Variable] | None = None,
 ) -> str:
     """Make a human-readable string representation of a Deterministic or Potential in a model.
 
@@ -194,46 +214,41 @@ def str_for_potential_or_deterministic(
     if "latex" in formatting:
         print_name = r"\text{" + _latex_escape(print_name.strip("$")) + "}"
         if include_params:
-            return rf"${print_name} {sep_latex} \operatorname{{{dist_name}}}({_str_for_expression(var, formatting=formatting)})$"
+            return rf"${print_name} {sep_latex} \operatorname{{{dist_name}}}({_str_for_expression(var, formatting=formatting, named_vars=named_vars)})$"
         else:
             return rf"${print_name} {sep_latex} \operatorname{{{dist_name}}}$"
     else:  # plain
         if include_params:
-            return rf"{print_name} {sep_plain} {dist_name}({_str_for_expression(var, formatting=formatting)})"
+            return rf"{print_name} {sep_plain} {dist_name}({_str_for_expression(var, formatting=formatting, named_vars=named_vars)})"
         else:
             return rf"{print_name} {sep_plain} {dist_name}"
 
 
-def _str_for_input_var(var: Variable, formatting: str) -> str:
+def _str_for_input_var(
+    var: Variable, formatting: str, named_vars: set[Variable] | None = None
+) -> str:
     def _is_potential_or_deterministic(var: Variable) -> bool:
-        # FIXME: This is an (insufficient) hack. For model_repr we know which nodes are named variables
-        # and we should propagate that information instead of guessing based on whether something was monkey-patched
+        # Fallback for standalone calls (named_vars is None).
+        # When named_vars is provided, this is unnecessary.
         if not hasattr(var, "str_repr"):
             return False
         try:
             return var.str_repr.__func__.func is str_for_potential_or_deterministic
         except AttributeError:
-            # in case other code overrides str_repr, fallback
             return False
 
     if isinstance(var, Constant | SharedVariable):
         return _str_for_constant(var, formatting)
-    elif isinstance(var.owner.op, MeasurableOp) or _is_potential_or_deterministic(var):
+    elif (
+        (named_vars is not None and var in named_vars)
+        or isinstance(var.owner.op, MeasurableOp)
+        or _is_potential_or_deterministic(var)
+    ):
         return _str_for_input_rv(var, formatting)
     elif isinstance(var.owner.op, DimShuffle):
-        return _str_for_input_var(var.owner.inputs[0], formatting)
+        return _str_for_input_var(var.owner.inputs[0], formatting, named_vars)
     else:
-        if not isinstance(var, TensorVariable):
-            return _str_for_expression(var, formatting)
-        try:
-            from pymc.exceptions import NotConstantValueError
-            from pymc.pytensorf import constant_fold
-
-            [folded] = constant_fold([var], raise_not_constant=True)
-            assert isinstance(folded, np.ndarray)
-            return _str_for_constant_value(folded, formatting)
-        except NotConstantValueError:
-            return _str_for_expression(var, formatting)
+        return _str_for_expression(var, formatting, named_vars)
 
 
 def _str_for_input_rv(var: Variable, formatting: str) -> str:
@@ -272,11 +287,12 @@ def _str_for_constant_value(
         return rf"<{var_type}>"
 
 
-def _str_for_expression(var: Variable, formatting: str) -> str:
-    # Avoid circular import
-
-    # construct a string like f(a1, ..., aN) listing all named variables as arguments
+def _str_for_expression(
+    var: Variable, formatting: str, named_vars: set[Variable] | None = None
+) -> str:
     def _expand(x):
+        if named_vars is not None and x in named_vars:
+            return None
         if x.owner and not isinstance(x.owner.op, MeasurableOp):
             return reversed(x.owner.inputs)
 
@@ -284,7 +300,11 @@ def _str_for_expression(var: Variable, formatting: str) -> str:
     names = []
     for x in walk(nodes=var.owner.inputs, expand=_expand):
         assert isinstance(x, Variable)
-        if x.owner and isinstance(x.owner.op, MeasurableOp):
+        if named_vars is not None and x in named_vars:
+            if x.name:
+                parents.append(x)
+                names.append(x.name)
+        elif x.owner and isinstance(x.owner.op, MeasurableOp):
             parents.append(x)
             xname = x.name
             if xname is None:
@@ -292,9 +312,12 @@ def _str_for_expression(var: Variable, formatting: str) -> str:
                     xname = rf"<{opname}>"
             assert xname is not None
             names.append(xname)
-        elif isinstance(x, SharedVariable) and x.name and not isinstance(x.type, RandomType):
-            parents.append(x)
-            names.append(x.name)
+
+    if not names:
+        if "latex" in formatting:
+            return r"\text{<constant>}"
+        else:
+            return "<constant>"
 
     if "latex" in formatting:
         return (

--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -230,9 +230,7 @@ def str_for_potential_or_deterministic(
             return rf"{print_name} {sep_plain} {dist_name}"
 
 
-def _str_for_input_var(
-    var: Variable, formatting: str, named_vars: set[Variable]
-) -> str:
+def _str_for_input_var(var: Variable, formatting: str, named_vars: set[Variable]) -> str:
     if isinstance(var, Constant | SharedVariable):
         return _str_for_constant(var, formatting)
     elif var in named_vars or isinstance(var.owner.op, MeasurableOp):

--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -49,6 +49,9 @@ def str_for_dist(
     This can be either LaTeX or plain, optionally with distribution parameter
     values included.
     """
+    if named_vars is None:
+        named_vars = set()
+
     dist_op = dist.owner.op
 
     if include_params:
@@ -208,6 +211,9 @@ def str_for_potential_or_deterministic(
     This can be either LaTeX or plain, optionally with distribution parameter
     values included.
     """
+    if named_vars is None:
+        named_vars = set()
+
     print_name = var.name if var.name is not None else "<unnamed>"
     sep_plain = "~" if dist_name == "Potential" else "="
     sep_latex = r"\sim" if dist_name == "Potential" else "="
@@ -225,25 +231,11 @@ def str_for_potential_or_deterministic(
 
 
 def _str_for_input_var(
-    var: Variable, formatting: str, named_vars: set[Variable] | None = None
+    var: Variable, formatting: str, named_vars: set[Variable]
 ) -> str:
-    def _is_potential_or_deterministic(var: Variable) -> bool:
-        # Fallback for standalone calls (named_vars is None).
-        # When named_vars is provided, this is unnecessary.
-        if not hasattr(var, "str_repr"):
-            return False
-        try:
-            return var.str_repr.__func__.func is str_for_potential_or_deterministic
-        except AttributeError:
-            return False
-
     if isinstance(var, Constant | SharedVariable):
         return _str_for_constant(var, formatting)
-    elif (
-        (named_vars is not None and var in named_vars)
-        or isinstance(var.owner.op, MeasurableOp)
-        or _is_potential_or_deterministic(var)
-    ):
+    elif var in named_vars or isinstance(var.owner.op, MeasurableOp):
         return _str_for_input_rv(var, formatting)
     elif isinstance(var.owner.op, DimShuffle):
         return _str_for_input_var(var.owner.inputs[0], formatting, named_vars)
@@ -287,11 +279,9 @@ def _str_for_constant_value(
         return rf"<{var_type}>"
 
 
-def _str_for_expression(
-    var: Variable, formatting: str, named_vars: set[Variable] | None = None
-) -> str:
+def _str_for_expression(var: Variable, formatting: str, named_vars: set[Variable]) -> str:
     def _expand(x):
-        if named_vars is not None and x in named_vars:
+        if x in named_vars:
             return None
         if x.owner and not isinstance(x.owner.op, MeasurableOp):
             return reversed(x.owner.inputs)
@@ -300,7 +290,7 @@ def _str_for_expression(
     names = []
     for x in walk(nodes=var.owner.inputs, expand=_expand):
         assert isinstance(x, Variable)
-        if named_vars is not None and x in named_vars:
+        if x in named_vars:
             if x.name:
                 parents.append(x)
                 names.append(x.name)

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -210,9 +210,7 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 r"$\text{pred} = \operatorname{Deterministic}",
             ],
         }
-        self.model_expected = {
-            k: list(v) for k, v in self.expected.items()
-        }
+        self.model_expected = {k: list(v) for k, v in self.expected.items()}
         self.model_expected[("plain", True)][9] = r"Y_obs ~ Normal(mu, sigma)"
         self.model_expected[("latex", True)][9] = (
             r"$\text{Y\_obs} \sim \operatorname{Normal}(\text{mu},~\text{sigma})$"

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -18,7 +18,18 @@ import numpy as np
 
 from pytensor.tensor.random import normal
 
-from pymc import Bernoulli, Censored, CustomDist, Gamma, HalfCauchy, Mixture, StudentT, Truncated
+from pymc import (
+    Bernoulli,
+    Censored,
+    CustomDist,
+    Data,
+    Exponential,
+    Gamma,
+    HalfCauchy,
+    Mixture,
+    StudentT,
+    Truncated,
+)
 from pymc.distributions import (
     Dirichlet,
     DirichletMultinomial,
@@ -373,12 +384,10 @@ class TestDimsDist:
 
 def test_data_vars_in_model_repr():
     """Data variables appear in model repr and in Deterministic dependency lists (issue #7536)."""
-    import pymc as pm
-
-    with pm.Model() as model:
-        x = pm.Data("x", 0)
-        y = pm.Normal("y")
-        f = pm.Deterministic("f", x + y)
+    with Model() as model:
+        x = Data("x", 0)
+        y = Normal("y")
+        Deterministic("f", x + y)
 
     text = model.str_repr()
     assert "x = Data(0)" in text
@@ -390,12 +399,10 @@ def test_data_vars_in_model_repr():
     assert r"\text{x}" in latex
 
 
-def test_constant_folding_in_repr():
+def test_constant_only_expression_in_repr():
     """Constant-only expressions show <constant> instead of f() (issue #7538)."""
-    import pymc as pm
-
-    with pm.Model() as model:
-        x = pm.Exponential("x", lam=2)
+    with Model() as model:
+        Exponential("x", lam=2)
 
     text = model.str_repr()
     assert "f()" not in text
@@ -404,11 +411,9 @@ def test_constant_folding_in_repr():
 
 def test_data_var_repr_no_params():
     """Data variable repr without params."""
-    import pymc as pm
-
-    with pm.Model() as model:
-        x = pm.Data("x", 5)
-        pm.Normal("y", x)
+    with Model() as model:
+        x = Data("x", 5)
+        Normal("y", x)
 
     text_no_params = model.str_repr(include_params=False)
     assert "x = Data" in text_no_params
@@ -417,13 +422,11 @@ def test_data_var_repr_no_params():
 
 def test_data_var_latex_underscore_escaping():
     """Data variable names with underscores are escaped in LaTeX (direct call and model repr)."""
-    import pymc as pm
-
     from pymc.printing import str_for_data_var
 
-    with pm.Model() as model:
-        my_data = pm.Data("my_data", 42)
-        pm.Normal("y", my_data)
+    with Model() as model:
+        my_data = Data("my_data", 42)
+        Normal("y", my_data)
 
     # Direct call
     latex_with_params = str_for_data_var(my_data, formatting="latex", include_params=True)
@@ -441,11 +444,9 @@ def test_data_var_latex_underscore_escaping():
 
 def test_function_of_named_var_in_repr():
     """A non-constant expression should keep f(named_var) form in model repr."""
-    import pymc as pm
-
-    with pm.Model() as model:
-        a = pm.Normal("a")
-        b = pm.Normal("b", mu=a * 2)
+    with Model() as model:
+        a = Normal("a")
+        Normal("b", mu=a * 2)
 
     text = model.str_repr()
     assert "b ~ Normal(f(a), 1)" in text

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import re
+
 import numpy as np
 
 from pytensor.tensor.random import normal
@@ -34,6 +36,11 @@ from pymc.pytensorf import floatX
 
 
 class BaseTestStrAndLatexRepr:
+    @staticmethod
+    def _latex_segments(tex: str) -> list[str]:
+        """Split a LaTeX repr on its separator (\\sim or =) into segments for substring checks."""
+        return [s for s in re.split(r"\\sim| = ", tex.strip("$")) if s.strip()]
+
     def test__repr_latex_(self):
         for distribution, tex in zip(self.distributions, self.expected[("latex", True)]):
             assert distribution._repr_latex_() == tex
@@ -42,7 +49,7 @@ class BaseTestStrAndLatexRepr:
 
         # make sure each variable is in the model
         for tex in self.expected[("latex", True)]:
-            for segment in tex.strip("$").split(r"\sim"):
+            for segment in self._latex_segments(tex):
                 assert segment in model_tex
 
     def test_str_repr(self):
@@ -53,7 +60,7 @@ class BaseTestStrAndLatexRepr:
             model_text = self.model.str_repr(*str_format)
             for text in self.expected[str_format]:
                 if str_format[0] == "latex":
-                    for segment in text.strip("$").split(r"\sim"):
+                    for segment in self._latex_segments(text):
                         assert segment in model_text
                 else:
                     assert text in model_text
@@ -137,7 +144,7 @@ class TestMonolith(BaseTestStrAndLatexRepr):
             ("plain", True): [
                 r"alpha ~ Normal(0, 10)",
                 r"sigma ~ HalfNormal(0, 1)",
-                r"mu ~ Deterministic(f(alpha, beta))",
+                r"mu = Deterministic(f(alpha, beta))",
                 r"beta ~ Normal(0, 10)",
                 r"Z ~ MultivariateNormal(<constant>, <constant>)",
                 r"nb_with_p_n ~ NegativeBinomial(10, nbp)",
@@ -150,12 +157,12 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 ),
                 r"Y_obs ~ Normal(mu, sigma)",
                 r"pot ~ Potential(f(alpha, beta))",
-                r"pred ~ Deterministic(f(<normal>))",
+                r"pred = Deterministic(f(<normal>))",
             ],
             ("plain", False): [
                 r"alpha ~ Normal",
                 r"sigma ~ HalfNormal",
-                r"mu ~ Deterministic",
+                r"mu = Deterministic",
                 r"beta ~ Normal",
                 r"Z ~ MultivariateNormal",
                 r"nb_with_p_n ~ NegativeBinomial",
@@ -164,12 +171,12 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 r"nested_mix ~ Mixture",
                 r"Y_obs ~ Normal",
                 r"pot ~ Potential",
-                r"pred ~ Deterministic",
+                r"pred = Deterministic",
             ],
             ("latex", True): [
                 r"$\text{alpha} \sim \operatorname{Normal}(0,~10)$",
                 r"$\text{sigma} \sim \operatorname{HalfNormal}(0,~1)$",
-                r"$\text{mu} \sim \operatorname{Deterministic}(f(\text{alpha},~\text{beta}))$",
+                r"$\text{mu} = \operatorname{Deterministic}(f(\text{alpha},~\text{beta}))$",
                 r"$\text{beta} \sim \operatorname{Normal}(0,~10)$",
                 r"$\text{Z} \sim \operatorname{MultivariateNormal}(\text{<constant>},~\text{<constant>})$",
                 r"$\text{nb\_with\_p\_n} \sim \operatorname{NegativeBinomial}(10,~\text{nbp})$",
@@ -182,12 +189,12 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 ),
                 r"$\text{Y\_obs} \sim \operatorname{Normal}(\text{mu},~\text{sigma})$",
                 r"$\text{pot} \sim \operatorname{Potential}(f(\text{alpha},~\text{beta}))$",
-                r"$\text{pred} \sim \operatorname{Deterministic}(f(\text{<normal>}))",
+                r"$\text{pred} = \operatorname{Deterministic}(f(\text{<normal>}))",
             ],
             ("latex", False): [
                 r"$\text{alpha} \sim \operatorname{Normal}$",
                 r"$\text{sigma} \sim \operatorname{HalfNormal}$",
-                r"$\text{mu} \sim \operatorname{Deterministic}$",
+                r"$\text{mu} = \operatorname{Deterministic}$",
                 r"$\text{beta} \sim \operatorname{Normal}$",
                 r"$\text{Z} \sim \operatorname{MultivariateNormal}$",
                 r"$\text{nb\_with\_p\_n} \sim \operatorname{NegativeBinomial}$",
@@ -196,7 +203,7 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 r"$\text{nested\_mix} \sim \operatorname{Mixture}$",
                 r"$\text{Y\_obs} \sim \operatorname{Normal}$",
                 r"$\text{pot} \sim \operatorname{Potential}$",
-                r"$\text{pred} \sim \operatorname{Deterministic}",
+                r"$\text{pred} = \operatorname{Deterministic}",
             ],
         }
 
@@ -380,12 +387,12 @@ def test_data_vars_in_model_repr():
         f = pm.Deterministic("f", x + y)
 
     text = model.str_repr()
-    assert "x ~ Data(0)" in text
+    assert "x = Data(0)" in text
     assert "y ~ Normal(0, 1)" in text
-    assert "f ~ Deterministic(f(y, x))" in text
+    assert "f = Deterministic(f(y, x))" in text
 
     latex = model.str_repr(formatting="latex")
-    assert r"\operatorname{Data}(0)" in latex
+    assert r"&= &\operatorname{Data}(0)" in latex
     assert r"\text{x}" in latex
 
 
@@ -410,7 +417,7 @@ def test_data_var_repr_no_params():
         pm.Normal("y", x)
 
     text_no_params = model.str_repr(include_params=False)
-    assert "x ~ Data" in text_no_params
+    assert "x = Data" in text_no_params
     assert "y ~ Normal" in text_no_params
 
 

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -42,25 +42,17 @@ class BaseTestStrAndLatexRepr:
         return [s for s in re.split(r"\\sim| = ", tex.strip("$")) if s.strip()]
 
     def test__repr_latex_(self):
-        for distribution, tex in zip(self.distributions, self.expected[("latex", True)]):
-            assert distribution._repr_latex_() == tex
-
         model_tex = self.model._repr_latex_()
-        model_expected = getattr(self, "model_expected", self.expected)
 
         # make sure each variable is in the model
-        for tex in model_expected[("latex", True)]:
+        for tex in self.expected[("latex", True)]:
             for segment in self._latex_segments(tex):
                 assert segment in model_tex
 
     def test_str_repr(self):
-        model_expected = getattr(self, "model_expected", self.expected)
         for str_format in self.formats:
-            for dist, text in zip(self.distributions, self.expected[str_format]):
-                assert dist.str_repr(*str_format) == text
-
             model_text = self.model.str_repr(*str_format)
-            for text in model_expected[str_format]:
+            for text in self.expected[str_format]:
                 if str_format[0] == "latex":
                     for segment in self._latex_segments(text):
                         assert segment in model_text
@@ -157,9 +149,7 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                     r"Mixture(<constant>, DiracDelta(0), Poisson(5)), "
                     r"Censored(Bernoulli(0.5), -1, 1))"
                 ),
-                r"Y_obs ~ Normal(f(alpha, beta), sigma)",
-                # Model-only checks below (not individually tested because
-                # named_vars changes the output vs standalone repr)
+                r"Y_obs ~ Normal(mu, sigma)",
                 r"pot ~ Potential(f(mu))",
                 r"pred = Deterministic(f(<normal>))",
             ],
@@ -191,7 +181,7 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                     r"~\operatorname{Mixture}(\text{<constant>},~\operatorname{DiracDelta}(0),~\operatorname{Poisson}(5)),"
                     r"~\operatorname{Censored}(\operatorname{Bernoulli}(0.5),~-1,~1))$"
                 ),
-                r"$\text{Y\_obs} \sim \operatorname{Normal}(f(\text{alpha},~\text{beta}),~\text{sigma})$",
+                r"$\text{Y\_obs} \sim \operatorname{Normal}(\text{mu},~\text{sigma})$",
                 r"$\text{pot} \sim \operatorname{Potential}(f(\text{mu}))$",
                 r"$\text{pred} = \operatorname{Deterministic}(f(\text{<normal>}))",
             ],
@@ -210,11 +200,6 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 r"$\text{pred} = \operatorname{Deterministic}",
             ],
         }
-        self.model_expected = {k: list(v) for k, v in self.expected.items()}
-        self.model_expected[("plain", True)][9] = r"Y_obs ~ Normal(mu, sigma)"
-        self.model_expected[("latex", True)][9] = (
-            r"$\text{Y\_obs} \sim \operatorname{Normal}(\text{mu},~\text{sigma})$"
-        )
 
 
 class TestData(BaseTestStrAndLatexRepr):
@@ -454,8 +439,8 @@ def test_data_var_latex_underscore_escaping():
     assert r"my\_data" in model_latex
 
 
-def test_constant_fold_fallback():
-    """When constant folding fails (non-constant symbolic inputs), fall back to f(...) gracefully."""
+def test_function_of_named_var_in_repr():
+    """A non-constant expression should keep f(named_var) form in model repr."""
     import pymc as pm
 
     with pm.Model() as model:
@@ -464,23 +449,6 @@ def test_constant_fold_fallback():
 
     text = model.str_repr()
     assert "b ~ Normal(f(a), 1)" in text
-
-
-def test_standalone_potential_repr_does_not_use_named_var_fallback():
-    """Standalone repr should not infer named intermediates via fallback heuristics."""
-    import pymc as pm
-
-    with pm.Model():
-        alpha = pm.Normal("alpha")
-        beta = pm.Normal("beta")
-        mu = pm.Deterministic("mu", alpha + beta)
-        pot = pm.Potential("pot", mu**2)
-
-    pot_repr = pot.str_repr()
-    assert "pot ~ Potential(f(" in pot_repr
-    assert "mu" not in pot_repr
-    assert "alpha" in pot_repr
-    assert "beta" in pot_repr
 
 
 class TestLatexRepr:

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -46,19 +46,21 @@ class BaseTestStrAndLatexRepr:
             assert distribution._repr_latex_() == tex
 
         model_tex = self.model._repr_latex_()
+        model_expected = getattr(self, "model_expected", self.expected)
 
         # make sure each variable is in the model
-        for tex in self.expected[("latex", True)]:
+        for tex in model_expected[("latex", True)]:
             for segment in self._latex_segments(tex):
                 assert segment in model_tex
 
     def test_str_repr(self):
+        model_expected = getattr(self, "model_expected", self.expected)
         for str_format in self.formats:
             for dist, text in zip(self.distributions, self.expected[str_format]):
                 assert dist.str_repr(*str_format) == text
 
             model_text = self.model.str_repr(*str_format)
-            for text in self.expected[str_format]:
+            for text in model_expected[str_format]:
                 if str_format[0] == "latex":
                     for segment in self._latex_segments(text):
                         assert segment in model_text
@@ -155,7 +157,7 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                     r"Mixture(<constant>, DiracDelta(0), Poisson(5)), "
                     r"Censored(Bernoulli(0.5), -1, 1))"
                 ),
-                r"Y_obs ~ Normal(mu, sigma)",
+                r"Y_obs ~ Normal(f(alpha, beta), sigma)",
                 # Model-only checks below (not individually tested because
                 # named_vars changes the output vs standalone repr)
                 r"pot ~ Potential(f(mu))",
@@ -189,7 +191,7 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                     r"~\operatorname{Mixture}(\text{<constant>},~\operatorname{DiracDelta}(0),~\operatorname{Poisson}(5)),"
                     r"~\operatorname{Censored}(\operatorname{Bernoulli}(0.5),~-1,~1))$"
                 ),
-                r"$\text{Y\_obs} \sim \operatorname{Normal}(\text{mu},~\text{sigma})$",
+                r"$\text{Y\_obs} \sim \operatorname{Normal}(f(\text{alpha},~\text{beta}),~\text{sigma})$",
                 r"$\text{pot} \sim \operatorname{Potential}(f(\text{mu}))$",
                 r"$\text{pred} = \operatorname{Deterministic}(f(\text{<normal>}))",
             ],
@@ -208,6 +210,13 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 r"$\text{pred} = \operatorname{Deterministic}",
             ],
         }
+        self.model_expected = {
+            k: list(v) for k, v in self.expected.items()
+        }
+        self.model_expected[("plain", True)][9] = r"Y_obs ~ Normal(mu, sigma)"
+        self.model_expected[("latex", True)][9] = (
+            r"$\text{Y\_obs} \sim \operatorname{Normal}(\text{mu},~\text{sigma})$"
+        )
 
 
 class TestData(BaseTestStrAndLatexRepr):
@@ -457,6 +466,23 @@ def test_constant_fold_fallback():
 
     text = model.str_repr()
     assert "b ~ Normal(f(a), 1)" in text
+
+
+def test_standalone_potential_repr_does_not_use_named_var_fallback():
+    """Standalone repr should not infer named intermediates via fallback heuristics."""
+    import pymc as pm
+
+    with pm.Model():
+        alpha = pm.Normal("alpha")
+        beta = pm.Normal("beta")
+        mu = pm.Deterministic("mu", alpha + beta)
+        pot = pm.Potential("pot", mu**2)
+
+    pot_repr = pot.str_repr()
+    assert "pot ~ Potential(f(" in pot_repr
+    assert "mu" not in pot_repr
+    assert "alpha" in pot_repr
+    assert "beta" in pot_repr
 
 
 class TestLatexRepr:

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -136,7 +136,7 @@ class TestMonolith(BaseTestStrAndLatexRepr):
             # add a deterministic that depends on an unnamed random variable
             pred = Deterministic("pred", Normal.dist(0, 1))
 
-        self.distributions = [alpha, sigma, mu, b, Z, nb2, zip, w, nested_mix, Y_obs, pot]
+        self.distributions = [alpha, sigma, mu, b, Z, nb2, zip, w, nested_mix, Y_obs]
         self.deterministics_or_potentials = [mu, pot, pred]
         # tuples of (formatting, include_params)
         self.formats = [("plain", True), ("plain", False), ("latex", True), ("latex", False)]
@@ -156,7 +156,9 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                     r"Censored(Bernoulli(0.5), -1, 1))"
                 ),
                 r"Y_obs ~ Normal(mu, sigma)",
-                r"pot ~ Potential(f(alpha, beta))",
+                # Model-only checks below (not individually tested because
+                # named_vars changes the output vs standalone repr)
+                r"pot ~ Potential(f(mu))",
                 r"pred = Deterministic(f(<normal>))",
             ],
             ("plain", False): [
@@ -188,7 +190,7 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                     r"~\operatorname{Censored}(\operatorname{Bernoulli}(0.5),~-1,~1))$"
                 ),
                 r"$\text{Y\_obs} \sim \operatorname{Normal}(\text{mu},~\text{sigma})$",
-                r"$\text{pot} \sim \operatorname{Potential}(f(\text{alpha},~\text{beta}))$",
+                r"$\text{pot} \sim \operatorname{Potential}(f(\text{mu}))$",
                 r"$\text{pred} = \operatorname{Deterministic}(f(\text{<normal>}))",
             ],
             ("latex", False): [
@@ -341,7 +343,7 @@ class TestDimsDist:
             ("plain", True): [
                 r"mu ~ Normal(0, 10)",
                 r"sigma ~ Normal(0, 1)",
-                r"zsn ~ ZeroSumNormal(f(), f(group))",
+                r"zsn ~ ZeroSumNormal(<constant>, <constant>)",
                 r"y ~ Normal(f(mu, zsn), sigma)",
             ],
             ("plain", False): [
@@ -353,7 +355,7 @@ class TestDimsDist:
             ("latex", True): [
                 r"\text{mu} &\sim & \operatorname{Normal}(0,~10)",
                 r"\text{sigma} &\sim & \operatorname{Normal}(0,~1)",
-                r"\text{zsn} &\sim & \operatorname{ZeroSumNormal}(f(),~f(\text{group}))",
+                r"\text{zsn} &\sim & \operatorname{ZeroSumNormal}(\text{<constant>},~\text{<constant>})",
                 r"\text{y} &\sim & \operatorname{Normal}(f(\text{mu},~\text{zsn}),~\text{sigma})",
             ],
             ("latex", False): [
@@ -397,7 +399,7 @@ def test_data_vars_in_model_repr():
 
 
 def test_constant_folding_in_repr():
-    """Constant-only expressions are folded instead of showing f() (issue #7538)."""
+    """Constant-only expressions show <constant> instead of f() (issue #7538)."""
     import pymc as pm
 
     with pm.Model() as model:
@@ -405,7 +407,7 @@ def test_constant_folding_in_repr():
 
     text = model.str_repr()
     assert "f()" not in text
-    assert "x ~ Exponential(0.5)" == text
+    assert "x ~ Exponential(<constant>)" == text
 
 
 def test_data_var_repr_no_params():

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -139,13 +139,13 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 r"sigma ~ HalfNormal(0, 1)",
                 r"mu ~ Deterministic(f(alpha, beta))",
                 r"beta ~ Normal(0, 10)",
-                r"Z ~ MultivariateNormal(f(), f())",
+                r"Z ~ MultivariateNormal(<constant>, <constant>)",
                 r"nb_with_p_n ~ NegativeBinomial(10, nbp)",
-                r"zip ~ Mixture(f(), DiracDelta(0), Poisson(5))",
+                r"zip ~ Mixture(<constant>, DiracDelta(0), Poisson(5))",
                 r"w ~ Dirichlet(<constant>)",
                 (
                     r"nested_mix ~ Mixture(w, "
-                    r"Mixture(f(), DiracDelta(0), Poisson(5)), "
+                    r"Mixture(<constant>, DiracDelta(0), Poisson(5)), "
                     r"Censored(Bernoulli(0.5), -1, 1))"
                 ),
                 r"Y_obs ~ Normal(mu, sigma)",
@@ -171,13 +171,13 @@ class TestMonolith(BaseTestStrAndLatexRepr):
                 r"$\text{sigma} \sim \operatorname{HalfNormal}(0,~1)$",
                 r"$\text{mu} \sim \operatorname{Deterministic}(f(\text{alpha},~\text{beta}))$",
                 r"$\text{beta} \sim \operatorname{Normal}(0,~10)$",
-                r"$\text{Z} \sim \operatorname{MultivariateNormal}(f(),~f())$",
+                r"$\text{Z} \sim \operatorname{MultivariateNormal}(\text{<constant>},~\text{<constant>})$",
                 r"$\text{nb\_with\_p\_n} \sim \operatorname{NegativeBinomial}(10,~\text{nbp})$",
-                r"$\text{zip} \sim \operatorname{Mixture}(f(),~\operatorname{DiracDelta}(0),~\operatorname{Poisson}(5))$",
+                r"$\text{zip} \sim \operatorname{Mixture}(\text{<constant>},~\operatorname{DiracDelta}(0),~\operatorname{Poisson}(5))$",
                 r"$\text{w} \sim \operatorname{Dirichlet}(\text{<constant>})$",
                 (
                     r"$\text{nested\_mix} \sim \operatorname{Mixture}(\text{w},"
-                    r"~\operatorname{Mixture}(f(),~\operatorname{DiracDelta}(0),~\operatorname{Poisson}(5)),"
+                    r"~\operatorname{Mixture}(\text{<constant>},~\operatorname{DiracDelta}(0),~\operatorname{Poisson}(5)),"
                     r"~\operatorname{Censored}(\operatorname{Bernoulli}(0.5),~-1,~1))$"
                 ),
                 r"$\text{Y\_obs} \sim \operatorname{Normal}(\text{mu},~\text{sigma})$",
@@ -334,7 +334,7 @@ class TestDimsDist:
             ("plain", True): [
                 r"mu ~ Normal(0, 10)",
                 r"sigma ~ Normal(0, 1)",
-                r"zsn ~ ZeroSumNormal(f(), f())",
+                r"zsn ~ ZeroSumNormal(f(), f(group))",
                 r"y ~ Normal(f(mu, zsn), sigma)",
             ],
             ("plain", False): [
@@ -346,7 +346,7 @@ class TestDimsDist:
             ("latex", True): [
                 r"\text{mu} &\sim & \operatorname{Normal}(0,~10)",
                 r"\text{sigma} &\sim & \operatorname{Normal}(0,~1)",
-                r"\text{zsn} &\sim & \operatorname{ZeroSumNormal}(f(),~f())",
+                r"\text{zsn} &\sim & \operatorname{ZeroSumNormal}(f(),~f(\text{group}))",
                 r"\text{y} &\sim & \operatorname{Normal}(f(\text{mu},~\text{zsn}),~\text{sigma})",
             ],
             ("latex", False): [
@@ -368,6 +368,86 @@ class TestDimsDist:
             model_text = self.model.str_repr(formatting=formatting, include_params=include_params)
             for text in self.expected[(formatting, include_params)]:
                 assert text in model_text
+
+
+def test_data_vars_in_model_repr():
+    """Data variables appear in model repr and in Deterministic dependency lists (issue #7536)."""
+    import pymc as pm
+
+    with pm.Model() as model:
+        x = pm.Data("x", 0)
+        y = pm.Normal("y")
+        f = pm.Deterministic("f", x + y)
+
+    text = model.str_repr()
+    assert "x ~ Data(0)" in text
+    assert "y ~ Normal(0, 1)" in text
+    assert "f ~ Deterministic(f(y, x))" in text
+
+    latex = model.str_repr(formatting="latex")
+    assert r"\operatorname{Data}(0)" in latex
+    assert r"\text{x}" in latex
+
+
+def test_constant_folding_in_repr():
+    """Constant-only expressions are folded instead of showing f() (issue #7538)."""
+    import pymc as pm
+
+    with pm.Model() as model:
+        x = pm.Exponential("x", lam=2)
+
+    text = model.str_repr()
+    assert "f()" not in text
+    assert "x ~ Exponential(0.5)" == text
+
+
+def test_data_var_repr_no_params():
+    """Data variable repr without params."""
+    import pymc as pm
+
+    with pm.Model() as model:
+        x = pm.Data("x", 5)
+        pm.Normal("y", x)
+
+    text_no_params = model.str_repr(include_params=False)
+    assert "x ~ Data" in text_no_params
+    assert "y ~ Normal" in text_no_params
+
+
+def test_data_var_latex_underscore_escaping():
+    """Data variable names with underscores are escaped in LaTeX (direct call and model repr)."""
+    import pymc as pm
+
+    from pymc.printing import str_for_data_var
+
+    with pm.Model() as model:
+        my_data = pm.Data("my_data", 42)
+        pm.Normal("y", my_data)
+
+    # Direct call
+    latex_with_params = str_for_data_var(my_data, formatting="latex", include_params=True)
+    assert r"my\_data" in latex_with_params
+    assert r"\operatorname{Data}(42)" in latex_with_params
+
+    latex_no_params = str_for_data_var(my_data, formatting="latex", include_params=False)
+    assert r"my\_data" in latex_no_params
+    assert r"\operatorname{Data}" in latex_no_params
+
+    # Via model repr
+    model_latex = model.str_repr(formatting="latex")
+    assert r"my\_data" in model_latex
+
+
+def test_constant_fold_fallback():
+    """When constant folding fails (non-constant symbolic inputs), fall back to f(...) gracefully."""
+    import pymc as pm
+
+    with pm.Model() as model:
+        a = pm.Normal("a")
+        b = pm.Normal("b", mu=a * 2)
+
+    text = model.str_repr()
+    assert "b ~ Normal(f(a), 1)" in text
 
 
 class TestLatexRepr:


### PR DESCRIPTION
## Summary

Improve model text representations by addressing two open issues and one semantic cleanup:

- **#7536** — `pm.Data` variables now appear in `str_for_model` output and in Deterministic/Potential dependency lists.
- **#7538** — Constant-only parameters no longer render as opaque `f()`; they now render as `<constant>`.
- **Semantic separators** — Data and Deterministic variables use `=` instead of `~`. Potential keeps `~`.

## Closes #7536 — Data variables now visible

For:

```python
with pm.Model() as m:
    x = pm.Data("x", 0)
    y = pm.Normal("y")
    f = pm.Deterministic("f", x + y)
```

`str_for_model(m)` now includes both:

- `x = Data(0)`
- `f = Deterministic(f(y, x))`

## Closes #7538 — Constant-only `f()` eliminated

For:

```python
with pm.Model() as m:
    x = pm.Exponential("x", lam=2)
```

`str_for_model(m)` now shows:

- `x ~ Exponential(<constant>)`

So the empty `f()` placeholder is gone, without adding constant-fold computation in this print path.

## Semantic separators

- Data: `x = Data(...)`
- Deterministic: `mu = Deterministic(...)`
- Potential: `pot ~ Potential(...)`
- Random variables: unchanged (`~`)

## Changes

### `pymc/printing.py`

- Added `str_for_data_var` for Data variable rendering.
- Included `model.data_vars` in `str_for_model` output.
- Updated alignment logic to support both `~` and `=` in plain and LaTeX output.
- Deterministic uses `=` and Potential uses `~` in `str_for_potential_or_deterministic`.
- Threaded model-derived `named_vars` through internals for dependency naming.
- Removed heuristic fallback checks in `_str_for_input_var`.
- Kept constant-only expression rendering as `<constant>` (no print-time constant folding pass).

### `tests/test_printing.py`

- Updated expected outputs for:
  - semantic separators (`Deterministic` now `=`)
  - constant-only parameter rendering (`f()` -> `<constant>`)
- Added targeted tests:
  - `test_data_vars_in_model_repr`
  - `test_constant_folding_in_repr`
  - `test_data_var_repr_no_params`
  - `test_data_var_latex_underscore_escaping`
  - `test_function_of_named_var_in_repr`
- Simplified repr tests to focus on model repr assertions per review feedback.

## Test plan

- [x] `pytest tests/test_printing.py -v`
- [x] `pre-commit run --all-files`