### PR TITLE
v6->main

### DIFF
--- a/tests/distributions/test_random_alternative_backends.py
+++ b/tests/distributions/test_random_alternative_backends.py
@@ -11,8 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from contextlib import nullcontext
-
 import numpy as np
 import pytest
 
@@ -44,15 +42,13 @@ def test_dirichlet_multinomial_dims(mode):
     with pm.Model(coords={"trial": range(3), "item": range(3)}) as m:
         dm = DirichletMultinomial("dm", n=5, a=np.eye(3) * 1e6 + 0.01, dims=("trial", "item"))
 
-    # JAX does not allow us to JIT a function with dynamic shape
-    expected_ctxt = pytest.raises(TypeError) if mode == "JAX" else nullcontext()
-    with expected_ctxt:
-        pm.draw(dm, mode=mode)
-
-    # Should be fine after freezing the dims that specify the shape
-    frozen_dm = freeze_dims_and_data(m)["dm"]
-    dm_draws = pm.draw(frozen_dm, mode=mode, random_seed=36)
+    dm_draws = pm.draw(dm, mode=mode, random_seed=36)
     np.testing.assert_equal(dm_draws, np.eye(3) * 5)
+
+    # Should also work after freezing the dims that specify the shape
+    frozen_dm = freeze_dims_and_data(m)["dm"]
+    frozen_dm_draws = pm.draw(frozen_dm, mode=mode, random_seed=36)
+    np.testing.assert_equal(frozen_dm_draws, np.eye(3) * 5)
 
 
 def test_mvstudentt(mode):


### PR DESCRIPTION
- **Implement dims Censored**
- **ZeroSumNormal: Explicit sigma signature**
- **ZeroSumNormal: Fix logp shape of transformed variates**
- **ZeroSumNormal: Fix dims variant with batch sigma**
- **stream to stderr**
- **Add specify_broadcastable on the log_jac_det to fix HalfStudentT and HalfCauchy**
- **Remove `tune` stat from steps and fix non-discarding of tuning draws from trace (#8015)**
- **Update pre-commit hook id**
- **Emit `DEMetropolis` `"scaling"` stat as average**
- **Fix Wishart incompatibility with newer scipy**
- **Bump Pytenor dependency**
- **Better representation for model with `dims` distributions**
- **Fix off-by-one progress bar bugs (#8201)**
- **Clean up marimo progress bar (#8184)**
- **Fix failure in change_dist_size when RVs don't take dtype argument**
- **JAX can now work with shape inputs**
