### PR TITLE
Change `sample_posterior_predictive` API wrt to volatility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,7 +166,7 @@ jobs:
           cache-environment: true
       - name: Install-pymc
         run: |
-          pip install "pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3" --no-deps
+          pip install "pytensor @ git+https://github.com/pymc-devs/pytensor.git@main" --no-deps
           pip install -e . --no-deps
           python --version
           micromamba list
@@ -216,7 +216,7 @@ jobs:
           cache-environment: true
       - name: Install-pymc
         run: |
-          pip install "pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3" --no-deps
+          pip install "pytensor @ git+https://github.com/pymc-devs/pytensor.git@main" --no-deps
           pip install -e . --no-deps
           python --version
           micromamba list
@@ -274,7 +274,7 @@ jobs:
           cache-environment: true
       - name: Install pymc
         run: |
-          pip install "pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3" --no-deps
+          pip install "pytensor @ git+https://github.com/pymc-devs/pytensor.git@main" --no-deps
           pip install -e . --no-deps
           python --version
           micromamba list
@@ -326,7 +326,7 @@ jobs:
           cache-environment: true
       - name: Install pymc
         run: |
-          pip install "pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3" --no-deps
+          pip install "pytensor @ git+https://github.com/pymc-devs/pytensor.git@main" --no-deps
           pip install -e . --no-deps
           python --version
           micromamba list
@@ -373,7 +373,7 @@ jobs:
           cache-environment: true
       - name: Install-pymc
         run: |
-          pip install "pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3" --no-deps
+          pip install "pytensor @ git+https://github.com/pymc-devs/pytensor.git@main" --no-deps
           pip install -e . --no-deps
           python --version
           micromamba list

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -40,7 +40,7 @@ dependencies:
 - mypy=1.19.1
 - types-cachetools
 - pip:
-  - pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3
+  - pytensor @ git+https://github.com/pymc-devs/pytensor.git@main
   - pymc-sphinx-theme>=0.16.0
   - numdifftools>=0.9.40
   - mcbackend>=0.4.0

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -35,5 +35,5 @@ dependencies:
 - watermark
 - sphinx-remove-toctrees
 - pip:
-  - pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3
+  - pytensor @ git+https://github.com/pymc-devs/pytensor.git@main
   - numdifftools>=0.9.40

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -37,7 +37,7 @@ dependencies:
 - mypy=1.19.1
 - types-cachetools
 - pip:
-  - pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3
+  - pytensor @ git+https://github.com/pymc-devs/pytensor.git@main
   - git+https://github.com/pymc-devs/pymc-sphinx-theme
   - numdifftools>=0.9.40
   - mcbackend>=0.4.0

--- a/pymc/exceptions.py
+++ b/pymc/exceptions.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 __all__ = [
+    "ImplicitFreezeWarning",
     "ImputationWarning",
     "IncorrectArgumentsError",
     "SamplingError",
@@ -38,6 +39,17 @@ class TraceDirectoryError(ValueError):
 
 class ImputationWarning(UserWarning):
     """Warning that there are missing values that will be imputed."""
+
+    pass
+
+
+class ImplicitFreezeWarning(UserWarning):
+    """Warning that trace values are being reused instead of resampled.
+
+    Emitted by ``sample_posterior_predictive`` when a trace basic RV has a
+    volatile upstream (changed Data/coords or a resampled ancestor) but is not
+    listed in ``sample_vars``.
+    """
 
     pass
 

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -31,15 +31,13 @@ import xarray as xr
 from pytensor import tensor as pt
 from pytensor.graph import vectorize_graph
 from pytensor.graph.basic import (
-    Apply,
     Constant,
     Variable,
 )
 from pytensor.graph.fg import FunctionGraph
 from pytensor.graph.traversal import ancestors, general_toposort, walk
-from pytensor.tensor.random.variable import RandomGeneratorSharedVariable
+from pytensor.tensor.random.type import RandomType
 from pytensor.tensor.sharedvar import SharedVariable, TensorSharedVariable
-from pytensor.tensor.variable import TensorConstant
 from rich.theme import Theme
 
 import pymc as pm
@@ -48,6 +46,7 @@ from pymc.backends.arviz import _DefaultTrace, dataset_to_point_list
 from pymc.backends.base import MultiTrace
 from pymc.blocking import PointType
 from pymc.distributions.shape_utils import change_dist_size
+from pymc.exceptions import ImplicitFreezeWarning
 from pymc.model import Model, modelcontext
 from pymc.progress_bar import create_simple_progress, default_progress_theme
 from pymc.pytensorf import compile, rvs_in_graph
@@ -72,26 +71,41 @@ PointList: TypeAlias = list[PointType]
 _log = logging.getLogger(__name__)
 
 
-def get_constant_coords(trace_coords: dict[str, np.ndarray], model: Model) -> set:
-    """Get the set of coords that have remained constant between the trace and model."""
-    constant_coords = set()
-    for dim, coord in trace_coords.items():
-        current_coord = model.coords.get(dim, None)
-        current_length = model.dim_lengths.get(dim, None)
-        if isinstance(current_length, TensorSharedVariable):
-            current_length = current_length.get_value()
-        elif isinstance(current_length, TensorConstant):
-            current_length = current_length.data
-        if (
-            current_coord is not None
-            and len(coord) == len(current_coord)
-            and np.all(coord == current_coord)
-        ) or (
-            # Coord was defined without values (only length)
-            current_coord is None and len(coord) == current_length
-        ):
-            constant_coords.add(dim)
-    return constant_coords
+def _build_constant_data(
+    trace_constant_data: dict[str, np.ndarray],
+    trace_coords: dict[str, np.ndarray],
+    model: Model,
+) -> dict[Variable, Any]:
+    """Collect trace-time values for data-like nodes in the model.
+
+    Returns a mapping from the model's registered data Variables (``pm.Data``
+    SharedVariables plus named Constants introduced by ``pm.do`` /
+    ``freeze_dims_and_data``) and its shared dim-length vars to the value each
+    held at inference time, as recovered from the trace.
+
+    Dim-length shareds are only included when the trace's coord labels still
+    match the model's (or when neither has explicit labels), so a same-length
+    coord with different labels still counts as volatile.
+    """
+    constant_data: dict[Variable, Any] = {}
+    for dv in model.data_vars:
+        if dv.name in trace_constant_data:
+            constant_data[dv] = trace_constant_data[dv.name]
+    for dim, length_var in model.dim_lengths.items():
+        if not isinstance(length_var, SharedVariable) or dim not in trace_coords:
+            continue
+        trace_coord = trace_coords[dim]
+        current_coord = model.coords.get(dim)
+        if current_coord is not None:
+            unchanged = len(current_coord) == len(trace_coord) and bool(
+                np.all(np.asarray(current_coord) == trace_coord)
+            )
+        else:
+            # Coord declared with a length only; match against the current length.
+            unchanged = int(length_var.get_value()) == len(trace_coord)
+        if unchanged:
+            constant_data[length_var] = len(trace_coord)
+    return constant_data
 
 
 def get_vars_in_point_list(trace, model):
@@ -105,13 +119,154 @@ def get_vars_in_point_list(trace, model):
     return vars_in_trace
 
 
+def _data_var_is_volatile(
+    var: Variable,
+    constant_data: dict[Variable, Any],
+) -> bool:
+    """Return True if a data-like variable no longer matches its trace-time value.
+
+    Membership in ``constant_data`` is by Variable identity: registered data
+    variables (``model.data_vars`` — ``pm.Data`` SharedVariables plus named
+    Constants from ``pm.do`` / ``freeze_dims_and_data``) and shared dim-length
+    vars get their trace-time value stored there. For a ``SharedVariable`` or
+    ``Constant`` in the mapping, current value is compared against the stored
+    one. Non-root data variables (e.g. expression Variables introduced by
+    ``pm.do``) have no readable current value; their volatility is determined
+    by propagation from their inputs in :func:`_compute_volatile_vars`, not
+    here.
+    """
+    if isinstance(var.type, RandomType):
+        # RNG variables are not themselves a source of volatility; their consumers are.
+        return False
+    if isinstance(var, SharedVariable):
+        if var in constant_data:
+            stored = var.type.filter(constant_data[var])
+            return not var.type.values_eq_approx(stored, var.get_value(borrow=True))
+        return True  # unknown shared variable — conservatively volatile
+    if isinstance(var, Constant):
+        if var in constant_data:
+            stored = var.type.filter(constant_data[var])
+            return not var.type.values_eq_approx(stored, var.data)
+        return False  # literal constant not in registry — non-volatile
+    # Non-root expression Variable: propagation handles it.
+    return False
+
+
+def _compute_volatile_vars(
+    fg: FunctionGraph,
+    *,
+    vars_in_trace: set[Variable],
+    rvs: set[Variable],
+    constant_data: dict[Variable, Any],
+    volatile_vars: set[Variable],
+    freeze_vars: set[Variable],
+) -> set[Variable]:
+    """Classify every variable reachable from ``fg.outputs`` as volatile or not.
+
+    A variable is volatile when any of these holds (unless it is in
+    ``freeze_vars``, which blocks propagation):
+
+    - It is in ``volatile_vars`` (explicit seed).
+    - It is a data-like variable whose current value no longer matches the
+      trace-time value in ``constant_data`` (see :func:`_data_var_is_volatile`).
+    - It is one of ``rvs`` but not present in the trace.
+    - Any of its inputs is already flagged volatile.
+    """
+    volatile_closure: set[Variable] = set()
+    variables = general_toposort(fg.outputs, deps=lambda x: x.owner.inputs if x.owner else [])
+    for var in variables:
+        if var in freeze_vars:
+            continue
+        if (
+            var in volatile_vars
+            or (var in rvs and var not in vars_in_trace)
+            or (var.owner is None and _data_var_is_volatile(var, constant_data))
+            or (var.owner is not None and any(inp in volatile_closure for inp in var.owner.inputs))
+        ):
+            volatile_closure.add(var)
+    return volatile_closure
+
+
+def _maybe_warn_implicit_freeze(
+    *,
+    auto_frozen: list[Variable],
+    volatile_closure: set[Variable],
+    volatile_vars: set[Variable],
+    rv_set: set[Variable],
+    vars_in_trace_set: set[Variable],
+    constant_data: dict[Variable, Any],
+    model: Model,
+    trace_coords: dict[str, np.ndarray],
+) -> None:
+    """Warn when an auto-frozen trace RV has a volatile ancestor the user may have wanted resampled."""
+    # Partition direct volatile sources once, so the per-RV loop is just intersections.
+    # "data": shared Data/coord values that changed since inference time.
+    # "non-data": RVs in sample_vars plus RVs missing from the trace (both get a fresh draw).
+    data_sources = {
+        var
+        for var in volatile_closure
+        if var.owner is None and _data_var_is_volatile(var, constant_data)
+    }
+    non_data_sources = {
+        var
+        for var in volatile_closure
+        if var in volatile_vars or (var in rv_set and var not in vars_in_trace_set)
+    }
+
+    warn_reasons: dict[str, list[str]] = {}
+    for rv in auto_frozen:
+        ancs = set(ancestors([rv])) - {rv}
+        reasons: list[str] = []
+        changed = sorted({anc.name or "<unnamed>" for anc in ancs & data_sources})
+        if changed:
+            reasons.append(f"upstream Data/coords changed ({', '.join(changed)})")
+        resampled = sorted({anc.name for anc in ancs & non_data_sources if anc.name is not None})
+        if resampled:
+            reasons.append(f"ancestor is resampled ({', '.join(resampled)})")
+        if reasons:
+            assert rv.name is not None  # trace RVs always have names
+            warn_reasons[rv.name] = reasons
+
+    if not warn_reasons:
+        return
+
+    # Flag coord-length changes specifically, since they are very likely to cause
+    # shape errors with the (unchanged-shape) frozen trace values.
+    length_changes = []
+    for dim_name, dim_length_var in model.dim_lengths.items():
+        if dim_name not in trace_coords or not isinstance(dim_length_var, TensorSharedVariable):
+            continue
+        new_length = int(dim_length_var.get_value())
+        old_length = len(trace_coords[dim_name])
+        if new_length != old_length:
+            length_changes.append((dim_name, old_length, new_length))
+
+    details = "; ".join(
+        f"{name!r} ({'; '.join(reasons)})" for name, reasons in sorted(warn_reasons.items())
+    )
+    msg = (
+        f"The following trace variables were implicitly frozen, but something in their "
+        f"upstream suggests you may have wanted them resampled: {details}. To resample "
+        f"them, pass them in `sample_vars`; to silence this warning while keeping the "
+        f"trace values, pass them in `freeze_vars`."
+    )
+    if length_changes:
+        changes_str = ", ".join(f"{name!r} ({old} -> {new})" for name, old, new in length_changes)
+        msg += (
+            f" Coordinates changed length ({changes_str}); this function is likely "
+            f"to fail with shape errors unless the affected variables are added to "
+            f"`sample_vars`."
+        )
+    warnings.warn(msg, ImplicitFreezeWarning, stacklevel=3)
+
+
 def compile_forward_sampling_function(
     outputs: list[Variable],
     vars_in_trace: list[Variable],
     basic_rvs: list[Variable] | None = None,
-    givens_dict: dict[Variable, Any] | None = None,
-    constant_data: dict[str, np.ndarray] | None = None,
-    constant_coords: set[str] | None = None,
+    constant_data: dict[Variable, Any] | None = None,
+    volatile_vars: set[Variable] | None = None,
+    freeze_vars: set[Variable] | None = None,
     **kwargs,
 ) -> tuple[Callable[..., np.ndarray | list[np.ndarray]], set[Variable]]:
     """Compile a function to draw samples, conditioned on the values of some variables.
@@ -124,11 +279,14 @@ def compile_forward_sampling_function(
     Volatile variables are variables whose values could change between runs of the
     compiled function or after inference has been run. These variables are:
 
-    - Variables in the outputs list
-    - ``SharedVariable`` instances that are not ``RandomGeneratorSharedVariable``, and whose values changed with respect to what they were at inference time
-    - Variables that are in the `basic_rvs` list but not in the ``vars_in_trace`` list
-    - Variables that are keys in the ``givens_dict``
+    - Variables in ``volatile_vars``
+    - ``SharedVariable`` or ``Constant`` data nodes whose current value no longer matches the trace-time value stored in ``constant_data`` (see :func:`_data_var_is_volatile`)
+    - Variables that are in the ``basic_rvs`` list but not in the ``vars_in_trace`` list
     - Variables that have volatile inputs
+
+    Variables in ``freeze_vars`` are never considered volatile, regardless of the above
+    rules. They act as volatility barriers, stopping the propagation of volatility to
+    their dependents. Frozen variables are always treated as trace inputs.
 
     Concretely, this function can be used to compile a function to sample from the
     posterior predictive distribution of a model that has variables that are conditioned
@@ -138,19 +296,11 @@ def compile_forward_sampling_function(
     ignored and new values will be computed (in the case of deterministics and potentials) or
     sampled (in the case of random variables).
 
-    This function also enables a way to impute values for any variable in the computational
-    graph that produces the desired outputs: the ``givens_dict``. This dictionary can be used
-    to set the ``givens`` argument of the pytensor function compilation. This will essentially
-    replace a node in the computational graph with any other expression that has the same
-    type as the desired node. Passing variables in the givens_dict is considered an intervention
-    that might lead to different variable values from those that could have been seen during
-    inference, as such, **any variable that is passed in the ``givens_dict`` will be considered
-    volatile**.
-
     Parameters
     ----------
     outputs : List[pytensor.graph.basic.Variable]
-        The list of variables that will be returned by the compiled function
+        The list of variables that will be returned by the compiled function.
+        Outputs are not inherently volatile.
     vars_in_trace : List[pytensor.graph.basic.Variable]
         The list of variables that are assumed to have values stored in the trace
     basic_rvs : Optional[List[pytensor.graph.basic.Variable]]
@@ -159,29 +309,25 @@ def compile_forward_sampling_function(
         be considered as random variable instances. This includes variables that have
         a ``RandomVariable`` owner op, but also unpure random variables like Mixtures, or
         Censored distributions.
-    givens_dict : Optional[Dict[pytensor.graph.basic.Variable, Any]]
-        A dictionary that maps tensor variables to the values that should be used to replace them
-        in the compiled function. The types of the key and value should match or an error will be
-        raised during compilation.
-    constant_data : Optional[Dict[str, numpy.ndarray]]
-        A dictionary that maps the names of ``Data`` instances to their
-        corresponding values at inference time. If a model was created with ``Data``, these
-        are stored as ``SharedVariable`` with the name of the data variable and a value equal to
-        the initial data. At inference time, this information is stored in ``DataTree``
-        objects under the ``constant_data`` group, which allows us to check whether a
-        ``SharedVariable`` instance changed its values after inference or not. If the values have
-        changed, then the ``SharedVariable`` is assumed to be volatile. If it has not changed, then
-        the ``SharedVariable`` is assumed to not be volatile. If a ``SharedVariable`` is not found
-        in either ``constant_data`` or ``constant_coords``, then it is assumed to be volatile.
-        Setting ``constant_data`` to ``None`` is equivalent to passing an empty dictionary.
-    constant_coords : Optional[Set[str]]
-        A set with the names of the mutable coordinates that have not changed their shape after
-        inference. If a model was created with mutable coordinates, these are stored as
-        ``SharedVariable`` with the name of the coordinate and a value equal to the length of said
-        coordinate. This set let's us check if a ``SharedVariable`` is a mutated coordinate, in
-        which case, it is considered volatile. If a ``SharedVariable`` is not found
-        in either ``constant_data`` or ``constant_coords``, then it is assumed to be volatile.
-        Setting ``constant_coords`` to ``None`` is equivalent to passing an empty set.
+    constant_data : Optional[Dict[Variable, Any]]
+        A dictionary that maps data-like ``Variable`` instances (``pm.Data``
+        SharedVariables, named ``Constant`` nodes introduced by ``pm.do`` /
+        ``freeze_dims_and_data``, or shared dim-length vars) to the value each
+        held at inference time. At check time the current value of each listed
+        node is compared against the stored one via ``values_eq_approx``; if
+        they differ the node is treated as volatile. A ``SharedVariable``
+        absent from ``constant_data`` is conservatively treated as volatile;
+        an absent ``Constant`` is treated as non-volatile. Setting
+        ``constant_data`` to ``None`` is equivalent to passing an empty
+        dictionary.
+    volatile_vars : Optional[Set[pytensor.graph.basic.Variable]]
+        Variables that are unconditionally volatile. Volatility propagates from these
+        to their dependents in the graph.
+    freeze_vars : Optional[Set[pytensor.graph.basic.Variable]]
+        A set of variables that should never be considered volatile, even if they would
+        otherwise be due to having volatile inputs or depending on changed data. Frozen
+        variables act as volatility barriers: they stop the propagation of volatility to
+        their dependents and are always treated as inputs that pull values from the trace.
 
     Returns
     -------
@@ -191,88 +337,51 @@ def compile_forward_sampling_function(
         Set of all basic_rvs that were considered volatile and will be resampled when
         the function is evaluated
     """
-    if givens_dict is None:
-        givens_dict = {}
-
     if basic_rvs is None:
         basic_rvs = []
 
     if constant_data is None:
         constant_data = {}
-    if constant_coords is None:
-        constant_coords = set()
+    if volatile_vars is None:
+        volatile_vars = set()
+    if freeze_vars is None:
+        freeze_vars = set()
 
-    # We define a helper function to check if shared values match to an array
-    def shared_value_matches(var):
-        try:
-            old_array_value = constant_data[var.name]
-        except KeyError:
-            return var.name in constant_coords
-        current_shared_value = var.get_value(borrow=True)
-        return np.array_equal(old_array_value, current_shared_value)
-
-    # We need a function graph to walk the clients and propagate the volatile property
     fg = FunctionGraph(outputs=outputs, clone=False)
-
-    # Walk the graph from inputs to outputs and tag the volatile variables
-    nodes: list[Variable] = general_toposort(
-        fg.outputs, deps=lambda x: x.owner.inputs if x.owner else []
-    )  # type: ignore[call-overload]
-    volatile_nodes: set[Any] = set()
-    for node in nodes:
-        if (
-            node in fg.outputs
-            or node in givens_dict
-            or (  # SharedVariables, except RandomState/Generators
-                isinstance(node, SharedVariable)
-                and not isinstance(node, RandomGeneratorSharedVariable)
-                and not shared_value_matches(node)
-            )
-            or (  # Basic RVs that are not in the trace
-                node in basic_rvs and node not in vars_in_trace
-            )
-            or (  # Variables that have any volatile input
-                node.owner and any(inp in volatile_nodes for inp in node.owner.inputs)
-            )
-        ):
-            volatile_nodes.add(node)
+    volatile_closure = _compute_volatile_vars(
+        fg,
+        vars_in_trace=set(vars_in_trace),
+        rvs=set(basic_rvs),
+        constant_data=constant_data,
+        volatile_vars=volatile_vars,
+        freeze_vars=freeze_vars,
+    )
 
     # Collect the function inputs by walking the graph from the outputs. Inputs will be:
     # 1. Random variables that are not volatile
     # 2. Variables that have no owner and are not constant or shared
     inputs = []
 
-    def expand(node):
+    def expand(var):
         if (
             (
-                node.owner is None and not isinstance(node, Constant | SharedVariable)
+                var.owner is None and not isinstance(var, Constant | SharedVariable)
             )  # Variables without owners that are not constant or shared
-            or node in vars_in_trace  # Variables in the trace
-        ) and node not in volatile_nodes:
+            or var in vars_in_trace  # Variables in the trace
+        ) and var not in volatile_closure:
             # This test will include variables without owners, and that are not constant
-            # or shared, because these nodes will never be considered volatile
-            inputs.append(node)
-        if node.owner:
-            return node.owner.inputs
+            # or shared, because these variables will never be considered volatile
+            inputs.append(var)
+        if var.owner:
+            return var.owner.inputs
 
     # walk produces a generator, so we have to actually exhaust the generator in a list to walk
     # the entire graph
     list(walk(fg.outputs, expand))
 
-    # Populate the givens list
-    givens = [
-        (
-            node,
-            value
-            if isinstance(value, Variable | Apply)
-            else pt.constant(value, dtype=getattr(node, "dtype", None), name=node.name),
-        )
-        for node, value in givens_dict.items()
-    ]
-
     return (
-        compile(inputs, fg.outputs, givens=givens, on_unused_input="ignore", **kwargs),
-        set(basic_rvs) & (volatile_nodes - set(givens_dict)),  # Basic RVs that will be resampled
+        compile(inputs, fg.outputs, on_unused_input="ignore", **kwargs),
+        set(basic_rvs) & volatile_closure,  # Basic RVs that will be resampled
     )
 
 
@@ -430,7 +539,7 @@ def sample_prior_predictive(
         vars_ = set(var_names)
 
     names = sorted(get_default_varnames(vars_, include_transformed=False))
-    vars_to_sample = [model[name] for name in names]
+    vars_to_evaluate = [model[name] for name in names]
 
     # Any variables from var_names still missing are assumed to be transformed variables.
     missing_names = vars_.difference(names)
@@ -446,10 +555,9 @@ def sample_prior_predictive(
     compile_kwargs.setdefault("accept_inplace", True)
 
     sampler_fn, volatile_basic_rvs = compile_forward_sampling_function(
-        vars_to_sample,
+        vars_to_evaluate,
         vars_in_trace=[],
         basic_rvs=model.basic_RVs,
-        givens_dict=None,
         random_seed=random_seed,
         **compile_kwargs,
     )
@@ -479,7 +587,10 @@ def sample_prior_predictive(
 def sample_posterior_predictive(
     trace,
     model: Model | None = None,
-    var_names: list[str] | None = None,
+    *,
+    var_names: str | list[str] | None = None,
+    sample_vars: str | list[str] | None = None,
+    freeze_vars: str | list[str] | None = None,
     sample_dims: list[str] | None = None,
     random_seed: RandomState = None,
     progressbar: bool = True,
@@ -494,7 +605,10 @@ def sample_posterior_predictive(
 def sample_posterior_predictive(
     trace,
     model: Model | None = None,
-    var_names: list[str] | None = None,
+    *,
+    var_names: str | list[str] | None = None,
+    sample_vars: str | list[str] | None = None,
+    freeze_vars: str | list[str] | None = None,
     sample_dims: list[str] | None = None,
     random_seed: RandomState = None,
     progressbar: bool = True,
@@ -508,7 +622,10 @@ def sample_posterior_predictive(
 def sample_posterior_predictive(
     trace,
     model: Model | None = None,
-    var_names: list[str] | None = None,
+    *,
+    var_names: str | list[str] | None = None,
+    sample_vars: str | list[str] | None = None,
+    freeze_vars: str | list[str] | None = None,
     sample_dims: list[str] | None = None,
     random_seed: RandomState = None,
     progressbar: bool = True,
@@ -537,10 +654,31 @@ def sample_posterior_predictive(
     model : Model (optional if in ``with`` context)
         Model to be used to generate the posterior predictive samples. It will
         generally be the model used to generate the `trace`, but it doesn't need to be.
-    var_names : Iterable[str], optional
-        Names of variables for which to compute the posterior predictive samples.
-        By default, only observed variables are sampled.
-        See the example below for what happens when this argument is customized.
+    sample_vars : str or list of str, optional
+        Random variables or deterministics to regenerate on each draw rather
+        than copy from the trace. Regeneration propagates volatility downstream:
+        an RV that is in the trace and not listed here keeps its trace value,
+        but if one of its ancestors is volatile (listed here, or a changed
+        Data/coord) an :class:`~pymc.exceptions.ImplicitFreezeWarning` flags
+        it so the user can opt in by adding it here, or silence the warning via
+        ``freeze_vars``. Empty by default — RVs missing from the trace (including
+        observed RVs) are always regenerated automatically. Cannot overlap with
+        ``freeze_vars``.
+    freeze_vars : str or list of str, optional
+        Trace variables (RVs or deterministics) to reuse from the trace. Cannot
+        overlap with ``sample_vars``. Trace RVs not in ``sample_vars`` are already
+        implicitly frozen, so the practical effect of listing an RV here is to
+        silence its :class:`~pymc.exceptions.ImplicitFreezeWarning`. Deterministics
+        don't trigger that warning at all — a volatile deterministic just
+        recomputes with the current upstream values — so listing one only matters
+        when you want to keep the trace value instead (see example below).
+    var_names : str or list of str, optional
+        Controls only which variables appear in the output; does not trigger
+        resampling. Each listed name is either computed fresh or copied from the
+        input trace, depending on whether it or any of its upstream is volatile
+        (see the behavior section below). Defaults to ``sample_vars`` when that is
+        specified; otherwise (the classic posterior-predictive default) to the
+        observed variables plus any deterministic that depends on these.
     sample_dims : list of str, optional
         Dimensions over which to loop and generate posterior predictive samples.
         When ``sample_dims`` is ``None`` (default) both "chain" and "draw" are considered sample
@@ -582,7 +720,9 @@ def sample_posterior_predictive(
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     The most common use of `sample_posterior_predictive` is to perform posterior predictive checks (in-sample predictions)
-    and new model predictions (out-of-sample predictions).
+    and new model predictions (out-of-sample predictions). Deterministics that
+    depend on :class:`~pymc.Data` are recomputed automatically when the data
+    changes — no extra work needed:
 
     .. code-block:: python
 
@@ -592,16 +732,68 @@ def sample_posterior_predictive(
             x = pm.Data("x", [-1, 0, 1], dims=["trial"])
             beta = pm.Normal("beta")
             noise = pm.HalfNormal("noise")
-            y = pm.Normal("y", mu=x * beta, sigma=noise, observed=[-2, 0, 3], dims=["trial"])
+            linpred = pm.Deterministic("linpred", x * beta, dims=["trial"])
+            y = pm.Normal("y", mu=linpred, sigma=noise, observed=[-2, 0, 3], dims=["trial"])
 
             idata = pm.sample()
-            # in-sample predictions
+
+            # in-sample posterior predictive
             posterior_predictive = pm.sample_posterior_predictive(idata).posterior_predictive
 
         with model:
             pm.set_data({"x": [-2, 2]}, coords={"trial": [3, 4]})
-            # out-of-sample predictions
-            predictions = pm.sample_posterior_predictive(idata, predictions=True).predictions
+            # out-of-sample predictions. `linpred` is recomputed with the new `x`
+            # (and the trace's `beta`); `y` is resampled from the new `linpred`.
+            pm.sample_posterior_predictive(idata, predictions=True, extend_inferencedata=True)
+
+
+    Freezing deterministics
+    ^^^^^^^^^^^^^^^^^^^^^^^
+
+    A deterministic is normally recomputed whenever its inputs change.
+    Occasionally, though, a deterministic captures something
+    that should stay anchored to the *training* data — e.g. an HSGP standardization
+    computed from ``pm.Data`` that must not be rederived from the prediction data.
+    Pass the deterministic in ``freeze_vars`` to keep its trace value:
+
+    .. code-block:: python
+
+        import pymc as pm
+
+        with pm.Model() as model:
+            x = pm.Data("x", [1.0, 2.0, 3.0])
+            x_mean = pm.Deterministic("x_mean", x.mean())
+            centered = pm.Deterministic("centered", x - x_mean)
+            mu = pm.Normal("mu")
+            obs = pm.Normal("obs", mu + centered, 1, observed=[0, 0, 0])
+
+            idata = pm.sample()
+
+        # New x values. Without freezing, `x_mean` would be recomputed as the new mean.
+        with model:
+            pm.set_data({"x": [100.0, 200.0, 300.0]})
+            pm.sample_posterior_predictive(idata, freeze_vars=["x_mean"])
+
+
+    Forcing a deterministic to recompute
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    If :func:`~pymc.do` swaps a new expression into a deterministic while
+    every RV and Data value stays unchanged, ``sample_posterior_predictive``
+    sees nothing volatile and reuses the deterministic from the trace. List
+    it in ``sample_vars`` to force recomputation from the current graph:
+
+    .. code-block:: python
+
+        with pm.Model() as model:
+            x = pm.Normal("x")
+            pm.Deterministic("det", x**2)
+            pm.Normal("obs", model["det"], 1, observed=[0.0])
+            idata = pm.sample()
+
+        with pm.do(model, {model["det"]: model["x"] ** 3}) as intervened_model:
+            # Force recomputation using the new `x**3` graph.
+            pm.sample_posterior_predictive(idata, sample_vars=["det", "obs"])
 
 
     Using different models
@@ -610,25 +802,38 @@ def sample_posterior_predictive(
     It's common to use the same model for posterior and posterior predictive sampling, but this is not required.
     The matching between unobserved model variables and posterior samples is based on the name alone.
 
-    For the last example we could have created a new predictions model. Note that we have to specify
-    `var_names` explicitly, because the newly defined `y` was not given any observations:
+    For the last example we could have created a new predictions model.
+    Since the new ``y`` has no observations, we request it via ``sample_vars`` argument.
 
     .. code-block:: python
 
-        with pm.Model(coords={"trial": [3, 4]}) as predictions_model:
+        import pymc as pm
+
+        with pm.Model(coords={"trial": [0, 1, 2]}) as train_model:
+            x = pm.Data("x", [-1, 0, 1], dims=["trial"])
+            beta = pm.Normal("beta")
+            noise = pm.HalfNormal("noise")
+            y = pm.Normal("y", mu=x * beta, sigma=noise, observed=[-2, 0, 3], dims=["trial"])
+
+            idata = pm.sample()
+
+        with pm.Model(coords={"trial": [3, 4]}) as prediction_model:
             x = pm.Data("x", [-2, 2], dims=["trial"])
             beta = pm.Normal("beta")
             noise = pm.HalfNormal("noise")
             y = pm.Normal("y", mu=x * beta, sigma=noise, dims=["trial"])
 
             predictions = pm.sample_posterior_predictive(
-                idata, var_names=["y"], predictions=True
-            ).predictions
+                idata,
+                sample_vars=["y"],
+                predictions=True,
+            )
 
 
     The new model may even have a different structure and unobserved variables that don't exist in the trace.
-    These variables will also be forward sampled. In the following example we added a new ``extra_noise``
-    variable between the inferred posterior ``noise`` and the new StudentT observational distribution  ``y``:
+    These variables will be sampled automatically because they have no trace values to fall back on.
+    In the following example we added a new ``extra_noise`` variable between the inferred posterior ``noise``
+    and the new StudentT observational distribution  ``y``:
 
     .. code-block:: python
 
@@ -639,33 +844,39 @@ def sample_posterior_predictive(
             extra_noise = pm.HalfNormal("extra_noise", sigma=noise)
             y = pm.StudentT("y", nu=4, mu=x * beta, sigma=extra_noise, dims=["trial"])
 
-            predictions = pm.sample_posterior_predictive(
-                idata, var_names=["y"], predictions=True
-            ).predictions
+            predictions = pm.sample_posterior_predictive(idata, var_names=["y"], predictions=True)
 
 
     For more about out-of-model predictions, see this `blog post <https://www.pymc-labs.com/blog-posts/out-of-model-predictions-with-pymc/>`_.
 
-    The behavior of `var_names`
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    The behavior of ``sample_vars``, ``freeze_vars``, and ``var_names``
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    The function returns forward samples for any variable included in `var_names`,
-    conditioned on the values of other random variables found in the trace.
+    Each of these three arguments controls one aspect of the operation:
 
-    To ensure the samples are internally consistent, any random variable that depends
-    on another random variable that is being sampled is itself sampled, even if
-    this variable is present in the trace and was not included in `var_names`.
-    The final list of variables being sampled is shown in the log output.
+    - ``sample_vars`` — trace variables to treat as volatile: regenerate them
+      (from their distribution or expression) instead of copying from the trace.
+      Empty by default.
+    - ``freeze_vars`` — which trace variables to reuse explicitly (silences the
+      implicit-freeze warning below).
+    - ``var_names`` — which variables appear in the output. Does not trigger
+      resampling of variables in the trace. Defaults to ``sample_vars``.
 
-    Note that if a random variable has no dependency on other random variables,
-    these forward samples are equivalent to their prior samples.
-    Likewise, if all random variables are being sampled, the behavior of this function
-    is equivalent to that of :func:`~pymc.sample_prior_predictive`.
+    **Volatility.** Volatility originates from three sources — variables listed
+    in ``sample_vars``, changed Data/coords, and RVs missing from the trace
+    (including observed RVs, which are always regenerated since they have no
+    trace value to reuse). It then propagates downstream through deterministics
+    and other RVs. An RV that *is* in the trace and not listed in ``sample_vars``
+    keeps its trace value — even when one of its ancestors is being resampled.
+    This prevents a single ``sample_vars=["x"]`` call, or a ``set_data`` call,
+    from silently invalidating the posterior values for every downstream
+    variable. When an auto-frozen trace variable has a volatile ancestor, an
+    :class:`~pymc.exceptions.ImplicitFreezeWarning` flags it so the user can
+    opt in by adding it to ``sample_vars`` (to resample) or opt out by adding
+    it to ``freeze_vars`` (to silence the warning while keeping the trace
+    value). The log lists all the RVs being resampled in any given call.
 
-    .. warning:: A random variable included in `var_names` will never be copied from the posterior group. It will always be sampled as described above. If you want, you can copy manually via ``idata.posterior_predictive["var_name"] = idata.posterior["var_name"]``.
-
-
-    The following code block explores how the behavior changes with different `var_names`:
+    The following examples use this model:
 
     .. code-block:: python
 
@@ -687,80 +898,77 @@ def sample_posterior_predictive(
 
             idata = pm.sample(tune=10, draws=10, chains=2, **kwargs)
 
-    Default behavior. Generate samples of ``obs``, conditioned on the posterior samples of ``z`` found in the trace.
-    These are often referred to as posterior predictive samples in the literature:
+    Default behavior: Generate samples of ``obs`` conditioned on the posterior
+    samples of ``z`` found in the trace. These are often referred to as posterior
+    predictive samples in the literature:
 
     .. code-block:: python
 
         with model:
-            pm.sample_posterior_predictive(idata, var_names=["obs"], **kwargs)
+            pm.sample_posterior_predictive(idata, **kwargs)
             # Sampling: [obs]
 
-    Re-compute the deterministic variable ``det``, conditioned on the posterior samples of ``z`` found in the trace:
-
-    .. code :: python
-
-          pm.sample_posterior_predictive(idata, var_names=["det"], **kwargs)
-          # Sampling: []
-
-    Generate samples of ``z`` and ``det``, conditioned on the posterior samples of ``x`` and ``y`` found in the trace.
+    Copy the trace values for ``z`` and ``det``. Nothing is resampled without explicit `sample_vars`:
 
     .. code :: python
 
         with model:
             pm.sample_posterior_predictive(idata, var_names=["z", "det"], **kwargs)
+            # Sampling: []
+
+    Generate new samples of z and det, conditioned on the posterior samples of x and y found in the trace.
+
+    .. code :: python
+
+        with model:
+            pm.sample_posterior_predictive(idata, var_names=["z", "det"], sample_vars=["z"], **kwargs)
             # Sampling: [z]
 
+    Generate samples of y, z and det, conditioned on the posterior samples of x found in the trace.
 
-    Generate samples of ``y``, ``z`` and ``det``, conditioned on the posterior samples of ``x`` found in the trace.
+    .. warning::
 
-    Note: The samples of ``y`` are equivalent to its prior, since it does not depend on any other variables.
-    In contrast, the samples of ``z`` and ``det`` depend on the new samples of ``y`` and the posterior samples of
-    ``x`` found in the trace.
+        The samples of ``y`` are equivalent to its prior, since it does not depend on any other variables.
+
+    In contrast, the samples of ``z`` and ``det`` depend on the new samples of ``y`` and the posterior samples of ``x`` found in the trace.
 
     .. code :: python
 
         with model:
-            pm.sample_posterior_predictive(idata, var_names=["y", "z", "det"], **kwargs)
+            pm.sample_posterior_predictive(idata, var_names=["y", "z", "det"], sample_vars=["y", "z"], **kwargs)
             # Sampling: [y, z]
 
-
-    Same as before, except ``z`` is not stored in the returned trace.
-    For computing ``det`` we still have to sample ``z`` as it depends on ``y``, which is also being sampled.
-
-    .. code :: python
-
-        with model:
-            pm.sample_posterior_predictive(idata, var_names=["y", "det"], **kwargs)
-            # Sampling: [y, z]
-
-    Every random variable is sampled. This is equivalent to calling :func:`~pymc.sample_prior_predictive`
+    Note that if ``z`` is not placed in `sample_vars` it *won't* be resampled even though it depends on the freshly drawn
+    ``y`` — cascade stops at RVs that are in the trace. A warning flags this behavior for ``z``:
 
     .. code :: python
 
         with model:
-            pm.sample_posterior_predictive(idata, var_names=["x", "y", "z", "det", "obs"], **kwargs)
-            # Sampling: [x, y, z, obs]
+            pm.sample_posterior_predictive(idata, var_names=["y", "z", "det"], sample_vars=["y"], **kwargs)
+            # ImplicitFreezeWarning: 'z' (ancestor is resampled (y))
+            # Sampling: [y]
 
-
-    .. danger:: Including a :func:`~pymc.Deterministic` in `var_names` may incorrectly force a random variable to be resampled, as happens with ``z`` in the following example:
-
+    If this is the intended behavior `z` can be added to freeze_vars explicitly, and the warning is avoided.
 
     .. code :: python
 
-        with pm.Model() as model:
-          x = pm.Normal("x")
-          y = pm.Normal("y")
-          det_xy = pm.Deterministic("det_xy", x + y**2)
-          z = pm.Normal("z", det_xy)
-          det_z = pm.Deterministic("det_z", pm.math.exp(z))
-          obs = pm.Normal("obs", det_z, 1, observed=[20])
+        with model:
+            pm.sample_posterior_predictive(idata, var_names=["y", "z", "det"], sample_vars=["y"], freeze_vars=["z"], **kwargs)
+            # Sampling: [y]
 
-          idata = pm.sample(tune=10, draws=10, chains=2, **kwargs)
+    Passing every RV to ``sample_vars`` makes this equivalent to :func:`~pymc.sample_prior_predictive`.
+    Including ``obs`` in ``sample_vars`` is redundant — it isn't in the trace so it is always regenerated:
 
-          pm.sample_posterior_predictive(idata, var_names=["det_xy", "det_z"], **kwargs)
-          # Sampling: [z]
+    .. code :: python
 
+        with model:
+            pm.sample_posterior_predictive(
+                idata,
+                var_names=["x", "y", "z", "det", "obs"],
+                sample_vars=["x", "y", "z", "obs"],
+                **kwargs,
+            )
+            # Sampling: [obs, x, y, z]
 
     Controlling the number of samples
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -801,13 +1009,19 @@ def sample_posterior_predictive(
     """
     _trace: MultiTrace | PointList
     nchain: int
+    if isinstance(var_names, str):
+        var_names = [var_names]
+    if isinstance(sample_vars, str):
+        sample_vars = [sample_vars]
+    if isinstance(freeze_vars, str):
+        freeze_vars = [freeze_vars]
     if idata_kwargs is None:
         idata_kwargs = {}
     else:
         idata_kwargs = idata_kwargs.copy()
     if sample_dims is None:
         sample_dims = ["chain", "draw"]
-    constant_data: dict[str, np.ndarray] = {}
+    trace_constant_data: dict[str, np.ndarray] = {}
     trace_coords: dict[str, np.ndarray] = {}
     if "coords" not in idata_kwargs:
         idata_kwargs["coords"] = {}
@@ -818,7 +1032,7 @@ def sample_posterior_predictive(
         _constant_data = getattr(trace, "constant_data", None)
         if _constant_data is not None:
             trace_coords.update({str(k): v.data for k, v in _constant_data.coords.items()})
-            constant_data.update({str(k): v.data for k, v in _constant_data.items()})
+            trace_constant_data.update({str(k): v.data for k, v in _constant_data.items()})
         idata = trace
         observed_data = trace.get("observed_data", None)
         if "posterior" in trace.children:
@@ -861,28 +1075,126 @@ def sample_posterior_predictive(
             stacklevel=2,
         )
 
-    constant_coords = get_constant_coords(trace_coords, model)
+    constant_data = _build_constant_data(trace_constant_data, trace_coords, model)
+    vars_in_trace = get_vars_in_point_list(_trace, model)
 
+    # Resolve output variables (what to return in the dataset).
+    # - If var_names is given, use it verbatim.
+    # - If sample_vars is given, the output is exactly sample_vars (the user's
+    #   explicit set of variables to re-evaluate).
+    # - Otherwise (the classic PPC default), the output is observed RVs plus any
+    #   deterministic that depends on them — the latter is a hack for partially
+    #   observed RVs (represented internally as a set_subtensor deterministic
+    #   combining the observed and unobserved parts).
     if var_names is not None:
-        vars_ = [model[x] for x in var_names]
+        output_vars = [model[x] for x in var_names]
+    elif sample_vars is not None:
+        output_vars = [model[x] for x in sample_vars]
     else:
-        observed_vars = model.observed_RVs
+        extra_observeds: list[Variable] = []
+        output_vars = list(model.observed_RVs)
         if observed_data is not None:
-            observed_vars += [
-                model[x] for x in observed_data if x in model and x not in observed_vars
-            ]
-        vars_ = observed_vars + observed_dependent_deterministics(model, observed_vars)
+            for name in observed_data:
+                if name in model and model[name] not in output_vars:
+                    output_vars.append(model[name])
+                    extra_observeds.append(model[name])
+        output_vars_set = set(output_vars)
+        output_vars += [
+            d
+            for d in observed_dependent_deterministics(model, extra_observeds)
+            if d not in output_vars_set
+        ]
 
-    vars_to_sample = list(get_default_varnames(vars_, include_transformed=False))
+    # Resolve sample_vars to the set of volatile-seed Variable objects. These override
+    # trace values on each draw (RVs re-sampled, deterministics re-evaluated). Basic
+    # RVs missing from the trace (including observed RVs) are always regenerated via
+    # compile_forward_sampling_function's volatility rule, so the default here is empty.
+    volatile_vars: set[Variable]
+    if sample_vars is None:
+        volatile_vars = set()
+    else:
+        # sample_vars entries must be RVs or deterministics (i.e. things with a
+        # trace-level concept). Data/coord containers don't fit.
+        allowed = set(model.basic_RVs) | set(model.deterministics)
+        if invalid := [name for name in sample_vars if model[name] not in allowed]:
+            raise ValueError(
+                f"sample_vars {sorted(invalid)} are not random variables or "
+                f"deterministics; only those can have trace values to override."
+            )
+        volatile_vars = {model[name] for name in sample_vars}
 
-    if not vars_to_sample:
+    rv_set = set(model.basic_RVs)
+    vars_in_trace_set = set(vars_in_trace)
+    sample_var_names = set(sample_vars or ())
+    trace_rvs = [rv for rv in vars_in_trace if rv in rv_set]
+
+    frozen_vars: set[Variable] = set()
+    if freeze_vars is not None:
+        frozen_vars = {model[x] for x in freeze_vars}
+        vars_in_trace_names = {v.name for v in vars_in_trace}
+        missing = {x for x in freeze_vars if x not in vars_in_trace_names}
+        if missing:
+            raise ValueError(
+                f"freeze_vars {sorted(missing)} are not present in the trace. "
+                f"Cannot freeze variables without stored values."
+            )
+        if sample_vars is not None and (overlap := (set(freeze_vars) & set(sample_vars))):
+            raise ValueError(
+                f"Variables {sorted(overlap)} are in both sample_vars and freeze_vars. "
+                f"A variable cannot be both resampled and frozen."
+            )
+
+    # Auto-freeze every trace basic RV not already in sample_vars or explicit freeze_vars.
+    # A warning below lists cases where this freeze is likely unintended
+    # (upstream Data/coords changed, or an ancestor is being resampled).
+    auto_frozen_vars = [
+        rv for rv in trace_rvs if rv.name not in sample_var_names and rv not in frozen_vars
+    ]
+    frozen_vars.update(auto_frozen_vars)
+
+    # Run the full volatility analysis once, over the combined graph of
+    # output_vars (so we can classify deterministics in var_names)
+    # and the auto-frozen trace RVs (so the warning below can check their ancestors).
+    volatility_fg = FunctionGraph(outputs=list(output_vars) + auto_frozen_vars, clone=False)
+    volatile_closure = _compute_volatile_vars(
+        volatility_fg,
+        vars_in_trace=vars_in_trace_set,
+        rvs=rv_set,
+        constant_data=constant_data,
+        volatile_vars=volatile_vars,
+        freeze_vars=frozen_vars,
+    )
+
+    # Dedupe output_vars preserving order, so downstream loops don't emit duplicates.
+    output_vars = list(dict.fromkeys(output_vars))
+
+    if not output_vars:
+        # Nothing to produce — neither sampled nor copied from the trace.
         if return_inferencedata and not extend_inferencedata:
             return xr.DataTree()
         elif return_inferencedata and extend_inferencedata:
             return trace if idata is None else idata
         return {}
 
-    vars_in_trace = get_vars_in_point_list(_trace, model)
+    # Compiled function outputs are strictly the entries of output_vars that need regeneration.
+    # An output in the trace and not volatile is copied from the trace below.
+    # Upstream volatile_vars and intermediate deterministics are computed by PyTensor as needed
+    # — they don't need to be listed as outputs.
+    compiled_outputs = [
+        var for var in output_vars if not (var in vars_in_trace_set and var not in volatile_closure)
+    ]
+    vars_to_evaluate = list(get_default_varnames(compiled_outputs, include_transformed=False))
+
+    _maybe_warn_implicit_freeze(
+        auto_frozen=auto_frozen_vars,
+        volatile_closure=volatile_closure,
+        volatile_vars=volatile_vars,
+        rv_set=rv_set,
+        vars_in_trace_set=vars_in_trace_set,
+        constant_data=constant_data,
+        model=model,
+        trace_coords=trace_coords,
+    )
 
     if random_seed is not None:
         (random_seed,) = _get_seeds_per_chain(random_seed, 1)
@@ -892,19 +1204,31 @@ def sample_posterior_predictive(
     compile_kwargs.setdefault("allow_input_downcast", True)
     compile_kwargs.setdefault("accept_inplace", True)
 
-    _sampler_fn, volatile_basic_rvs = compile_forward_sampling_function(
-        outputs=vars_to_sample,
-        vars_in_trace=vars_in_trace,
-        basic_rvs=model.basic_RVs,
-        givens_dict=None,
-        random_seed=random_seed,
-        constant_data=constant_data,
-        constant_coords=constant_coords,
-        **compile_kwargs,
-    )
-    sampler_fn = point_wrapper(_sampler_fn)
-    # All model variables have a name, but mypy does not know this
-    _log.info(f"Sampling: {sorted(volatile_basic_rvs, key=lambda var: var.name)}")  # type: ignore[arg-type, return-value]
+    sampler_fn: Callable | None
+    if vars_to_evaluate:
+        _sampler_fn, volatile_basic_rvs = compile_forward_sampling_function(
+            outputs=vars_to_evaluate,
+            vars_in_trace=vars_in_trace,
+            basic_rvs=model.basic_RVs,
+            random_seed=random_seed,
+            constant_data=constant_data,
+            volatile_vars=volatile_vars,
+            freeze_vars=frozen_vars,
+            **compile_kwargs,
+        )
+        sampler_fn = point_wrapper(_sampler_fn)
+        # All model variables have a name, but mypy does not know this
+        _log.info(f"Sampling: {sorted(volatile_basic_rvs, key=lambda var: var.name)}")  # type: ignore[arg-type, return-value]
+    else:
+        # Nothing needs to be sampled — output_vars will be fully populated from the
+        # trace. Skip compilation entirely.
+        sampler_fn = None
+        _log.info("Sampling: []")
+
+    # Determine output-only variables that should be copied from trace, not sampled.
+    evaluated_names = {v.name for v in vars_to_evaluate}
+    copy_from_trace_names = [var.name for var in output_vars if var.name not in evaluated_names]
+
     ppc_trace_t = _DefaultTrace(samples)
 
     progress = create_simple_progress(
@@ -930,10 +1254,14 @@ def sample_posterior_predictive(
                 else:
                     param = _trace[idx % len_trace]
 
-                values = sampler_fn(**param)
+                if sampler_fn is not None:
+                    values = sampler_fn(**param)
+                    for k, v in zip(vars_to_evaluate, values):
+                        ppc_trace_t.insert(k.name, v, idx)
 
-                for k, v in zip(vars_, values):
-                    ppc_trace_t.insert(k.name, v, idx)
+                # Copy output-only variables from trace
+                for name in copy_from_trace_names:
+                    ppc_trace_t.insert(name, param[name], idx)
 
                 progress.advance(task)
             progress.update(task, refresh=True, completed=samples)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ pandas>=0.24.0
 polyagamma
 pre-commit>=2.8.0
 pymc-sphinx-theme>=0.16.0
-pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3
+pytensor @ git+https://github.com/pymc-devs/pytensor.git@main
 pytest-cov>=2.5
 pytest>=3.0
 rich>=13.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cachetools>=4.2.1,<7
 cloudpickle
 numpy>=1.25.0
 pandas>=0.24.0
-pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3
+pytensor @ git+https://github.com/pymc-devs/pytensor.git@main
 rich>=13.7.1
 scipy>=1.4.1
 threadpoolctl>=3.1.0,<4.0.0

--- a/tests/model/transform/test_conditioning.py
+++ b/tests/model/transform/test_conditioning.py
@@ -189,7 +189,7 @@ def test_do_posterior_predictive():
     # Replace `y` by a constant `100.0`
     m_do = do(m, {y: 100.0})
     with m_do:
-        idata_do = pm.sample_posterior_predictive(idata_m, var_names="z")
+        idata_do = pm.sample_posterior_predictive(idata_m, sample_vars=["z"])
 
     assert 120 < idata_do.posterior_predictive["z"].mean() < 130
 
@@ -319,7 +319,7 @@ def test_do_sample_posterior_predictive(make_interventions_shared):
     )
 
     with do(model, {a: 1000}, make_interventions_shared=make_interventions_shared):
-        pp = sample_posterior_predictive(idata, var_names=["c"], predictions=True).predictions
+        pp = sample_posterior_predictive(idata, sample_vars=["c"], predictions=True).predictions
     assert (pp["c"] > 500).all()
 
 

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -14,6 +14,8 @@
 import logging
 import warnings
 
+from contextlib import nullcontext
+
 import numpy as np
 import numpy.random as npr
 import numpy.testing as npt
@@ -35,11 +37,13 @@ import pymc as pm
 
 from pymc.backends.base import MultiTrace
 from pymc.distributions.shape_utils import change_dist_size
+from pymc.exceptions import ImplicitFreezeWarning
+from pymc.model.transform.conditioning import do
 from pymc.model.transform.optimization import freeze_dims_and_data
 from pymc.pytensorf import compile, rvs_in_graph
 from pymc.sampling.forward import (
+    _build_constant_data,
     compile_forward_sampling_function,
-    get_constant_coords,
     get_vars_in_point_list,
     observed_dependent_deterministics,
     vectorize_over_posterior,
@@ -172,32 +176,12 @@ class TestCompileForwardSampler:
         f, volatile_rvs = compile_forward_sampling_function(
             outputs=model.observed_RVs,
             vars_in_trace=[beta, mu, sigma],
-            constant_data={"p": p.get_value()},
+            constant_data={p: p.get_value()},
             basic_rvs=model.basic_RVs,
         )
         assert volatile_rvs == {category, obs}
         assert {i.name for i in self.get_function_inputs(f)} == {"beta", "sigma"}
         assert {i.name for i in self.get_function_roots(f)} == {"x", "p", "beta", "sigma"}
-
-        f, volatile_rvs = compile_forward_sampling_function(
-            outputs=model.observed_RVs,
-            vars_in_trace=[beta, mu, sigma],
-            constant_data={"p": p.get_value()},
-            basic_rvs=model.basic_RVs,
-            givens_dict={category: np.zeros(10, dtype=category.dtype)},
-            # Disable `random_unsafe` so the disconnected `p` and `x` shared
-            # inputs are kept in the compiled graph for the assertion below.
-            mode=pytensor.compile.mode.get_mode(None).excluding("random_unsafe"),
-        )
-        assert volatile_rvs == {obs}
-        assert {i.name for i in self.get_function_inputs(f)} == {"beta", "sigma"}
-        assert {i.name for i in self.get_function_roots(f)} == {
-            "x",
-            "p",
-            "category",
-            "beta",
-            "sigma",
-        }
 
     def test_volatile_parameters(self):
         with pm.Model() as model:
@@ -220,13 +204,11 @@ class TestCompileForwardSampler:
             outputs=model.observed_RVs,
             vars_in_trace=[mu, nested_mu, sigma],
             basic_rvs=model.basic_RVs,
-            givens_dict={
-                mu: pytensor.shared(np.array(1.0), name="mu")
-            },  # mu will be considered volatile because it's in givens
+            volatile_vars={mu},  # mu (a deterministic) marked as a volatility seed
         )
-        assert volatile_rvs == {nested_mu, obs}
+        assert volatile_rvs == {mu, nested_mu, obs}
         assert {i.name for i in self.get_function_inputs(f)} == {"sigma"}
-        assert {i.name for i in self.get_function_roots(f)} == {"mu", "sigma"}
+        assert {i.name for i in self.get_function_roots(f)} == {"sigma"}
 
     def test_mixture(self):
         with pm.Model() as model:
@@ -366,7 +348,10 @@ class TestCompileForwardSampler:
             )
             y = pm.Normal("y", mu=mu, sigma=sigma, observed=data, dims=["obs", "name"])
 
-        # When no constant_data and constant_coords, all the dependent nodes will be volatile and
+        name_length = model.dim_lengths["name"]
+        obs_length = model.dim_lengths["obs"]
+
+        # When no constant_data, all the dependent nodes will be volatile and
         # resampled
         f, volatile_rvs = compile_forward_sampling_function(
             outputs=[y],
@@ -382,18 +367,21 @@ class TestCompileForwardSampler:
             outputs=[y],
             vars_in_trace=[a, b, mu, sigma],
             basic_rvs=model.basic_RVs,
-            constant_data={"offsets": offsets.get_value()},
+            constant_data={offsets: offsets.get_value()},
         )
         assert volatile_rvs == {y, a, sigma}
         assert {i.name for i in self.get_function_inputs(f)} == {"b"}
         assert {i.name for i in self.get_function_roots(f)} == {"b", "name", "obs"}
 
-        # When we declare constant_coords, the shared variables with matching names wont be volatile
+        # When we declare the dim-length shareds as constant, they won't be volatile
         f, volatile_rvs = compile_forward_sampling_function(
             outputs=[y],
             vars_in_trace=[a, b, mu, sigma],
             basic_rvs=model.basic_RVs,
-            constant_coords={"name", "obs"},
+            constant_data={
+                name_length: int(name_length.get_value()),
+                obs_length: int(obs_length.get_value()),
+            },
         )
         assert volatile_rvs == {y, b}
         assert {i.name for i in self.get_function_inputs(f)} == {"a", "sigma"}
@@ -405,13 +393,16 @@ class TestCompileForwardSampler:
             "offsets",
         }
 
-        # When we have both constant_data and constant_coords, only y will be volatile
+        # When we mix data and dim-length shareds, only y will be volatile
         f, volatile_rvs = compile_forward_sampling_function(
             outputs=[y],
             vars_in_trace=[a, b, mu, sigma],
             basic_rvs=model.basic_RVs,
-            constant_data={"offsets": offsets.get_value()},
-            constant_coords={"name", "obs"},
+            constant_data={
+                offsets: offsets.get_value(),
+                name_length: int(name_length.get_value()),
+                obs_length: int(obs_length.get_value()),
+            },
         )
         assert volatile_rvs == {y}
         assert {i.name for i in self.get_function_inputs(f)} == {"a", "b", "mu", "sigma"}
@@ -423,8 +414,11 @@ class TestCompileForwardSampler:
             outputs=[y],
             vars_in_trace=[a, b, mu, sigma],
             basic_rvs=model.basic_RVs,
-            constant_data={"offsets": offsets.get_value() + 1},
-            constant_coords={"name", "obs"},
+            constant_data={
+                offsets: offsets.get_value() + 1,
+                name_length: int(name_length.get_value()),
+                obs_length: int(obs_length.get_value()),
+            },
         )
         assert volatile_rvs == {y, b}
         assert {i.name for i in self.get_function_inputs(f)} == {"a", "sigma"}
@@ -461,7 +455,7 @@ class TestCompileForwardSampler:
         )
         with model:
             pp_diff_len = pm.sample_posterior_predictive(
-                trace_diff_len, var_names=["y"]
+                trace_diff_len, var_names=["y"], sample_vars=["x"]
             ).posterior_predictive
         assert pp_diff_len["y"].item() != np.pi
 
@@ -470,9 +464,36 @@ class TestCompileForwardSampler:
         model.set_dim("trial", new_length=7)
         with model:
             pp_diff_len_model_set = pm.sample_posterior_predictive(
-                trace_same_len, var_names=["y"]
+                trace_same_len, var_names=["y"], sample_vars=["x"]
             ).posterior_predictive
         assert pp_diff_len_model_set["y"].item() != np.pi
+
+    def test_freeze_vars_blocks_volatility(self):
+        """Frozen variables should not be marked volatile even when inputs are volatile."""
+        with pm.Model() as model:
+            y = pm.Data("y", np.ones(10))
+            mu = pm.Normal("mu", 0, 1)
+            nested_mu = pm.Normal("nested_mu", mu, 1, size=10)
+            sigma = pm.HalfNormal("sigma", 1)
+            obs = pm.Normal("obs", nested_mu, sigma, observed=y, shape=nested_mu.shape)
+
+        # Without freeze: mu missing from trace makes nested_mu volatile
+        f, volatile_rvs = compile_forward_sampling_function(
+            outputs=model.observed_RVs,
+            vars_in_trace=[nested_mu, sigma],
+            basic_rvs=model.basic_RVs,
+        )
+        assert volatile_rvs == {mu, nested_mu, obs}
+
+        # With freeze: nested_mu is frozen, so it stays non-volatile despite mu being volatile
+        f, volatile_rvs = compile_forward_sampling_function(
+            outputs=model.observed_RVs,
+            vars_in_trace=[nested_mu, sigma],
+            basic_rvs=model.basic_RVs,
+            freeze_vars={nested_mu},
+        )
+        assert volatile_rvs == {mu, obs}
+        assert {i.name for i in self.get_function_inputs(f)} == {"nested_mu", "sigma"}
 
 
 class TestSamplePPC:
@@ -623,7 +644,9 @@ class TestSamplePPC:
                 10 * [model.initial_point()], return_inferencedata=False
             )
             assert ppc0 == {}
-            ppc = pm.sample_posterior_predictive(idata, return_inferencedata=False, var_names=["b"])
+            ppc = pm.sample_posterior_predictive(
+                idata, return_inferencedata=False, sample_vars=["b"]
+            )
             assert len(ppc) == 1
             assert ppc["b"].shape == (
                 1,
@@ -871,7 +894,9 @@ class TestSamplePPC:
 
             d = pm.Deterministic("d", a - 4)
             pm.Normal("c", d, sigma=0.01)
-            ppc = pm.sample_posterior_predictive(trace, var_names="c", return_inferencedata=True)
+            ppc = pm.sample_posterior_predictive(
+                trace, sample_vars=["c"], return_inferencedata=True
+            )
         assert np.all(np.abs(ppc.posterior_predictive.c + 4) <= 0.1)
 
     def test_logging_sampled_basic_rvs_prior(self, caplog):
@@ -914,16 +939,17 @@ class TestSamplePPC:
         caplog.clear()
 
         with m:
-            pm.sample_posterior_predictive(idata, var_names=["y", "z"])
+            pm.sample_posterior_predictive(idata, var_names=["y", "z"], sample_vars=["y"])
         assert caplog.record_tuples == [("pymc.sampling.forward", logging.INFO, "Sampling: [y, z]")]
         caplog.clear()
 
-        # Resampling `x` will force resampling of `y`, even if it is in trace
+        # Resampling `x` does not cascade to `y`: `y` is in the trace and not in
+        # `sample_vars`, so it's implicitly frozen. A warning fires because `y` is
+        # downstream of a resampled variable.
         with m:
-            pm.sample_posterior_predictive(idata, var_names=["x", "z"])
-        assert caplog.record_tuples == [
-            ("pymc.sampling.forward", logging.INFO, "Sampling: [x, y, z]")
-        ]
+            with pytest.warns(ImplicitFreezeWarning, match="ancestor is resampled"):
+                pm.sample_posterior_predictive(idata, var_names=["x", "z"], sample_vars=["x"])
+        assert caplog.record_tuples == [("pymc.sampling.forward", logging.INFO, "Sampling: [x, z]")]
         caplog.clear()
 
         # Missing deterministic `x_det` does not show in the log, even if it is being
@@ -941,13 +967,14 @@ class TestSamplePPC:
         assert caplog.record_tuples == [("pymc.sampling.forward", logging.INFO, "Sampling: [z]")]
         caplog.clear()
 
-        # Missing `x` causes sampling of downstream `y` RV, even if it is present in trace
+        # `x` is missing from the trace, so it must be sampled. `y` is in the trace
+        # and not in `sample_vars`, so it's kept despite having a resampled ancestor;
+        # a warning flags it as a likely cascade candidate.
         idata = az_from_dict({"posterior": {"y": np.ones((1, 5))}})
         with m:
-            pm.sample_posterior_predictive(idata)
-        assert caplog.record_tuples == [
-            ("pymc.sampling.forward", logging.INFO, "Sampling: [x, y, z]")
-        ]
+            with pytest.warns(ImplicitFreezeWarning, match="ancestor is resampled"):
+                pm.sample_posterior_predictive(idata)
+        assert caplog.record_tuples == [("pymc.sampling.forward", logging.INFO, "Sampling: [x, z]")]
         caplog.clear()
 
     def test_logging_sampled_basic_rvs_posterior_deterministic(self, caplog):
@@ -957,14 +984,20 @@ class TestSamplePPC:
             y = pm.Normal("y", x_det)
             z = pm.Normal("z", y, observed=0)
 
-        # Explicit resampling a deterministic will lead to resampling of downstream RV `y`
-        # This behavior could change in the future as the posterior of `y` is still valid
+        # `x_det` is in the trace; listing it in var_names just copies it. Only `z`
+        # (observed, not in trace) is resampled.
         idata = az_from_dict(
-            {"posterior": {"x": np.zeros((1, 5)), "x_det": np.ones((1, 5)), "y": np.ones((1, 5))}}
+            {
+                "posterior": {
+                    "x": np.zeros((1, 5)),
+                    "x_det": np.ones((1, 5)),
+                    "y": np.ones((1, 5)),
+                }
+            }
         )
         with m:
             pm.sample_posterior_predictive(idata, var_names=["x_det", "z"])
-        assert caplog.record_tuples == [("pymc.sampling.forward", logging.INFO, "Sampling: [y, z]")]
+        assert caplog.record_tuples == [("pymc.sampling.forward", logging.INFO, "Sampling: [z]")]
         caplog.clear()
 
     @staticmethod
@@ -1025,96 +1058,57 @@ class TestSamplePPC:
 
     def test_logging_sampled_basic_rvs_posterior_mutable(self, mock_sample_results, caplog):
         kind, samples, model = mock_sample_results
-        with model:
+        # Trace variables whose upstream Data/coords appear changed are implicitly
+        # frozen (reused from the trace); the observed ``y`` is always resampled
+        # since it has no trace value. Whether a/b/sigma are implicitly frozen
+        # depends on how much each trace kind knows about constant_data/coords:
+        # - MultiTrace has no Data/coord info, so everything is assumed changed and
+        #   every trace variable is frozen.
+        # - DataTree has full info; with no real change nothing is frozen.
+        # - Dataset knows coords are unchanged but not Data, so only `b` (the
+        #   Data-dependent variable) is frozen.
+        # DataTree has full info and sees no change → nothing frozen, no warning.
+        # MultiTrace/Dataset flag mismatches → warning fires.
+        block1_warn = nullcontext() if kind == "DataTree" else pytest.warns(ImplicitFreezeWarning)
+        with model, block1_warn:
             pm.sample_posterior_predictive(samples)
-        if kind == "MultiTrace":
-            # MultiTrace will only have the actual MCMC posterior samples but no information on
-            # the Data and coordinate values, so it will always assume they are volatile
-            # and resample their descendants
-            assert caplog.record_tuples == [
-                ("pymc.sampling.forward", logging.INFO, "Sampling: [a, b, sigma, y]")
-            ]
-            caplog.clear()
-        elif kind == "DataTree":
-            # DataTree has all MCMC posterior samples and the values for both coordinates and
-            # data containers. This enables it to see that no data has changed and it should only
-            # resample the observed variable
-            assert caplog.record_tuples == [
-                ("pymc.sampling.forward", logging.INFO, "Sampling: [y]")
-            ]
-            caplog.clear()
-        elif kind == "Dataset":
-            # Dataset has all MCMC posterior samples and the values of the coordinates. This
-            # enables it to see that the coordinates have not changed, but the Data is
-            # assumed volatile by default
-            assert caplog.record_tuples == [
-                ("pymc.sampling.forward", logging.INFO, "Sampling: [b, y]")
-            ]
-            caplog.clear()
+        assert caplog.record_tuples == [("pymc.sampling.forward", logging.INFO, "Sampling: [y]")]
+        caplog.clear()
 
         original_offsets = model["offsets"].get_value()
         with model:
-            # Changing the Data values. This will only be picked up by DataTree
+            # Change the Data values. `b` depends on `offsets`, so DataTree now
+            # sees the mismatch and freezes `b` (the other kinds already were).
             pm.set_data({"offsets": original_offsets + 1})
-            pm.sample_posterior_predictive(samples)
-        if kind == "MultiTrace":
-            assert caplog.record_tuples == [
-                ("pymc.sampling.forward", logging.INFO, "Sampling: [a, b, sigma, y]")
-            ]
-            caplog.clear()
-        elif kind == "DataTree":
-            assert caplog.record_tuples == [
-                ("pymc.sampling.forward", logging.INFO, "Sampling: [b, y]")
-            ]
-            caplog.clear()
-        elif kind == "Dataset":
-            assert caplog.record_tuples == [
-                ("pymc.sampling.forward", logging.INFO, "Sampling: [b, y]")
-            ]
-            caplog.clear()
+            with pytest.warns(ImplicitFreezeWarning):
+                pm.sample_posterior_predictive(samples)
+        assert caplog.record_tuples == [("pymc.sampling.forward", logging.INFO, "Sampling: [y]")]
+        caplog.clear()
 
+        # Changing a coord's length would freeze variables whose shape no longer
+        # fits and produce shape errors at runtime. The caller must opt in to
+        # resampling those variables via `sample_vars`.
+        # DataTree sees that offsets is back to original and a/sigma are in
+        # sample_vars → nothing implicitly frozen, no warning.
+        block3_warn = nullcontext() if kind == "DataTree" else pytest.warns(ImplicitFreezeWarning)
         with model:
-            # Changing the mutable coordinates. This will be picked up by DataTree and Dataset
             model.set_dim("name", new_length=4, coord_values=["D", "E", "F", "G"])
             pm.set_data({"offsets": original_offsets, "y_obs": np.zeros((10, 4))})
-            pm.sample_posterior_predictive(samples)
-        if kind == "MultiTrace":
-            assert caplog.record_tuples == [
-                ("pymc.sampling.forward", logging.INFO, "Sampling: [a, b, sigma, y]")
-            ]
-            caplog.clear()
-        elif kind == "DataTree":
-            assert caplog.record_tuples == [
-                ("pymc.sampling.forward", logging.INFO, "Sampling: [a, sigma, y]")
-            ]
-            caplog.clear()
-        elif kind == "Dataset":
-            assert caplog.record_tuples == [
-                ("pymc.sampling.forward", logging.INFO, "Sampling: [a, b, sigma, y]")
-            ]
-            caplog.clear()
+            with block3_warn:
+                pm.sample_posterior_predictive(samples, sample_vars=["a", "sigma", "y"])
+        assert caplog.record_tuples == [
+            ("pymc.sampling.forward", logging.INFO, "Sampling: [a, sigma, y]")
+        ]
+        caplog.clear()
 
         with model:
-            # Changing the mutable coordinate values, but not shape, and also changing Data.
-            # This will trigger resampling of all variables
+            # Coord length unchanged but values changed; shape still matches.
             model.set_dim("name", new_length=3, coord_values=["A", "B", "D"])
             pm.set_data({"offsets": original_offsets + 1, "y_obs": np.zeros((10, 3))})
-            pm.sample_posterior_predictive(samples)
-        if kind == "MultiTrace":
-            assert caplog.record_tuples == [
-                ("pymc.sampling.forward", logging.INFO, "Sampling: [a, b, sigma, y]")
-            ]
-            caplog.clear()
-        elif kind == "DataTree":
-            assert caplog.record_tuples == [
-                ("pymc.sampling.forward", logging.INFO, "Sampling: [a, b, sigma, y]")
-            ]
-            caplog.clear()
-        elif kind == "Dataset":
-            assert caplog.record_tuples == [
-                ("pymc.sampling.forward", logging.INFO, "Sampling: [a, b, sigma, y]")
-            ]
-            caplog.clear()
+            with pytest.warns(ImplicitFreezeWarning):
+                pm.sample_posterior_predictive(samples)
+        assert caplog.record_tuples == [("pymc.sampling.forward", logging.INFO, "Sampling: [y]")]
+        caplog.clear()
 
     def test_observed_data_needed_in_pp(self):
         # Model where y_data is not part of the generative graph.
@@ -1460,6 +1454,297 @@ class TestSamplePosteriorPredictive:
             assert len(pp.posterior_predictive["pred_id"]) == 5
 
 
+@pytest.mark.filterwarnings("error")
+class TestSamplePosteriorPredictiveVolatility:
+    """Tests for the ``var_names`` / ``sample_vars`` / ``freeze_vars`` knobs."""
+
+    def test_var_names_output_vs_sample_vars_resample(self):
+        """`var_names` controls the returned contents only; `sample_vars` is what
+        triggers resampling of a non-volatile trace variable."""
+        with pm.Model() as model:
+            mu = pm.Normal("mu", 0, 1)
+            pm.Normal("obs", mu, 1, observed=np.zeros(5))
+
+        trace = az_from_dict({"posterior": {"mu": np.ones((1, 100))}})
+        with model:
+            # Listing mu in var_names alone does not resample it — copied from trace.
+            ppc_copied = pm.sample_posterior_predictive(
+                trace, var_names=["mu", "obs"], return_inferencedata=False
+            )
+            npt.assert_array_equal(ppc_copied["mu"].flatten(), np.ones(100))
+            assert "obs" in ppc_copied
+
+            # Adding sample_vars=["mu"] forces a fresh draw.
+            ppc_resampled = pm.sample_posterior_predictive(
+                trace,
+                var_names=["mu", "obs"],
+                sample_vars=["mu"],
+                return_inferencedata=False,
+            )
+            assert not np.all(ppc_resampled["mu"] == 1.0)
+            assert "obs" in ppc_resampled
+
+    def test_freeze_deterministic(self):
+        """Freezing a deterministic keeps its trace value instead of recomputing
+        from new data. Verified by inspecting the downstream resampled ``obs``
+        (HSGP-style standardization use case)."""
+        # obs is observed with tiny noise, so its resampled values reveal whether
+        # `x_mean` was recomputed from the new x (mean=200) or kept frozen at the
+        # training-time mean (2.0).
+        with pm.Model() as model:
+            x = pm.Data("x", [1.0, 2.0, 3.0])
+            x_mean = pm.Deterministic("x_mean", x.mean())
+            centered = pm.Deterministic("centered", x - x_mean)
+            scale = pm.DiracDelta("scale", 1.0)
+            pm.Normal("obs", scale * centered, 1e-6, observed=np.zeros(3))
+            prior = pm.sample_prior_predictive(draws=2, random_seed=0)
+        # Fake the prior as a posterior (the draws don't matter, only the graph).
+        # `x_mean` must be in the trace so it can be frozen.
+        idata = az_from_dict(
+            {
+                "posterior": {
+                    "scale": prior.prior["scale"].values,
+                    "x_mean": prior.prior["x_mean"].values,
+                },
+                "constant_data": {"x": np.array([1.0, 2.0, 3.0])},
+            }
+        )
+
+        with model:
+            pm.set_data({"x": [100.0, 200.0, 300.0]})
+            # No freeze: x_mean is recomputed as mean([100,200,300])=200,
+            # so centered = [-100, 0, 100] and obs ≈ [-100, 0, 100].
+            ppc_recomputed = pm.sample_posterior_predictive(
+                idata, return_inferencedata=False, progressbar=False, random_seed=0
+            )
+            npt.assert_allclose(ppc_recomputed["obs"][0, 0], [-100.0, 0.0, 100.0], atol=1e-3)
+
+            # Freeze x_mean: stays at training-time mean 2.0,
+            # so centered = [98, 198, 298] and obs ≈ [98, 198, 298].
+            ppc_frozen = pm.sample_posterior_predictive(
+                idata,
+                freeze_vars=["x_mean"],
+                return_inferencedata=False,
+                progressbar=False,
+                random_seed=0,
+            )
+            npt.assert_allclose(ppc_frozen["obs"][0, 0], [98.0, 198.0, 298.0], atol=1e-3)
+
+    def test_freeze_vars_and_sample_vars_overlap_raises(self):
+        """freeze_vars and sample_vars must be disjoint."""
+        with pm.Model() as model:
+            mu = pm.Normal("mu", 0, 1)
+            obs = pm.Normal("obs", mu, 1, observed=np.zeros(5))
+
+        trace = az_from_dict({"posterior": {"mu": np.ones((1, 10))}})
+        with model:
+            with pytest.raises(ValueError, match="both sample_vars and freeze_vars"):
+                pm.sample_posterior_predictive(
+                    trace,
+                    sample_vars=["mu"],
+                    freeze_vars=["mu"],
+                )
+
+    def test_freeze_vars_not_in_trace_raises(self):
+        """freeze_vars entries must exist in the trace."""
+        with pm.Model() as model:
+            mu = pm.Normal("mu")
+            pm.Normal("extra", 0, 1)  # in the model but not in the trace
+            pm.Normal("obs", mu, 1, observed=np.zeros(1))
+        trace = az_from_dict({"posterior": {"mu": np.ones((1, 5))}})
+
+        with model, pytest.raises(ValueError, match="not present in the trace"):
+            pm.sample_posterior_predictive(trace, freeze_vars=["extra"])
+
+    def test_sample_vars_not_in_var_names_excluded_from_output(self):
+        """`var_names` strictly controls the returned contents. A resampled
+        variable is still used as a volatility seed, but if it isn't listed in
+        ``var_names`` it does not appear in the output."""
+        with pm.Model() as model:
+            y = pm.Normal("y")
+            z = pm.Normal("z", y)
+            pm.Normal("obs", z, 1e-6, observed=np.zeros(1))
+            prior = pm.sample_prior_predictive(draws=2, random_seed=0)
+        idata = az_from_dict(
+            {
+                "posterior": {
+                    "y": prior.prior["y"].values,
+                    "z": prior.prior["z"].values,
+                }
+            }
+        )
+
+        # Resampling y makes z volatile (its ancestor is resampled), but z isn't
+        # in sample_vars → implicit freeze warning, z kept from trace.
+        with model, pytest.warns(ImplicitFreezeWarning, match="ancestor is resampled"):
+            ppc = pm.sample_posterior_predictive(
+                idata,
+                sample_vars=["y"],
+                var_names=["z"],
+                return_inferencedata=False,
+                progressbar=False,
+                random_seed=0,
+            )
+        # z is auto-frozen (not in sample_vars) → kept from trace.
+        npt.assert_allclose(ppc["z"].squeeze(), prior.prior["z"].values.squeeze())
+        # y was resampled as a volatility seed, but isn't in var_names → not returned.
+        assert "y" not in ppc
+        assert set(ppc) == {"z"}
+
+    def test_var_names_not_in_trace_is_sampled(self):
+        """A basic RV listed in `var_names` but missing from the trace is
+        sampled, not silently dropped."""
+        with pm.Model() as model:
+            y = pm.Normal("y")
+            pm.Normal("obs", y, 1, observed=np.zeros(1))
+            prior = pm.sample_prior_predictive(draws=2, random_seed=0)
+
+        with pm.Model() as expanded:
+            y = pm.Normal("y")
+            z = pm.Normal("z", y)  # not in the trace
+            pm.Normal("obs", z, 1e-6, observed=np.zeros(1))
+
+        # Trace has y but not z. Asking for z in var_names should produce fresh z.
+        idata = az_from_dict({"posterior": {"y": prior.prior["y"].values}})
+        with expanded:
+            ppc = pm.sample_posterior_predictive(
+                idata,
+                var_names=["z"],
+                return_inferencedata=False,
+                progressbar=False,
+                random_seed=0,
+            )
+        assert "z" in ppc
+        assert ppc["z"].size > 0
+
+    def test_sample_vars_rejects_data(self):
+        """Data containers can't be in sample_vars — no trace value to override."""
+        with pm.Model() as model:
+            x = pm.Data("x", [1.0, 2.0, 3.0])
+            mu = pm.Normal("mu")
+            pm.Normal("obs", mu=mu + x.mean(), sigma=1, observed=[0, 0, 0])
+            prior = pm.sample_prior_predictive(draws=2, random_seed=0)
+        idata = az_from_dict({"posterior": {"mu": prior.prior["mu"].values}})
+
+        with model, pytest.raises(ValueError, match="not random variables or deterministics"):
+            pm.sample_posterior_predictive(idata, sample_vars=["x"])
+
+    def test_changed_constant_detected_as_volatile(self):
+        """A TensorConstant whose name is in `constant_data` but whose value
+        changed (e.g. after `pm.do(..., make_interventions_shared=False)`)
+        must register as volatile so downstream basic RVs are flagged."""
+        with pm.Model() as m:
+            x = pm.Data("x", np.array([1.0, 2.0, 3.0]))
+            b = pm.Normal("b", x.sum(), sigma=1)
+            pm.Normal("obs", b, 1e-6, observed=np.zeros(1))
+            prior = pm.sample_prior_predictive(draws=2, random_seed=0)
+
+        new_x = pt.constant([10.0, 20.0, 30.0], name="x")
+        do_m = do(m, {"x": new_x}, make_interventions_shared=False)
+        idata = az_from_dict(
+            {
+                "posterior": {"b": prior.prior["b"].values},
+                "constant_data": {"x": np.array([1.0, 2.0, 3.0])},
+            }
+        )
+
+        with do_m:
+            with pytest.warns(ImplicitFreezeWarning, match="upstream Data/coords changed"):
+                pm.sample_posterior_predictive(
+                    idata, return_inferencedata=False, progressbar=False, random_seed=0
+                )
+
+    def test_sample_vars_deterministic_forces_recompute(self):
+        """When ``pm.do`` swaps in a different expression for a deterministic,
+        the model's graph changes but the trace still has the old values.
+        Default behaviour copies from the trace; putting the deterministic in
+        `sample_vars` forces a fresh computation using the new graph."""
+        with pm.Model() as m:
+            x = pm.Normal("x")
+            pm.Deterministic("det", x**2)
+            pm.Normal("obs", m["det"], 1e-6, observed=np.zeros(1))
+            prior = pm.sample_prior_predictive(draws=3, random_seed=0)
+
+        # Reshape `det` to `x**3`. The new graph is different, but the trace
+        # still carries the old `det = x**2` values.
+        do_m = do(m, {m["det"]: m["x"] ** 3})
+        x_trace = prior.prior["x"].values
+        old_det = prior.prior["det"].values
+        idata = az_from_dict({"posterior": {"x": x_trace, "det": old_det}})
+
+        # Default: `det` is copied from the trace (no volatility detected at the
+        # basic-RV level, and deterministics aren't volatile by default).
+        with do_m:
+            ppc_copied = pm.sample_posterior_predictive(
+                idata,
+                var_names=["det"],
+                return_inferencedata=False,
+                progressbar=False,
+                random_seed=0,
+            )
+        npt.assert_allclose(ppc_copied["det"].squeeze(), old_det.squeeze())
+
+        # `sample_vars=["det"]`: force recomputation using do_m's graph (x**3).
+        with do_m:
+            ppc_forced = pm.sample_posterior_predictive(
+                idata,
+                var_names=["det"],
+                sample_vars=["det"],
+                return_inferencedata=False,
+                progressbar=False,
+                random_seed=0,
+            )
+        npt.assert_allclose(ppc_forced["det"].squeeze(), x_trace.squeeze() ** 3)
+
+    def test_implicit_freeze_warning(self):
+        """When upstream Data changes, trace variables are auto-frozen with a
+        warning; no warning fires when nothing changed, or when the user
+        explicitly opts in via `sample_vars` / `freeze_vars`."""
+        with pm.Model() as model:
+            x = pm.Data("x", 0.0)
+            # beta depends on x, so changing x makes beta volatile.
+            beta = pm.Normal("beta", mu=x, sigma=1)
+            # Tiny noise on obs reveals the beta value actually used: if beta is
+            # frozen at the trace value (1.0) obs ≈ 1.0; if it's resampled from
+            # N(mu=5, sigma=1) obs will be nowhere near 1.0.
+            pm.Normal("obs", beta, 1e-6, observed=0.0)
+
+        trace = az_from_dict(
+            {
+                "posterior": {"beta": np.ones((1, 10))},
+                "constant_data": {"x": np.array(0.0)},
+            }
+        )
+        with model:
+            # Nothing has changed — trace x matches model x, so no warning
+            # (the filterwarnings marker would error if one fired).
+            pm.sample_posterior_predictive(
+                trace, return_inferencedata=False, progressbar=False, random_seed=0
+            )
+
+            pm.set_data({"x": 5.0})
+
+            # Default: beta is implicitly frozen at 1.0, with a warning.
+            with pytest.warns(ImplicitFreezeWarning, match="implicitly frozen"):
+                ppc = pm.sample_posterior_predictive(
+                    trace, return_inferencedata=False, progressbar=False, random_seed=0
+                )
+            npt.assert_allclose(ppc["obs"], 1.0, atol=1e-3)
+
+            # Explicit `freeze_vars=["beta"]`: same frozen behavior, no warning.
+            ppc_frozen = pm.sample_posterior_predictive(
+                trace,
+                freeze_vars=["beta"],
+                return_inferencedata=False,
+                progressbar=False,
+                random_seed=0,
+            )
+            npt.assert_allclose(ppc_frozen["obs"], 1.0, atol=1e-3)
+
+            # Explicit `sample_vars=["beta"]`: user opts into resampling, no warning.
+            pm.sample_posterior_predictive(trace, sample_vars=["beta"])
+
+
 def test_distinct_rvs():
     """Make sure `RandomVariable`s generated using a `Model`'s default RNG state all have distinct states."""
 
@@ -1770,18 +2055,30 @@ class TestNestedRandom:
         assert prior["target"].shape == (prior_samples, *shape)
 
 
-def test_get_constant_coords():
+def test_build_constant_data():
     with pm.Model() as model:
         model.add_coord("length_coord", length=1)
         model.add_coord("value_coord", values=(3,))
+        x = pm.Data("x", np.array([1.0, 2.0, 3.0]))
 
+    length_var = model.dim_lengths["length_coord"]
+    value_var = model.dim_lengths["value_coord"]
+
+    trace_constant_data = {"x": np.array([1.0, 2.0, 3.0])}
     trace_coords_same = {"length_coord": np.array([0]), "value_coord": np.array([3])}
-    constant_coords_same = get_constant_coords(trace_coords_same, model)
-    assert constant_coords_same == {"length_coord", "value_coord"}
+    constant_data_same = _build_constant_data(trace_constant_data, trace_coords_same, model)
+    # Both dim-length shareds recorded, plus the pm.Data entry
+    assert set(constant_data_same) == {x, length_var, value_var}
 
+    # Different coord values / length -- the dim-length shareds drop out
     trace_coords_diff = {"length_coord": np.array([0, 1]), "value_coord": np.array([4])}
-    constant_coords_diff = get_constant_coords(trace_coords_diff, model)
-    assert constant_coords_diff == set()
+    constant_data_diff = _build_constant_data(trace_constant_data, trace_coords_diff, model)
+    assert set(constant_data_diff) == {x}
+
+    # pm.Data missing from the trace -> not in mapping (treated volatile later)
+    constant_data_no_x = _build_constant_data({}, trace_coords_same, model)
+    assert x not in constant_data_no_x
+    assert set(constant_data_no_x) == {length_var, value_var}
 
 
 def test_get_vars_in_point_list():


### PR DESCRIPTION
Keep in mind this is like our second most important function in PyMC, and it was easily a footgun whenever var_names was involved or there were unobserved RVs that depended on modified data/coordinates (see #7069).

After this RV variables in the trace are never resampled by default, even if it may mean the graph is invalid (shape or semantically). A warning is issued, directing users to explicitly add variables "deemed volatile" into `sample_vars` (to resample them) or `freeze_vars` (to confirm this was intended).

Regular uses that don't touch `var_names` should stay the same as before. After these I think `var_names` becomes very intuitive (and less important as well)

**Main knobs**
- `sample_vars` — variables to force sampling. RVs present in the trace will never be resampled unless they show up here. Deterministics are still recomputed automatically based on volatility, but can be included here in case the volatility analysis wouldn't trigger them (there's a pm.do use case in the tests/docstrings). Variables that don't exist in the trace (including observeds) are always sampled, but can be added here for completeness.
- `freeze_vars` — variables to explicitly reuse from the trace. Should also be used for RVs in the trace that seem volatile but are intended to not be resampled. Also works for deterministics — e.g. the HSGP-style case of a training-time mean-centering that shouldn't be rederived from prediction data.                                                                                                
- `ImplicitFreezeWarning` in `pymc.exceptions` — emitted when a trace RV is deemed volatile but not explicitly in `sample_vars` or `freeze_vars`. This is the knob to alert users they need to make a decision, reducing silent "footguns".
- `var_names` is strictly output-gating now. It just determines what variables appear in the returned trace.

**Other changes**

- `var_names` / `sample_vars` / `freeze_vars`, and everything after `model`, are now keyword-only.
- A `pm.Data` replaced by a `TensorConstant` with a different value (e.g. via `pm.do(…, make_interventions_shared=False)` or `freeze_dims_and_data`) now participates in volatility detection (closes #6876).
- Docstring rewritten: common uses first (standard PPC, `set_data` predictions, freezing/forcing a deterministic, out-of-model predictions), detailed volatility rules only after.
- Some (hopefully) sane default for default var_names, when `sample_vars` is specified.
- Removed givens argument in the inner function (closes #6614)

Closes #7069 
Closes #6876 
Closes #6614

TODO:
- [x] clean code
- [x] clean tests