### PR TITLE
Clarify Wishart warning messaging

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -998,8 +998,9 @@ class Wishart(Continuous):
 
     Notes
     -----
-    This distribution is unusable in a PyMC model. You should instead
-    use LKJCholeskyCov or LKJCorr.
+    PyMC can evaluate the log-probability of a Wishart distribution, but it
+    should not be used as a prior for covariance matrices in a PyMC model.
+    Use LKJCholeskyCov or LKJCorr instead.
     """
 
     rv_op = wishart
@@ -1010,11 +1011,11 @@ class Wishart(Continuous):
         V = pt.as_tensor_variable(V)
 
         warnings.warn(
-            "The Wishart distribution can currently not be used "
-            "for MCMC sampling. The probability of sampling a "
-            "symmetric matrix is basically zero. Instead, please "
-            "use LKJCholeskyCov or LKJCorr. For more information "
-            "on the issues surrounding the Wishart see here: "
+            "The Wishart distribution should not be used as a prior "
+            "for covariance matrices in a PyMC model. The probability "
+            "of sampling a symmetric matrix is basically zero. "
+            "Use LKJCholeskyCov or LKJCorr instead. For more information "
+            "on the issues surrounding Wishart see here: "
             "https://github.com/pymc-devs/pymc/issues/538.",
             UserWarning,
         )

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -1033,7 +1033,9 @@ class BaseTestDistributionRandom:
 
         self.validate_tests_list()
         if self.pymc_dist == pm.Wishart:
-            with pytest.warns(UserWarning, match="can currently not be used for MCMC sampling"):
+            with pytest.warns(
+                UserWarning, match="should not be used as a prior for covariance matrices"
+            ):
                 self._instantiate_pymc_rv()
         else:
             self._instantiate_pymc_rv()
@@ -1047,7 +1049,9 @@ class BaseTestDistributionRandom:
                     "Custom check cannot start with `test_` or else it will be executed twice."
                 )
             if self.pymc_dist == pm.Wishart and check_name.startswith("check_rv_size"):
-                with pytest.warns(UserWarning, match="can currently not be used for MCMC sampling"):
+                with pytest.warns(
+                    UserWarning, match="should not be used as a prior for covariance matrices"
+                ):
                     getattr(self, check_name)()
             else:
                 getattr(self, check_name)()

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -549,7 +549,7 @@ class TestMatchesScipy:
 
     @pytest.mark.parametrize("n", [2, 3])
     def test_wishart(self, n):
-        with pytest.warns(UserWarning, match="Wishart distribution can currently not be used"):
+        with pytest.warns(UserWarning, match="should not be used as a prior for covariance matrices"):
             check_logp(
                 pm.Wishart,
                 PdMatrix(n),

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -549,7 +549,9 @@ class TestMatchesScipy:
 
     @pytest.mark.parametrize("n", [2, 3])
     def test_wishart(self, n):
-        with pytest.warns(UserWarning, match="should not be used as a prior for covariance matrices"):
+        with pytest.warns(
+            UserWarning, match="should not be used as a prior for covariance matrices"
+        ):
             check_logp(
                 pm.Wishart,
                 PdMatrix(n),


### PR DESCRIPTION
## Summary
- clarify the `pm.Wishart` docstring to explain that PyMC can evaluate its log-probability but it should not be used as a covariance prior in models
- align the runtime warning with that wording and keep the LKJ alternatives explicit
- update Wishart warning assertions in the distribution tests and shared test helpers

## Testing
- `HOME=/tmp XDG_CACHE_HOME=/tmp MPLCONFIGDIR=/tmp .venv/bin/python -m pytest tests/distributions/test_multivariate.py -k Wishart -q`