### PR TITLE
ENH: Add ZeroOneInflatedBeta distribution (#8190)

### DIFF
--- a/pymc/distributions/__init__.py
+++ b/pymc/distributions/__init__.py
@@ -81,6 +81,7 @@ from pymc.distributions.mixture import (
     HurdlePoisson,
     Mixture,
     NormalMixture,
+    ZeroOneInflatedBeta,
     ZeroInflatedBinomial,
     ZeroInflatedNegativeBinomial,
     ZeroInflatedPoisson,
@@ -203,6 +204,7 @@ __all__ = [
     "WishartBartlett",
     "ZeroInflatedBinomial",
     "ZeroInflatedNegativeBinomial",
+    "ZeroOneInflatedBeta",
     "ZeroInflatedPoisson",
     "ZeroSumNormal",
 ]

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -24,7 +24,7 @@ from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.random.utils import normalize_size_param
 
 from pymc.distributions import transforms
-from pymc.distributions.continuous import Gamma, LogNormal, Normal, get_tau_sigma
+from pymc.distributions.continuous import Beta, Gamma, LogNormal, Normal, get_tau_sigma
 from pymc.distributions.discrete import Binomial, NegativeBinomial, Poisson
 from pymc.distributions.dist_math import check_parameters
 from pymc.distributions.distribution import (
@@ -50,6 +50,7 @@ __all__ = [
     "HurdlePoisson",
     "Mixture",
     "NormalMixture",
+    "ZeroOneInflatedBeta",
     "ZeroInflatedBinomial",
     "ZeroInflatedNegativeBinomial",
     "ZeroInflatedPoisson",
@@ -573,6 +574,87 @@ def _zero_inflated_mixture(*, name, nonzero_p, nonzero_dist, **kwargs):
         return Mixture(name, weights, comp_dists, **kwargs)
     else:
         return Mixture.dist(weights, comp_dists, **kwargs)
+
+
+def _zero_one_inflated_mixture(*, name, zero_p, one_p, middle_dist, **kwargs):
+    """Create a zero-one-inflated mixture (helper function).
+
+    If name is `None`, this function returns an unregistered variable.
+    """
+    zero_p = pt.as_tensor_variable(zero_p)
+    one_p = pt.as_tensor_variable(one_p)
+    middle_p = 1 - zero_p - one_p
+    weights = pt.stack([zero_p, one_p, middle_p], axis=-1)
+    dtype = middle_dist.dtype
+    comp_dists = [
+        DiracDelta.dist(np.asarray(0, dtype=dtype)),
+        DiracDelta.dist(np.asarray(1, dtype=dtype)),
+        middle_dist,
+    ]
+    if name is not None:
+        return Mixture(name, weights, comp_dists, **kwargs)
+    else:
+        return Mixture.dist(weights, comp_dists, **kwargs)
+
+
+class ZeroOneInflatedBeta:
+    R"""
+    Zero-one-inflated Beta distribution.
+
+    The pdf of this distribution is
+
+    .. math::
+
+        f(x \mid \text{zoi}, \text{coi}, \mu, \kappa) =
+            \left\{ \begin{array}{l}
+            \text{zoi}(1-\text{coi}), \text{if } x = 0 \\
+            \text{zoi}\,\text{coi}, \text{if } x = 1 \\
+            (1-\text{zoi})\text{BetaPDF}(x \mid \mu, \kappa), \text{if } 0 < x < 1
+            \end{array} \right.
+
+    ========  ==========================
+    Support   :math:`x \in [0, 1]`
+    Mean      :math:`\text{zoi}\,\text{coi} + (1-\text{zoi})\mu`
+    ========  ==========================
+
+    Parameters
+    ----------
+    zoi : tensor_like of float
+        Probability of boundary inflation (0 <= zoi <= 1).
+    coi : tensor_like of float
+        Conditional probability of one given boundary inflation (0 <= coi <= 1).
+    mu : tensor_like of float
+        Mean of the beta component (0 < mu < 1).
+    kappa : tensor_like of float
+        Precision of the beta component (kappa > 0).
+    """
+
+    def __new__(cls, name, zoi, coi, mu, kappa, **kwargs):
+        zoi = pt.as_tensor_variable(zoi)
+        coi = pt.as_tensor_variable(coi)
+        mu = pt.as_tensor_variable(mu)
+        kappa = pt.as_tensor_variable(kappa)
+        return _zero_one_inflated_mixture(
+            name=name,
+            zero_p=zoi * (1 - coi),
+            one_p=zoi * coi,
+            middle_dist=Beta.dist(mu=mu, nu=kappa),
+            **kwargs,
+        )
+
+    @classmethod
+    def dist(cls, zoi, coi, mu, kappa, **kwargs):
+        zoi = pt.as_tensor_variable(zoi)
+        coi = pt.as_tensor_variable(coi)
+        mu = pt.as_tensor_variable(mu)
+        kappa = pt.as_tensor_variable(kappa)
+        return _zero_one_inflated_mixture(
+            name=None,
+            zero_p=zoi * (1 - coi),
+            one_p=zoi * coi,
+            middle_dist=Beta.dist(mu=mu, nu=kappa),
+            **kwargs,
+        )
 
 
 class ZeroInflatedPoisson:

--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -51,6 +51,7 @@ from pymc.distributions import (
     StickBreakingWeights,
     Triangular,
     Uniform,
+    ZeroOneInflatedBeta,
     ZeroInflatedBinomial,
     ZeroInflatedNegativeBinomial,
     ZeroInflatedPoisson,
@@ -1496,6 +1497,39 @@ class TestZeroInflatedMixture:
             {"n": NatSmall, "p": Unit, "psi": Unit},
         )
 
+    def test_zerooneinflatedbeta_logp(self):
+        def logp_fn(value, zoi, coi, mu, kappa):
+            if value == 0:
+                return np.log(zoi * (1 - coi))
+            elif value == 1:
+                return np.log(zoi * coi)
+            else:
+                alpha = mu * kappa
+                beta = (1 - mu) * kappa
+                return np.log(1 - zoi) + st.beta.logpdf(value, alpha, beta)
+
+        def logcdf_fn(value, zoi, coi, mu, kappa):
+            if value == 1:
+                return 0.0
+            alpha = mu * kappa
+            beta = (1 - mu) * kappa
+            cdf = zoi * (1 - coi) + (1 - zoi) * st.beta.cdf(value, alpha, beta)
+            return np.log(cdf)
+
+        check_logp(
+            ZeroOneInflatedBeta,
+            Unit,
+            {"zoi": Unit, "coi": Unit, "mu": Unit, "kappa": Rplusbig},
+            logp_fn,
+        )
+
+        check_logcdf(
+            ZeroOneInflatedBeta,
+            Unit,
+            {"zoi": Unit, "coi": Unit, "mu": Unit, "kappa": Rplusbig},
+            logcdf_fn,
+        )
+
     @pytest.mark.parametrize(
         "psi, mu, size, expected",
         [
@@ -1557,6 +1591,31 @@ class TestZeroInflatedMixture:
         assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
+        "zoi, coi, mu, kappa, size, expected",
+        [
+            (0.5, 0.4, 0.6, 10.0, None, 0.5 * 0.4 + (1 - 0.5) * 0.6),
+            (0.7, 0.2, 0.3, 5.0, 4, np.full(4, 0.7 * 0.2 + (1 - 0.7) * 0.3)),
+            (
+                np.array([0.2, 0.8]),
+                np.array([0.1, 0.9]),
+                np.array([0.4, 0.6]),
+                np.array([2.0, 8.0]),
+                None,
+                np.array(
+                    [
+                        0.2 * 0.1 + (1 - 0.2) * 0.4,
+                        0.8 * 0.9 + (1 - 0.8) * 0.6,
+                    ]
+                ),
+            ),
+        ],
+    )
+    def test_zero_one_inflated_beta_support_point(self, zoi, coi, mu, kappa, size, expected):
+        with Model() as model:
+            ZeroOneInflatedBeta("x", zoi=zoi, coi=coi, mu=mu, kappa=kappa, size=size)
+        assert_support_point_is_expected(model, expected)
+
+    @pytest.mark.parametrize(
         "dist, non_psi_args",
         [
             (ZeroInflatedPoisson.dist, (2,)),
@@ -1567,6 +1626,16 @@ class TestZeroInflatedMixture:
     def test_zero_inflated_dists_dtype_and_broadcast(self, dist, non_psi_args):
         x = dist([0.5, 0.5, 0.5], *non_psi_args)
         assert x.dtype in discrete_types
+        assert x.eval().shape == (3,)
+
+    def test_zero_one_inflated_beta_dtype_and_broadcast(self):
+        x = ZeroOneInflatedBeta.dist(
+            zoi=[0.2, 0.6, 0.8],
+            coi=[0.7, 0.5, 0.1],
+            mu=[0.4, 0.3, 0.9],
+            kappa=[3.0, 5.0, 10.0],
+        )
+        assert x.dtype not in discrete_types
         assert x.eval().shape == (3,)
 
 


### PR DESCRIPTION
## Description

Closes #8190 

This PR introduces the `pm.ZeroOneInflatedBeta` distribution as requested in #8190. 

### Implementation Details
- Implemented `ZeroOneInflatedBeta` utilizing a 3-way `Mixture` under the hood. It accurately captures the continuous boundary masses at exactly `0` and `1`, along with the `Beta` distribution for the continuous middle part `(0, 1)`.
- Exported the new distribution in [pymc/distributions/__init__.py](cci:7://file:///c:/Users/hp/Downloads/pymc/pymc/distributions/__init__.py:0:0-0:0) making it available at the top-level API.

### Testing
- Added targeted tests for the new distribution in [tests/distributions/test_mixture.py](cci:7://file:///c:/Users/hp/Downloads/pymc/tests/distributions/test_mixture.py:0:0-0:0). 
- Tests run and successfully pass for the `zero_one_inflated_beta` cases. 
- **Note:** During tests, a `MixtureTransformWarning` is raised for the default transform on this 3-component mixture. This behavior is expected out of the box unless a custom/default transform policy is explicitly added for this compound distribution in the future.

## Checklist
- [x] Code style is correct (follows `black` & `flake8` guidelines)
- [x] Added tests that cover the new distribution
- [x] Passed local test suite successfully
