### PR TITLE
ci: revert pytensor dependency back to official release in dev enviro…

### DIFF
--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -12,6 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
+- pytensor>=2.38.2,<2.39
 - python-graphviz
 - networkx
 - scipy>=1.4.1
@@ -39,7 +40,6 @@ dependencies:
 - mypy=1.19.1
 - types-cachetools
 - pip:
-  - pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3
   - pymc-sphinx-theme>=0.16.0
   - numdifftools>=0.9.40
   - mcbackend>=0.4.0


### PR DESCRIPTION
…nment

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->


## Description
This PR reverts the `pytensor` dependency in `conda-envs/environment-dev.yml` back to the official release (`>=2.38.2,<2.39`). It removes the temporary `v3` GitHub branch link, bringing the dev environment back into alignment with the standard test environment dependencies. 

## Related Issue
- [x] Closes #8199
- [ ] Related to #

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works *(N/A - CI environment update)*
- [ ] Added necessary documentation (docstrings and/or example notebooks) *(N/A)*
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):


<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
