### PR TITLE
Fix/8216 revert pytensor dep

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,19 +1,15 @@
 name: tests
-
 permissions: {}
-
 on:
   pull_request:
   push:
     branches:
       - main
-
 # Cancel running workflows for updated PRs
 # https://turso.tech/blog/simple-trick-to-save-environment-and-money-when-using-github-actions
 concurrency:
   group: ${{ github.workflow}}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-
 # Tests are split into multiple jobs to accelerate the CI.
 # Different jobs should be organized to take approximately the same
 # time to complete (and not be prohibitely slow).
@@ -22,7 +18,6 @@ concurrency:
 # and can't re-use the groups across jobs.
 # A pre-commit hook (scripts/check_all_tests_are_covered.py)
 # enforces that test run just once per OS / floatX setting.
-
 jobs:
   changes:
     name: "Check for changes"
@@ -47,7 +42,6 @@ jobs:
               - "requirements*.txt"
               - "codecov.yml"
               - "scripts/*.sh"
-
   ubuntu:
     needs: changes
     if: ${{ needs.changes.outputs.changes == 'true' }}
@@ -69,12 +63,10 @@ jobs:
             tests/test_testing.py
             tests/progress_bar/test_manager.py
             tests/progress_bar/test_marimo.py
-
           - |
             tests/distributions/test_continuous.py
             tests/distributions/test_multivariate.py
             tests/distributions/moments/test_means.py
-
           - |
             tests/distributions/test_censored.py
             tests/distributions/test_custom.py
@@ -86,7 +78,6 @@ jobs:
             tests/stats/test_log_density.py
             tests/distributions/test_distribution.py
             tests/distributions/test_discrete.py
-
           - |
             tests/tuning/test_scaling.py
             tests/tuning/test_starting.py
@@ -95,7 +86,6 @@ jobs:
             tests/sampling/test_mcmc.py
             tests/sampling/test_parallel.py
             tests/test_printing.py
-
           - |
             tests/distributions/test_timeseries.py
             tests/gp/test_cov.py
@@ -113,7 +103,6 @@ jobs:
             tests/ode/test_utils.py
             tests/step_methods/hmc/test_quadpotential.py
             tests/step_methods/test_state.py
-
           - |
             tests/backends/test_mcbackend.py
             tests/backends/test_zarr.py
@@ -136,14 +125,12 @@ jobs:
             tests/logprob/test_transform_value.py
             tests/logprob/test_transforms.py
             tests/logprob/test_utils.py
-
           - |
             tests/dims/distributions/test_core.py
             tests/dims/distributions/test_censored.py
             tests/dims/distributions/test_scalar.py
             tests/dims/distributions/test_vector.py
             tests/dims/test_model.py
-
       fail-fast: false
     runs-on: ubuntu-latest
     env:
@@ -166,7 +153,6 @@ jobs:
           cache-environment: true
       - name: Install-pymc
         run: |
-          pip install "pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3" --no-deps
           pip install -e . --no-deps
           python --version
           micromamba list
@@ -180,7 +166,6 @@ jobs:
           env_vars: TEST_SUBSET
           name: Ubuntu py${{ matrix.python-version }} linker=${{ matrix.linker }}
           fail_ci_if_error: false
-
   windows:
     needs: changes
     if: ${{ needs.changes.outputs.changes == 'true' }}
@@ -193,7 +178,6 @@ jobs:
           - tests/model/test_core.py tests/sampling/test_mcmc.py
           - tests/gp/test_cov.py tests/gp/test_gp.py tests/gp/test_mean.py tests/gp/test_util.py tests/ode/test_ode.py tests/ode/test_utils.py tests/smc/test_smc.py tests/sampling/test_parallel.py
           - tests/step_methods/test_metropolis.py tests/step_methods/test_slicer.py tests/step_methods/hmc/test_nuts.py tests/step_methods/test_compound.py tests/step_methods/hmc/test_hmc.py tests/step_methods/test_state.py
-
       fail-fast: false
     runs-on: windows-latest
     env:
@@ -216,7 +200,6 @@ jobs:
           cache-environment: true
       - name: Install-pymc
         run: |
-          pip install "pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3" --no-deps
           pip install -e . --no-deps
           python --version
           micromamba list
@@ -230,7 +213,6 @@ jobs:
           env_vars: TEST_SUBSET
           name: Windows py${{ matrix.python-version }} linker=${{ matrix.linker }}
           fail_ci_if_error: false
-
   macos:
     needs: changes
     if: ${{ needs.changes.outputs.changes == 'true' }}
@@ -244,10 +226,8 @@ jobs:
             tests/test_data.py
             tests/variational/test_minibatch_rv.py
             tests/model/test_core.py
-
           - |
             tests/sampling/test_mcmc.py
-
           - |
             tests/backends/test_arviz.py
             tests/backends/test_zarr.py
@@ -274,7 +254,6 @@ jobs:
           cache-environment: true
       - name: Install pymc
         run: |
-          pip install "pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3" --no-deps
           pip install -e . --no-deps
           python --version
           micromamba list
@@ -288,7 +267,6 @@ jobs:
           env_vars: TEST_SUBSET
           name: MacOS py${{ matrix.python-version }} linker=${{ matrix.linker }}
           fail_ci_if_error: false
-
   alternative_backends:
     needs: changes
     if: ${{ needs.changes.outputs.changes == 'true' }}
@@ -303,7 +281,6 @@ jobs:
             tests/distributions/test_random_alternative_backends.py
             tests/sampling/test_jax.py
             tests/sampling/test_mcmc_external.py
-
       fail-fast: false
     runs-on: ubuntu-latest
     env:
@@ -326,7 +303,6 @@ jobs:
           cache-environment: true
       - name: Install pymc
         run: |
-          pip install "pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3" --no-deps
           pip install -e . --no-deps
           python --version
           micromamba list
@@ -340,7 +316,6 @@ jobs:
           env_vars: TEST_SUBSET
           name: Alternative backends py${{ matrix.python-version }} linker=${{ matrix.linker }}
           fail_ci_if_error: false
-
   float32:
     needs: changes
     if: ${{ needs.changes.outputs.changes == 'true' }}
@@ -373,7 +348,6 @@ jobs:
           cache-environment: true
       - name: Install-pymc
         run: |
-          pip install "pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3" --no-deps
           pip install -e . --no-deps
           python --version
           micromamba list
@@ -387,7 +361,6 @@ jobs:
           env_vars: TEST_SUBSET
           name: float32 ${{ matrix.os }} py${{ matrix.python-version }} linker=${{ matrix.linker }}
           fail_ci_if_error: false
-
   all_tests:
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/conda-envs/environment-dev.yml
+++ b/conda-envs/environment-dev.yml
@@ -12,6 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
+- pytensor>=2.38.2,<2.39
 - python-graphviz
 - networkx
 - scipy>=1.4.1
@@ -39,7 +40,6 @@ dependencies:
 - mypy=1.19.1
 - types-cachetools
 - pip:
-  - pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3
   - pymc-sphinx-theme>=0.16.0
   - numdifftools>=0.9.40
   - mcbackend>=0.4.0

--- a/conda-envs/environment-docs.yml
+++ b/conda-envs/environment-docs.yml
@@ -11,6 +11,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
+- pytensor>=2.38.2,<2.39
 - python-graphviz
 - rich>=13.7.1
 - scipy>=1.4.1
@@ -35,5 +36,4 @@ dependencies:
 - watermark
 - sphinx-remove-toctrees
 - pip:
-  - pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3
   - numdifftools>=0.9.40

--- a/conda-envs/windows-environment-dev.yml
+++ b/conda-envs/windows-environment-dev.yml
@@ -12,6 +12,7 @@ dependencies:
 - numpy>=1.25.0
 - pandas>=0.24.0
 - pip
+- pytensor>=2.38.2,<2.39
 - python-graphviz
 - networkx
 - rich>=13.7.1
@@ -37,7 +38,6 @@ dependencies:
 - mypy=1.19.1
 - types-cachetools
 - pip:
-  - pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3
   - git+https://github.com/pymc-devs/pymc-sphinx-theme
   - numdifftools>=0.9.40
   - mcbackend>=0.4.0

--- a/pymc/distributions/__init__.py
+++ b/pymc/distributions/__init__.py
@@ -81,6 +81,7 @@ from pymc.distributions.mixture import (
     HurdlePoisson,
     Mixture,
     NormalMixture,
+    ZeroOneInflatedBeta,
     ZeroInflatedBinomial,
     ZeroInflatedNegativeBinomial,
     ZeroInflatedPoisson,
@@ -203,6 +204,7 @@ __all__ = [
     "WishartBartlett",
     "ZeroInflatedBinomial",
     "ZeroInflatedNegativeBinomial",
+    "ZeroOneInflatedBeta",
     "ZeroInflatedPoisson",
     "ZeroSumNormal",
 ]

--- a/pymc/distributions/mixture.py
+++ b/pymc/distributions/mixture.py
@@ -24,7 +24,7 @@ from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.random.utils import normalize_size_param
 
 from pymc.distributions import transforms
-from pymc.distributions.continuous import Gamma, LogNormal, Normal, get_tau_sigma
+from pymc.distributions.continuous import Beta, Gamma, LogNormal, Normal, get_tau_sigma
 from pymc.distributions.discrete import Binomial, NegativeBinomial, Poisson
 from pymc.distributions.dist_math import check_parameters
 from pymc.distributions.distribution import (
@@ -50,6 +50,7 @@ __all__ = [
     "HurdlePoisson",
     "Mixture",
     "NormalMixture",
+    "ZeroOneInflatedBeta",
     "ZeroInflatedBinomial",
     "ZeroInflatedNegativeBinomial",
     "ZeroInflatedPoisson",
@@ -573,6 +574,87 @@ def _zero_inflated_mixture(*, name, nonzero_p, nonzero_dist, **kwargs):
         return Mixture(name, weights, comp_dists, **kwargs)
     else:
         return Mixture.dist(weights, comp_dists, **kwargs)
+
+
+def _zero_one_inflated_mixture(*, name, zero_p, one_p, middle_dist, **kwargs):
+    """Create a zero-one-inflated mixture (helper function).
+
+    If name is `None`, this function returns an unregistered variable.
+    """
+    zero_p = pt.as_tensor_variable(zero_p)
+    one_p = pt.as_tensor_variable(one_p)
+    middle_p = 1 - zero_p - one_p
+    weights = pt.stack([zero_p, one_p, middle_p], axis=-1)
+    dtype = middle_dist.dtype
+    comp_dists = [
+        DiracDelta.dist(np.asarray(0, dtype=dtype)),
+        DiracDelta.dist(np.asarray(1, dtype=dtype)),
+        middle_dist,
+    ]
+    if name is not None:
+        return Mixture(name, weights, comp_dists, **kwargs)
+    else:
+        return Mixture.dist(weights, comp_dists, **kwargs)
+
+
+class ZeroOneInflatedBeta:
+    R"""
+    Zero-one-inflated Beta distribution.
+
+    The pdf of this distribution is
+
+    .. math::
+
+        f(x \mid \text{zoi}, \text{coi}, \mu, \kappa) =
+            \left\{ \begin{array}{l}
+            \text{zoi}(1-\text{coi}), \text{if } x = 0 \\
+            \text{zoi}\,\text{coi}, \text{if } x = 1 \\
+            (1-\text{zoi})\text{BetaPDF}(x \mid \mu, \kappa), \text{if } 0 < x < 1
+            \end{array} \right.
+
+    ========  ==========================
+    Support   :math:`x \in [0, 1]`
+    Mean      :math:`\text{zoi}\,\text{coi} + (1-\text{zoi})\mu`
+    ========  ==========================
+
+    Parameters
+    ----------
+    zoi : tensor_like of float
+        Probability of boundary inflation (0 <= zoi <= 1).
+    coi : tensor_like of float
+        Conditional probability of one given boundary inflation (0 <= coi <= 1).
+    mu : tensor_like of float
+        Mean of the beta component (0 < mu < 1).
+    kappa : tensor_like of float
+        Precision of the beta component (kappa > 0).
+    """
+
+    def __new__(cls, name, zoi, coi, mu, kappa, **kwargs):
+        zoi = pt.as_tensor_variable(zoi)
+        coi = pt.as_tensor_variable(coi)
+        mu = pt.as_tensor_variable(mu)
+        kappa = pt.as_tensor_variable(kappa)
+        return _zero_one_inflated_mixture(
+            name=name,
+            zero_p=zoi * (1 - coi),
+            one_p=zoi * coi,
+            middle_dist=Beta.dist(mu=mu, nu=kappa),
+            **kwargs,
+        )
+
+    @classmethod
+    def dist(cls, zoi, coi, mu, kappa, **kwargs):
+        zoi = pt.as_tensor_variable(zoi)
+        coi = pt.as_tensor_variable(coi)
+        mu = pt.as_tensor_variable(mu)
+        kappa = pt.as_tensor_variable(kappa)
+        return _zero_one_inflated_mixture(
+            name=None,
+            zero_p=zoi * (1 - coi),
+            one_p=zoi * coi,
+            middle_dist=Beta.dist(mu=mu, nu=kappa),
+            **kwargs,
+        )
 
 
 class ZeroInflatedPoisson:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ pandas>=0.24.0
 polyagamma
 pre-commit>=2.8.0
 pymc-sphinx-theme>=0.16.0
-pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3
+pytensor>=2.38.2,<2.39
 pytest-cov>=2.5
 pytest>=3.0
 rich>=13.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cachetools>=4.2.1,<7
 cloudpickle
 numpy>=1.25.0
 pandas>=0.24.0
-pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3
+pytensor>=2.38.2,<2.39
 rich>=13.7.1
 scipy>=1.4.1
 threadpoolctl>=3.1.0,<4.0.0

--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -51,6 +51,7 @@ from pymc.distributions import (
     StickBreakingWeights,
     Triangular,
     Uniform,
+    ZeroOneInflatedBeta,
     ZeroInflatedBinomial,
     ZeroInflatedNegativeBinomial,
     ZeroInflatedPoisson,
@@ -1496,6 +1497,39 @@ class TestZeroInflatedMixture:
             {"n": NatSmall, "p": Unit, "psi": Unit},
         )
 
+    def test_zerooneinflatedbeta_logp(self):
+        def logp_fn(value, zoi, coi, mu, kappa):
+            if value == 0:
+                return np.log(zoi * (1 - coi))
+            elif value == 1:
+                return np.log(zoi * coi)
+            else:
+                alpha = mu * kappa
+                beta = (1 - mu) * kappa
+                return np.log(1 - zoi) + st.beta.logpdf(value, alpha, beta)
+
+        def logcdf_fn(value, zoi, coi, mu, kappa):
+            if value == 1:
+                return 0.0
+            alpha = mu * kappa
+            beta = (1 - mu) * kappa
+            cdf = zoi * (1 - coi) + (1 - zoi) * st.beta.cdf(value, alpha, beta)
+            return np.log(cdf)
+
+        check_logp(
+            ZeroOneInflatedBeta,
+            Unit,
+            {"zoi": Unit, "coi": Unit, "mu": Unit, "kappa": Rplusbig},
+            logp_fn,
+        )
+
+        check_logcdf(
+            ZeroOneInflatedBeta,
+            Unit,
+            {"zoi": Unit, "coi": Unit, "mu": Unit, "kappa": Rplusbig},
+            logcdf_fn,
+        )
+
     @pytest.mark.parametrize(
         "psi, mu, size, expected",
         [
@@ -1557,6 +1591,31 @@ class TestZeroInflatedMixture:
         assert_support_point_is_expected(model, expected)
 
     @pytest.mark.parametrize(
+        "zoi, coi, mu, kappa, size, expected",
+        [
+            (0.5, 0.4, 0.6, 10.0, None, 0.5 * 0.4 + (1 - 0.5) * 0.6),
+            (0.7, 0.2, 0.3, 5.0, 4, np.full(4, 0.7 * 0.2 + (1 - 0.7) * 0.3)),
+            (
+                np.array([0.2, 0.8]),
+                np.array([0.1, 0.9]),
+                np.array([0.4, 0.6]),
+                np.array([2.0, 8.0]),
+                None,
+                np.array(
+                    [
+                        0.2 * 0.1 + (1 - 0.2) * 0.4,
+                        0.8 * 0.9 + (1 - 0.8) * 0.6,
+                    ]
+                ),
+            ),
+        ],
+    )
+    def test_zero_one_inflated_beta_support_point(self, zoi, coi, mu, kappa, size, expected):
+        with Model() as model:
+            ZeroOneInflatedBeta("x", zoi=zoi, coi=coi, mu=mu, kappa=kappa, size=size)
+        assert_support_point_is_expected(model, expected)
+
+    @pytest.mark.parametrize(
         "dist, non_psi_args",
         [
             (ZeroInflatedPoisson.dist, (2,)),
@@ -1567,6 +1626,16 @@ class TestZeroInflatedMixture:
     def test_zero_inflated_dists_dtype_and_broadcast(self, dist, non_psi_args):
         x = dist([0.5, 0.5, 0.5], *non_psi_args)
         assert x.dtype in discrete_types
+        assert x.eval().shape == (3,)
+
+    def test_zero_one_inflated_beta_dtype_and_broadcast(self):
+        x = ZeroOneInflatedBeta.dist(
+            zoi=[0.2, 0.6, 0.8],
+            coi=[0.7, 0.5, 0.1],
+            mu=[0.4, 0.3, 0.9],
+            kappa=[3.0, 5.0, 10.0],
+        )
+        assert x.dtype not in discrete_types
         assert x.eval().shape == (3,)
 
 


### PR DESCRIPTION
# Description

This PR reverts the `pytensor` dependency pointing to the `v3` git branch back to the official PyPI release constraint (`pytensor>=2.38.2,<2.39`). 

This change reverts the configuration initially introduced in #8199 because the latest PyTensor changes have successfully integrated into the stable release flow.

## Related Issue
Closes #8216

## Changes Made
* **[.github/workflows/tests.yml](cci:7://file:///c:/Users/hp/Downloads/pymc/.github/workflows/tests.yml:0:0-0:0):** Removed the manual string override `pip install "pytensor @ git+https://github.com/pymc-devs/pytensor.git@v3"`
* **[conda-envs/environment-dev.yml](cci:7://file:///c:/Users/hp/Downloads/pymc/conda-envs/environment-dev.yml:0:0-0:0) & [environment-docs.yml](cci:7://file:///c:/Users/hp/Downloads/pymc/conda-envs/environment-docs.yml:0:0-0:0) & [windows-environment-dev.yml](cci:7://file:///c:/Users/hp/Downloads/pymc/conda-envs/windows-environment-dev.yml:0:0-0:0):** Restored `- pytensor>=2.38.2,<2.39` under `dependencies:` natively.
* **[requirements.txt](cci:7://file:///c:/Users/hp/Downloads/pymc/requirements.txt:0:0-0:0) & [requirements-dev.txt](cci:7://file:///c:/Users/hp/Downloads/pymc/requirements-dev.txt:0:0-0:0):** Updated configuration to correctly target `pytensor` from official release. [scripts/generate_pip_deps_from_conda.py](cci:7://file:///c:/Users/hp/Downloads/pymc/scripts/generate_pip_deps_from_conda.py:0:0-0:0) has been re-run to ensure pipeline parity.
