### PR TITLE
Unconstrain transform for Wishart

### DIFF
--- a/pymc/distributions/multivariate.py
+++ b/pymc/distributions/multivariate.py
@@ -35,7 +35,7 @@ from pytensor.tensor import (
 )
 from pytensor.tensor.elemwise import DimShuffle
 from pytensor.tensor.exceptions import NotScalarConstantError
-from pytensor.tensor.linalg import det, eigh, solve_triangular, trace
+from pytensor.tensor.linalg import eigh, solve_triangular
 from pytensor.tensor.linalg import inv as matrix_inverse
 from pytensor.tensor.random import chisquare
 from pytensor.tensor.random.basic import MvNormalRV, dirichlet, multinomial, multivariate_normal
@@ -43,12 +43,11 @@ from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.random.utils import (
     normalize_size_param,
 )
-from scipy import stats
 
 import pymc as pm
 
 from pymc.distributions import transforms
-from pymc.distributions.continuous import BoundedContinuous, ChiSquared, Normal
+from pymc.distributions.continuous import BoundedContinuous
 from pymc.distributions.dist_math import (
     betaln,
     check_parameters,
@@ -74,6 +73,7 @@ from pymc.distributions.shape_utils import (
 )
 from pymc.distributions.transforms import (
     CholeskyCorrTransform,
+    CholeskyCovTransform,
     ZeroSumTransform,
     _default_transform,
 )
@@ -910,200 +910,230 @@ def matrix_pos_def(X, tol=1e-8):
     return pt.all(~pt.isnan(diag)) & pt.all(diag > tol)
 
 
-class WishartRV(RandomVariable):
+class WishartRV(SymbolicRandomVariable):
     name = "wishart"
-    signature = "(),(p,p)->(p,p)"
-    dtype = "floatX"
+    extended_signature = "[rng],[size],(),(p,p)->[rng],(p,p)"
     _print_name = ("Wishart", "\\operatorname{Wishart}")
 
+    def update(self, node):
+        return {node.inputs[0]: node.outputs[0]}
+
     @classmethod
-    def rng_fn(cls, rng, nu, V, size):
-        scipy_size = size if size else 1  # Default size for Scipy's wishart.rvs is 1
-        # Scipy doesn't accept batch nu or V
-        nu = _squeeze_to_ndim(nu, 0)
-        V = _squeeze_to_ndim(V, 2)
-        result = stats.wishart.rvs(int(nu), V, size=scipy_size, random_state=rng)
-        if size == (1,):
-            return result[np.newaxis, ...]
+    def rv_op(cls, nu, scale_chol, *, size=None, rng=None):
+        nu = pt.as_tensor_variable(nu, dtype="int64")
+        scale_chol = pt.as_tensor_variable(scale_chol)
+        if scale_chol.type.ndim < 2:
+            raise ValueError("Wishart `scale_chol` must have at least 2 dimensions")
+
+        rng = normalize_rng_param(rng)
+        size = normalize_size_param(size)
+
+        p = scale_chol.shape[-1]
+
+        # Effective batch shape for the inner chi-squared / normal samples.
+        # ``scale_chol`` keeps its original shape; the matmul ``scale_chol @ A``
+        # broadcasts naturally. When the user does not pass an explicit ``size``,
+        # the batch shape is inferred from broadcasting ``nu`` (ndim_supp 0) and
+        # ``scale_chol`` (ndim_supp 2).
+        if rv_size_is_none(size):
+            batch_shape = tuple(implicit_size_from_params(nu, scale_chol, ndims_params=[0, 2]))
         else:
-            return result
+            batch_shape = tuple(size)
 
+        # Bartlett decomposition: A is a (..., p, p) lower-triangular matrix
+        # with ``sqrt(chi^2_{nu - k})`` on the k-th diagonal entry and standard
+        # normals strictly below. Then ``L_X = scale_chol @ A`` is the Cholesky
+        # factor of a ``Wishart(nu, scale_chol scale_chol^T)`` draw, and the
+        # SPD draw is ``L_X L_X^T``. ``nu`` may itself be batched, so we expand
+        # a trailing axis for the per-diagonal subtraction.
+        chi_dofs = nu[..., None] - pt.arange(p, dtype="int64")  # (..., p)
+        next_rng, chi_sq = pt.random.chisquare(
+            df=chi_dofs,
+            size=(*batch_shape, p),
+            rng=rng,
+            return_next_rng=True,
+        )
+        chi_diag = pt.sqrt(chi_sq)  # (..., p)
 
-wishart = WishartRV()
+        n_offdiag = (p * (p - 1)) // 2
+        next_rng, offdiag = pt.random.normal(
+            loc=0.0,
+            scale=1.0,
+            size=(*batch_shape, n_offdiag),
+            rng=next_rng,
+            return_next_rng=True,
+        )
+
+        A = pt.zeros((*batch_shape, p, p), dtype=scale_chol.dtype)
+        diag_idx = pt.arange(p)
+        A = A[..., diag_idx, diag_idx].set(chi_diag)
+        tril_idx = pt.tril_indices(p, k=-1)
+        A = A[..., tril_idx[0], tril_idx[1]].set(offdiag)
+
+        L_X = scale_chol @ A
+        X = L_X @ L_X.mT
+
+        return cls(
+            inputs=[rng, size, nu, scale_chol],
+            outputs=[next_rng, X],
+        )(rng, size, nu, scale_chol)
 
 
 class Wishart(Continuous):
     r"""
     Wishart distribution.
 
-    The Wishart distribution is the probability distribution of the
-    maximum-likelihood estimator (MLE) of the precision matrix of a
-    multivariate normal distribution.  If V=1, the distribution is
-    identical to the chi-square distribution with nu degrees of
-    freedom.
+    The Wishart distribution is the probability distribution over symmetric
+    positive-definite (SPD) matrices that arises as the distribution of the sum
+    of outer products of i.i.d. multivariate normal vectors. If
+    :math:`x_i \sim \mathcal{N}(0, V)` are i.i.d. for :math:`i = 1, \dots, \nu`,
+    then :math:`X = \sum_i x_i x_i^\top \sim \mathrm{Wishart}_p(\nu, V)`.
 
     .. math::
 
-       f(X \mid nu, T) =
-           \frac{{\mid T \mid}^{nu/2}{\mid X \mid}^{(nu-k-1)/2}}{2^{nu k/2}
-           \Gamma_p(nu/2)} \exp\left\{ -\frac{1}{2} Tr(TX) \right\}
+       f(X \mid \nu, V) =
+           \frac{|X|^{(\nu-p-1)/2}}{2^{\nu p / 2} |V|^{\nu / 2} \Gamma_p(\nu / 2)}
+           \exp\left\{ -\frac{1}{2} \operatorname{tr}(V^{-1} X) \right\}
 
-    where :math:`k` is the rank of :math:`X`.
+    where :math:`p` is the rank of :math:`X`.
 
     ========  =========================================
-    Support   :math:`X(p x p)` positive definite matrix
-    Mean      :math:`nu V`
-    Variance  :math:`nu (v_{ij}^2 + v_{ii} v_{jj})`
+    Support   :math:`X\,(p \times p)` positive definite matrix
+    Mean      :math:`\nu V`
+    Variance  :math:`\nu (V_{ij}^2 + V_{ii} V_{jj})`
     ========  =========================================
 
     Parameters
     ----------
     nu : tensor_like of int
-        Degrees of freedom, > 0.
-    V : tensor_like of float
-        p x p positive definite matrix.
+        Degrees of freedom, must satisfy ``nu > p - 1``.
+    V : tensor_like of float, optional
+        ``(p, p)`` SPD scale matrix. Mutually exclusive with ``scale_chol``.
+    scale_chol : tensor_like of float, optional
+        ``(p, p)`` lower-triangular Cholesky factor of the scale matrix
+        (``V = scale_chol @ scale_chol.T``). Provide this when you already have the
+        decomposition to avoid a redundant Cholesky inside ``logp``. Mutually
+        exclusive with ``V``.
 
     Notes
     -----
-    This distribution is unusable in a PyMC model. You should instead
-    use LKJCholeskyCov or LKJCorr.
+    The default unconstraining transform is :class:`CholeskyCovTransform`, which
+    parameterizes ``X = L @ L.T`` from a free real vector with ``log L_kk`` on the
+    diagonal.
     """
 
-    rv_op = wishart
+    rv_type = WishartRV
+    rv_op = WishartRV.rv_op
 
     @classmethod
-    def dist(cls, nu, V, *args, **kwargs):
+    def _resolve_scale(cls, V, scale_chol):
+        if (V is None) == (scale_chol is None):
+            raise ValueError("Wishart requires exactly one of `V` or `scale_chol`.")
+        if scale_chol is not None:
+            return pt.as_tensor_variable(scale_chol)
+        return pt.linalg.cholesky(pt.as_tensor_variable(V))
+
+    @classmethod
+    def dist(cls, nu, V=None, *args, scale_chol=None, **kwargs):
         nu = pt.as_tensor_variable(nu, dtype=int)
-        V = pt.as_tensor_variable(V)
+        scale_chol = cls._resolve_scale(V, scale_chol)
+        return super().dist([nu, scale_chol], *args, **kwargs)
 
-        warnings.warn(
-            "The Wishart distribution can currently not be used "
-            "for MCMC sampling. The probability of sampling a "
-            "symmetric matrix is basically zero. Instead, please "
-            "use LKJCholeskyCov or LKJCorr. For more information "
-            "on the issues surrounding the Wishart see here: "
-            "https://github.com/pymc-devs/pymc/issues/538.",
-            UserWarning,
-        )
+    def support_point(rv, size, nu, scale_chol):
+        # Mean of Wishart(nu, V) is nu * V = nu * (L_V @ L_V.T). Always in the
+        # SPD support for valid nu > p - 1, so it's a safe initial point.
+        V = scale_chol @ scale_chol.mT
+        support_point = nu.astype(V.dtype) * V
+        if not rv_size_is_none(size):
+            p = scale_chol.shape[-1]
+            support_point = pt.full(pt.concatenate([size, [p, p]]), support_point)
+        return support_point
 
-        # mean = nu * V
-        # p = V.shape[0]
-        # mode = pt.switch(pt.ge(nu, p + 1), (nu - p - 1) * V, np.nan)
-        return super().dist([nu, V], *args, **kwargs)
-
-    def logp(X, nu, V):
+    def logp(X, nu, scale_chol):
         """
-        Calculate logp of Wishart distribution at specified value.
+        Log-density of the Wishart distribution at the SPD value ``X``.
 
-        Parameters
-        ----------
-        X: numeric
-            Value for which log-probability is calculated.
-
-        Returns
-        -------
-        TensorVariable
+        Implemented in Cholesky form: when the value comes from the unconstraining
+        ``CholeskyCovTransform``, ``cholesky(L @ L.T)`` rewrites to ``L`` and no
+        decomposition runs at runtime.
         """
-        p = V.shape[0]
+        p = X.shape[-1]
 
-        IVI = det(V)
-        IXI = det(X)
+        L_X = pt.linalg.cholesky(X)
+        log_det_X = 2 * pt.sum(pt.log(pt.diagonal(L_X, axis1=-2, axis2=-1)), axis=-1)
+        log_det_V = 2 * pt.sum(pt.log(pt.diagonal(scale_chol, axis1=-2, axis2=-1)), axis=-1)
+        # tr(V^{-1} X) = ||L_V^{-1} L_X||_F^2  via a triangular solve.
+        M = solve_triangular(scale_chol, L_X, lower=True)
+        tr_term = pt.sum(M**2, axis=(-2, -1))
 
         return check_parameters(
             (
-                (nu - p - 1) * pt.log(IXI)
-                - trace(matrix_inverse(V).dot(X))
+                (nu - p - 1) * log_det_X
+                - tr_term
                 - nu * p * pt.log(2)
-                - nu * pt.log(IVI)
+                - nu * log_det_V
                 - 2 * multigammaln(nu / 2.0, p)
             )
             / 2,
-            matrix_pos_def(X),
-            pt.eq(X, X.T),
             nu > (p - 1),
+            msg="nu > p - 1",
         )
+
+
+@_default_transform.register(WishartRV)
+def wishart_default_transform(op, rv):
+    _, _, _, scale_chol = rv.owner.inputs
+    n = scale_chol.shape[-1]
+    return CholeskyCovTransform(n=n)
 
 
 def WishartBartlett(name, S, nu, is_cholesky=False, return_cholesky=False, initval=None):
     r"""
-    Bartlett decomposition of the Wishart distribution.
+    Bartlett-decomposed Wishart prior. **Deprecated**: use :class:`Wishart` directly.
 
-    As the Wishart distribution requires the matrix to be symmetric positive
-    semi-definite, it is impossible for MCMC to ever propose acceptable matrices.
-
-    Instead, we can use the Barlett decomposition which samples a lower
-    diagonal matrix. Specifically:
-
-    .. math::
-        \text{If} L \sim \begin{pmatrix}
-        \sqrt{c_1} & 0 & 0 \\
-        z_{21} & \sqrt{c_2} & 0 \\
-        z_{31} & z_{32} & \sqrt{c_3}
-        \end{pmatrix}
-
-        \text{with} c_i \sim \chi^2(n-i+1) \text{ and } n_{ij} \sim \mathcal{N}(0, 1), \text{then} \\
-        L \times A \times A.T \times L.T \sim \text{Wishart}(L \times L.T, \nu)
-
-    See http://en.wikipedia.org/wiki/Wishart_distribution#Bartlett_decomposition
-    for more information.
+    This used to be the only MCMC-usable Wishart in PyMC, since the legacy
+    :class:`Wishart` had no unconstraining transform. The new :class:`Wishart`
+    is parameterized through its Cholesky factor with a default
+    :class:`CholeskyCovTransform`, so this helper is no longer needed and is
+    a thin shim around it for backward compatibility.
 
     Parameters
     ----------
     S : ndarray
-        p x p positive definite matrix
-        Or:
-        p x p lower-triangular matrix that is the Cholesky factor
-        of the covariance matrix.
+        ``(p, p)`` positive-definite scale matrix, or its lower-triangular
+        Cholesky factor when ``is_cholesky=True``.
     nu : tensor_like of int
-        Degrees of freedom, > dim(S).
-    is_cholesky : bool, default=False
-        Input matrix S is already Cholesky decomposed as S.T * S
-    return_cholesky : bool, default=False
-        Only return the Cholesky decomposed matrix.
-    initval : ndarray
-        p x p positive definite matrix used to initialize
-
-    Notes
-    -----
-    This is not a standard Distribution class but follows a similar
-    interface. Besides the Wishart distribution, it will add RVs
-    name_c and name_z to your model which make up the matrix.
-
-    This distribution is usually a bad idea to use as a prior for multivariate
-    normal. You should instead use LKJCholeskyCov or LKJCorr.
+        Degrees of freedom, > ``dim(S) - 1``.
+    is_cholesky : bool, default False
+        If True, ``S`` is interpreted as the Cholesky factor of the scale matrix
+        (mapped to :class:`Wishart`'s ``scale_chol`` argument).
+    return_cholesky : bool, default False
+        If True, return the Cholesky factor of the Wishart draw rather than the
+        SPD matrix itself.
     """
-    L = S if is_cholesky else scipy.linalg.cholesky(S)
-    diag_idx = np.diag_indices_from(S)
-    tril_idx = np.tril_indices_from(S, k=-1)
-    n_diag = len(diag_idx[0])
-    n_tril = len(tril_idx[0])
-
-    if initval is not None:
-        # Inverse transform
-        initval = np.dot(np.dot(np.linalg.inv(L), initval), np.linalg.inv(L.T))
-        initval = scipy.linalg.cholesky(initval, lower=True)
-        diag_testval = initval[diag_idx] ** 2
-        tril_testval = initval[tril_idx]
-    else:
-        diag_testval = None
-        tril_testval = None
-
-    c = pt.sqrt(
-        ChiSquared(f"{name}_c", nu - np.arange(2, 2 + n_diag), shape=n_diag, initval=diag_testval)
+    warnings.warn(
+        "WishartBartlett is deprecated and will be removed in a future release. "
+        "Use pm.Wishart directly. For `is_cholesky=True`, pass `scale_chol=S`. "
+        "For `return_cholesky=True`, wrap pm.Wishart in pt.linalg.cholesky as a "
+        "Deterministic.",
+        FutureWarning,
+        stacklevel=2,
     )
-    pm._log.info(f"Added new variable {name}_c to model diagonal of Wishart.")
-    z = Normal(f"{name}_z", 0.0, 1.0, shape=n_tril, initval=tril_testval)
-    pm._log.info(f"Added new variable {name}_z to model off-diagonals of Wishart.")
-    # Construct A matrix
-    A = pt.zeros(S.shape, dtype=np.float32)
-    A = pt.set_subtensor(A[diag_idx], c)
-    A = pt.set_subtensor(A[tril_idx], z)
-
-    # L * A * A.T * L.T ~ Wishart(L*L.T, nu)
+    if initval is not None:
+        # The legacy implementation seeded two internal RVs (diagonal `_c` and
+        # off-diagonal `_z` Bartlett components), so the old `initval` has no
+        # faithful translation to the new SPD-valued Wishart. Forcing the user
+        # to pass an initval on `pm.Wishart` directly is safer than silently
+        # re-interpreting the value.
+        raise NotImplementedError(
+            "`initval` is no longer supported in the WishartBartlett shim. "
+            "Pass `initval` (as an SPD matrix) to `pm.Wishart` directly."
+        )
+    scale_kwargs = {"scale_chol": S} if is_cholesky else {"V": S}
     if return_cholesky:
-        return pm.Deterministic(name, pt.dot(L, A))
-    else:
-        return pm.Deterministic(name, pt.dot(pt.dot(pt.dot(L, A), A.T), L.T))
+        wishart_rv = Wishart(f"_{name}_wishart", nu=nu, **scale_kwargs)
+        return pm.Deterministic(name, pt.linalg.cholesky(wishart_rv))
+    return Wishart(name, nu=nu, **scale_kwargs)
 
 
 def _lkj_normalizing_constant(eta, n):

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -33,15 +33,11 @@ from pymc.logprob.transforms import (
 
 __all__ = [
     "Chain",
-    "Chain",
     "CholeskyCorrTransform",
-    "CholeskyCovPacked",
     "CholeskyCovPacked",
     "Interval",
     "Transform",
     "ZeroSumTransform",
-    "ZeroSumTransform",
-    "circular",
     "circular",
     "log",
     "log_exp_m1",

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -35,6 +35,7 @@ __all__ = [
     "Chain",
     "CholeskyCorrTransform",
     "CholeskyCovPacked",
+    "CholeskyCovTransform",
     "Interval",
     "Transform",
     "ZeroSumTransform",
@@ -443,6 +444,95 @@ class CholeskyCovPacked(Transform):
 
     def log_jac_det(self, value, *inputs):
         return pt.sum(value[..., self.diag_idxs], axis=-1)
+
+
+class CholeskyCovTransform(Transform):
+    r"""Map an unconstrained real vector to a symmetric positive-definite (SPD) matrix.
+
+    Constrained space: ``(n, n)`` SPD matrix ``X``.
+    Unconstrained space: ``(n*(n+1)/2,)`` flat real vector packed in row-major
+    lower-triangular order.
+
+    The transform composes two steps:
+
+    1. Reshape the flat vector into a lower-triangular matrix ``L``, exponentiating
+       the diagonal entries (so ``L_kk > 0``).
+    2. Form ``X = L @ L.T``, the SPD matrix.
+
+    The lower-triangular ``L`` produced inside ``backward`` is tagged with
+    ``lower_triangular = True`` so PyTensor's ``cholesky_ldotlt`` rewrite eliminates
+    any subsequent ``cholesky(L @ L.T)`` calls (e.g. inside a Cholesky-based
+    ``Wishart.logp``), avoiding a redundant decomposition at runtime.
+
+    The Jacobian of the composite map (free reals :math:`\to L \to L L^\top`) is
+
+    .. math::
+
+        |J| = \prod_k L_{kk} \cdot 2^n \cdot \prod_k L_{kk}^{n-k+1}
+            = 2^n \cdot \prod_k L_{kk}^{n-k+2}.
+
+    With :math:`y_{kk} = \log L_{kk}` the diagonal entries of the unconstrained
+    vector, the log-Jacobian is
+
+    .. math::
+
+        \log |J| = n \log 2 + \sum_{k=1}^{n} (n - k + 2)\, y_{kk}.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        import numpy as np
+        import pytensor.tensor as pt
+        from pymc.distributions.transforms import CholeskyCovTransform
+
+        tr = CholeskyCovTransform(n=3)
+        unconstrained = pt.as_tensor(np.array([0.0, 0.5, 0.0, 0.2, -0.1, 0.0]))
+        Sigma = tr.backward(unconstrained)
+        # Sigma is a (3, 3) SPD matrix.
+    """
+
+    name = "cholesky-cov"
+
+    def __init__(self, n):
+        """Create a CholeskyCovTransform.
+
+        Parameters
+        ----------
+        n : int or TensorLike
+            Side length of the SPD matrix.
+        """
+        self.n = n
+        self.diag_idxs = pt.arange(1, n + 1).cumsum() - 1
+        self.tril_idxs = pt.tril_indices(n)
+
+    def backward(self, value, *inputs):
+        value = pt.as_tensor_variable(value)
+        # Exponentiate the diagonal entries so L has positive diagonal.
+        value_pos = value[..., self.diag_idxs].set(pt.exp(value[..., self.diag_idxs]))
+        # Scatter into a (..., n, n) lower-triangular matrix L.
+        n = self.n
+        L_shape = (*value.shape[:-1], n, n)
+        L = pt.zeros(L_shape, dtype=value.dtype)
+        L = L[..., self.tril_idxs[0], self.tril_idxs[1]].set(value_pos)
+        # Tag L as lower-triangular so cholesky(L @ L.mT) → L is rewritten away.
+        L.tag.lower_triangular = True
+        return L @ L.mT
+
+    def forward(self, value, *inputs):
+        value = pt.as_tensor_variable(value)
+        L = pt.linalg.cholesky(value)
+        flat = L[..., self.tril_idxs[0], self.tril_idxs[1]]
+        # log the diagonal entries to make them unconstrained.
+        return flat[..., self.diag_idxs].set(pt.log(flat[..., self.diag_idxs]))
+
+    def log_jac_det(self, value, *inputs):
+        value = pt.as_tensor_variable(value)
+        n = self.n
+        log_diag = value[..., self.diag_idxs]
+        coeffs = pt.arange(n + 1, 1, -1).astype(value.dtype)
+        return n * pt.log(2.0) + pt.sum(coeffs * log_diag, axis=-1)
 
 
 Chain = ChainedTransform

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -1078,14 +1078,8 @@ class BaseTestDistributionRandom:
     random_state = None
 
     def test_distribution(self):
-        import pytest
-
         self.validate_tests_list()
-        if self.pymc_dist == pm.Wishart:
-            with pytest.warns(UserWarning, match="can currently not be used for MCMC sampling"):
-                self._instantiate_pymc_rv()
-        else:
-            self._instantiate_pymc_rv()
+        self._instantiate_pymc_rv()
         if self.reference_dist is not None:
             self.reference_dist_draws = self.reference_dist()(
                 size=self.size, **self.reference_dist_params
@@ -1095,11 +1089,7 @@ class BaseTestDistributionRandom:
                 raise ValueError(
                     "Custom check cannot start with `test_` or else it will be executed twice."
                 )
-            if self.pymc_dist == pm.Wishart and check_name.startswith("check_rv_size"):
-                with pytest.warns(UserWarning, match="can currently not be used for MCMC sampling"):
-                    getattr(self, check_name)()
-            else:
-                getattr(self, check_name)()
+            getattr(self, check_name)()
 
     def get_random_state(self, reset=False):
         if self.random_state is None or reset:

--- a/tests/distributions/test_distribution.py
+++ b/tests/distributions/test_distribution.py
@@ -115,11 +115,6 @@ def test_all_distributions_have_support_points():
         dist_module.timeseries.EulerMaruyama,
     }
 
-    # Distributions that have been refactored but don't yet have support_points
-    not_implemented |= {
-        dist_module.multivariate.Wishart,
-    }
-
     unexpected_implemented = not_implemented - missing_support_points
     if unexpected_implemented:
         raise Exception(

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -24,8 +24,9 @@ import scipy.special as sp
 import scipy.stats as st
 
 from pytensor import tensor as pt
+from pytensor.compile.mode import get_mode
 from pytensor.tensor import TensorVariable
-from pytensor.tensor.blockwise import Blockwise
+from pytensor.tensor.blockwise import Blockwise, BlockwiseWithCoreShape
 from pytensor.tensor.linalg.decomposition.cholesky import Cholesky
 from pytensor.tensor.linalg.inverse import MatrixInverse
 from pytensor.tensor.random.basic import multivariate_normal
@@ -548,13 +549,12 @@ class TestMatchesScipy:
 
     @pytest.mark.parametrize("n", [2, 3])
     def test_wishart(self, n):
-        with pytest.warns(UserWarning, match="Wishart distribution can currently not be used"):
-            check_logp(
-                pm.Wishart,
-                PdMatrix(n),
-                {"nu": Domain([0, 3, 4, np.inf], "int64"), "V": PdMatrix(n)},
-                lambda value, nu, V: st.wishart.logpdf(value, int(nu), V),
-            )
+        check_logp(
+            pm.Wishart,
+            PdMatrix(n),
+            {"nu": Domain([0, 3, 4, np.inf], "int64"), "V": PdMatrix(n)},
+            lambda value, nu, V: st.wishart.logpdf(value, int(nu), V),
+        )
 
     @pytest.mark.parametrize("x_tri,eta,n,lp", LKJ_CASES)
     def test_lkjcorr(self, x_tri, eta, n, lp):
@@ -1995,32 +1995,100 @@ class TestStickBreakingWeights_1D_alpha(BaseTestDistributionRandom):
 
 
 class TestWishart(BaseTestDistributionRandom):
-    def wishart_rng_fn(self, size, nu, V, rng):
-        return st.wishart.rvs(int(nu), V, size=size, random_state=rng)
-
     pymc_dist = pm.Wishart
 
-    V = np.eye(3)
-    pymc_dist_params = {"nu": 4, "V": V}
-    reference_dist_params = {"nu": 4, "V": V}
-    expected_rv_op_params = {"nu": 4, "V": V}
+    V = np.eye(3) + 0.1 * np.ones((3, 3))
+    scale_chol = np.linalg.cholesky(V)
+    pymc_dist_params = {"nu": 4, "scale_chol": scale_chol}
+    expected_rv_op_params = {"nu": 4, "scale_chol": scale_chol}
     sizes_to_check = [None, 1, (4, 5)]
     sizes_expected = [
         (3, 3),
         (1, 3, 3),
         (4, 5, 3, 3),
     ]
-    reference_dist = lambda self: ft.partial(self.wishart_rng_fn, rng=self.get_random_state())  # noqa: E731
     checks_to_run = [
         "check_rv_size",
         "check_pymc_params_match_rv_op",
-        "check_pymc_draws_match_reference",
+        "check_random_matches_moments",
+        "check_random_matches_scipy",
         "check_rv_size_batched_params",
+        "check_param_validation",
     ]
 
+    def check_random_matches_moments(self):
+        """Verify the sampler produces draws with the right first two moments.
+
+        For ``X ~ Wishart(nu, V)`` the closed forms are
+        ``E[X_ij] = nu * V_ij`` and
+        ``Var(X_ij) = nu * (V_ij^2 + V_ii V_jj)``.
+        Neither depends on the Bartlett internals, so passing this gives
+        independent confirmation that the sampler is correct.
+        """
+        nu = 5
+        rng = np.random.default_rng(20240409)
+        # Non-trivial SPD scale to exercise off-diagonal entries.
+        A = rng.normal(size=(3, 3))
+        V = A @ A.T + 3 * np.eye(3)
+
+        n_draws = 20_000
+        draws = pm.draw(pm.Wishart.dist(nu=nu, V=V, size=n_draws), random_seed=20240409)
+        assert draws.shape == (n_draws, 3, 3)
+
+        # Closed-form moments.
+        expected_mean = nu * V
+        expected_entry_var = nu * (V**2 + np.outer(np.diag(V), np.diag(V)))
+
+        # First moment z-score: compare the sample mean's deviation from the
+        # expected value to its analytical standard error. With n_draws=20k,
+        # ~5 stderrs is overwhelmingly conservative for 9 independent entries.
+        se_mean = np.sqrt(expected_entry_var / n_draws)
+        z_mean = (draws.mean(axis=0) - expected_mean) / se_mean
+        npt.assert_array_less(np.abs(z_mean), 5.0)
+
+        # Second moment, same scheme. The SE of the sample variance scales
+        # like sqrt(2/n_draws) times the entry variance for near-Gaussian
+        # marginals — the Wishart entries are not Gaussian, so we use a
+        # somewhat looser bound here.
+        se_var = expected_entry_var * np.sqrt(2.0 / n_draws)
+        z_var = (draws.var(axis=0) - expected_entry_var) / se_var
+        npt.assert_array_less(np.abs(z_var), 6.0)
+
+    def check_random_matches_scipy(self):
+        """Entry-wise 2-sample KS against ``scipy.stats.wishart``.
+
+        Complements ``check_random_matches_moments`` (which checks closed-form
+        first and second moments) by comparing the full marginal distribution
+        of each unique entry against scipy's reference sampler.
+        """
+        nu = 6
+        rng = np.random.default_rng(20240410)
+        A = rng.normal(size=(3, 3))
+        V = A @ A.T + 3 * np.eye(3)
+
+        n_draws = 1_000
+        draws = pm.draw(pm.Wishart.dist(nu=nu, V=V, size=n_draws), random_seed=20240410)
+        ref = st.wishart(df=nu, scale=V).rvs(size=n_draws, random_state=20240411)
+
+        # Compare each unique entry (upper triangle including diagonal).
+        p = V.shape[-1]
+        iu = np.triu_indices(p)
+        p_values = [st.ks_2samp(draws[:, i, j], ref[:, i, j]).pvalue for i, j in zip(*iu)]
+        # Bonferroni-corrected threshold across the p(p+1)/2 entries.
+        assert min(p_values) > 0.001 / len(p_values)
+
+    def check_param_validation(self):
+        """``V`` and ``scale_chol`` are mutually exclusive."""
+        with pytest.raises(ValueError, match="exactly one of"):
+            pm.Wishart.dist(nu=5, V=np.eye(3), scale_chol=np.eye(3))
+        with pytest.raises(ValueError, match="exactly one of"):
+            pm.Wishart.dist(nu=5)
+
     def check_rv_size_batched_params(self):
+        # The Bartlett-based SymbolicRV supports batched scale matrices natively.
         for size in (None, (2,), (1, 2), (4, 3, 2)):
-            x = pm.Wishart.dist(nu=4, V=np.stack([np.eye(3), np.eye(3)]), size=size)
+            L = np.linalg.cholesky(np.stack([np.eye(3), np.eye(3)]))
+            x = pm.Wishart.dist(nu=4, scale_chol=L, size=size)
 
             if size is None:
                 expected_shape = (2, 3, 3)
@@ -2028,11 +2096,17 @@ class TestWishart(BaseTestDistributionRandom):
                 expected_shape = (*size, 3, 3)
 
             assert tuple(x.shape.eval()) == expected_shape
+            assert x.eval().shape == expected_shape
 
-            # RNG does not currently support batched parameters, whet it does this test
-            # should be updated to check that draws also have the expected shape
-            with pytest.raises(ValueError):
-                x.eval()
+
+class TestWishartV(BaseTestDistributionRandom):
+    pymc_dist = pm.Wishart
+
+    V = np.eye(3) + 0.1 * np.ones((3, 3))
+    L_V = np.linalg.cholesky(V)
+    pymc_dist_params = {"nu": 4, "V": V}
+    expected_rv_op_params = {"nu": 4, "scale_chol": L_V}
+    checks_to_run = ["check_pymc_params_match_rv_op"]
 
 
 class TestMatrixNormal(BaseTestDistributionRandom):
@@ -2396,6 +2470,53 @@ def test_mvnormal_no_cholesky_in_model_logp():
 
     logp_dlogp = m.logp_dlogp_function(ravel_inputs=True)
     assert not contains_cholesky_op(logp_dlogp._pytensor_function.maker.fgraph)
+
+
+def test_wishart_no_cholesky_in_model_logp():
+    """The Cholesky-based Wishart logp must not retain a Cholesky op for free RVs.
+
+    The default ``CholeskyCovTransform`` produces ``L @ L.T`` with ``L`` tagged as
+    lower-triangular, so PyTensor's ``cholesky_ldotlt`` rewrite folds the apparent
+    ``cholesky(L @ L.T)`` round trip in ``Wishart.logp`` back to ``L``. This test
+    locks in that property; if it fails the architecture has degraded and a custom
+    ``_logprob`` dispatcher is needed instead.
+    """
+    n = 3
+    with pm.Model() as m:
+        pm.Wishart("Sigma", nu=5, V=np.eye(n))
+
+    def fgraph_of(fn):
+        # PointFunc exposes the compiled pytensor function as `.f`,
+        # while ValueGradFunction (from logp_dlogp_function) uses `_pytensor_function`.
+        compiled = getattr(fn, "f", None) or fn._pytensor_function
+        return compiled.maker.fgraph
+
+    def contains_cholesky_op(fn):
+        return any(
+            isinstance(node.op, Cholesky)
+            or (
+                isinstance(node.op, Blockwise | BlockwiseWithCoreShape)
+                and isinstance(node.op.core_op, Cholesky)
+            )
+            for node in fgraph_of(fn).apply_nodes
+        )
+
+    # Negative control: when ``cholesky_ldotlt`` is excluded from the compilation
+    # mode (and only that rewrite), the optimized logp graph still contains a
+    # Cholesky op. This proves the test is sensitive to the rewrite firing.
+    no_rewrite_mode = get_mode().excluding("cholesky_ldotlt")
+    assert contains_cholesky_op(m.compile_logp(mode=no_rewrite_mode))
+
+    # The actual lock for logp.
+    assert not contains_cholesky_op(m.compile_logp())
+
+    # For dlogp / logp_dlogp the negative control via ``excluding`` does not
+    # work: PyTensor runs ``rewrite_pregrad`` (which includes cholesky_ldotlt)
+    # before the gradient is taken, so the rewrite still fires regardless of
+    # the final compilation mode. We just assert the optimized graphs stay
+    # Cholesky-free.
+    assert not contains_cholesky_op(m.compile_dlogp())
+    assert not contains_cholesky_op(m.logp_dlogp_function(ravel_inputs=True))
 
 
 def test_mvnormal_blockwise_solve_opt():

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -790,3 +790,81 @@ class TestLJKCholeskyCorrTransform:
         # Check for positive semi-definiteness
         eigenvalues = np.linalg.eigvalsh(corr)
         assert np.all(eigenvalues >= -1e-6)
+
+
+class TestCholeskyCovTransform:
+    def _get_test_values(self):
+        # L = [[1, 0, 0], [0.5, 1.5, 0], [-0.3, 0.2, 0.8]]; Sigma = L @ L.T
+        x_unconstrained = np.array(
+            [0.0, 0.5, np.log(1.5), -0.3, 0.2, np.log(0.8)], dtype=config.floatX
+        )
+        L = np.array([[1.0, 0.0, 0.0], [0.5, 1.5, 0.0], [-0.3, 0.2, 0.8]], dtype=config.floatX)
+        x_constrained = (L @ L.T).astype(config.floatX)
+        return x_unconstrained, x_constrained
+
+    def test_forward(self):
+        transform = tr.CholeskyCovTransform(n=3)
+        x_unconstrained, x_constrained = self._get_test_values()
+
+        np.testing.assert_allclose(
+            transform.forward(x_constrained).eval(),
+            x_unconstrained,
+            atol=1e-6,
+        )
+
+    def test_backward(self):
+        transform = tr.CholeskyCovTransform(n=3)
+        x_unconstrained, x_constrained = self._get_test_values()
+
+        np.testing.assert_allclose(
+            transform.backward(x_unconstrained).eval(),
+            x_constrained,
+            atol=1e-6,
+        )
+
+    def test_transform_round_trip(self):
+        transform = tr.CholeskyCovTransform(n=3)
+        x_unconstrained, x_constrained = self._get_test_values()
+
+        constrained_reconstructed = transform.backward(transform.forward(x_constrained)).eval()
+        unconstrained_reconstructed = transform.forward(transform.backward(x_unconstrained)).eval()
+
+        np.testing.assert_allclose(x_unconstrained, unconstrained_reconstructed, atol=1e-6)
+        np.testing.assert_allclose(x_constrained, constrained_reconstructed, atol=1e-6)
+
+    def test_log_jac_det(self):
+        transform = tr.CholeskyCovTransform(n=3)
+        x_unconstrained, _ = self._get_test_values()
+
+        computed_log_jac_det = transform.log_jac_det(x_unconstrained).eval()
+
+        # Autodiff: form the SPD output, take its lower-triangular packing
+        # (the constrained-space free coordinates), and compute the determinant
+        # of the Jacobian w.r.t. the unconstrained vector.
+        x = pt.tensor("x", shape=(6,))
+        Sigma = transform.backward(x)
+        tril_idx = pt.tril_indices(3)
+        constrained_free = Sigma[tril_idx[0], tril_idx[1]]
+        jac = pt.jacobian(constrained_free, x, vectorize=True)
+        _, autodiff_log_jac_det = pt.linalg.slogdet(jac)
+
+        np.testing.assert_allclose(
+            autodiff_log_jac_det.eval({x: x_unconstrained}),
+            computed_log_jac_det,
+            atol=1e-6,
+        )
+
+    @pytest.mark.parametrize("n", [3, 5, 10])
+    def test_backward_produces_valid_spd_matrix(self, n):
+        rng = np.random.default_rng()
+        n_samples = 5
+        n_packed = n * (n + 1) // 2
+
+        transform = tr.CholeskyCovTransform(n=n)
+        x_unconstrained = rng.normal(size=(n_samples, n_packed))
+
+        Sigma = transform.backward(x_unconstrained).eval()
+
+        np.testing.assert_allclose(Sigma, np.swapaxes(Sigma, -1, -2), atol=1e-6)
+        eigenvalues = np.linalg.eigvalsh(Sigma)
+        assert np.all(eigenvalues > 0)


### PR DESCRIPTION
Similar idea as #7380 (but this is actually simpler). Almost the same rewrite as LKJCholeskyCov, except here we unconstrain to the full dense matrix.

Closes https://github.com/pymc-devs/pymc/issues/8196 (it's now usable)