### PR TITLE
Make nutpie the default nuts sampler (if installed)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -328,6 +328,9 @@ jobs:
         run: |
           pip install "pytensor @ git+https://github.com/pymc-devs/pytensor.git@main" --no-deps
           pip install -e . --no-deps
+          # Track nutpie main so we exercise unreleased changes. Expected to be
+          # red until nutpie main drops its `arviz.InferenceData` references.
+          pip install "nutpie @ git+https://github.com/pymc-devs/nutpie@main"
           python --version
           micromamba list
       - name: Run tests

--- a/conda-envs/environment-alternative-backends.yml
+++ b/conda-envs/environment-alternative-backends.yml
@@ -11,7 +11,8 @@ dependencies:
 - cloudpickle
 - zarr>=2.5.0,<3
 - numba
-- nutpie >= 0.15.1
+# nutpie is installed from git in the CI workflow (see tests.yml) so we can track
+# the arviz 1.0 -compatible branch until an upstream release ships.
 # Jaxlib version must not be greater than jax version!
 - jax>=0.4.28
 - jaxlib>=0.4.28

--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -28,7 +28,7 @@ from typing import (
 import numpy as np
 import xarray
 
-from arviz_base import dict_to_dataset, rcParams
+from arviz_base import dict_to_dataset, make_attrs, rcParams
 from arviz_base.base import requires
 from arviz_base.types import CoordSpec, DimSpec
 from pytensor.graph import ancestors
@@ -42,7 +42,7 @@ import pymc
 from pymc.model import Model, modelcontext
 from pymc.progress_bar import CustomProgress, default_progress_theme
 from pymc.pytensorf import PointFunc, extract_obs_data
-from pymc.util import get_default_varnames
+from pymc.util import get_default_varnames, get_untransformed_name, is_transformed_name
 
 if TYPE_CHECKING:
     from pymc.backends.base import MultiTrace
@@ -136,6 +136,74 @@ def find_constants(model: "Model") -> dict[str, Var]:
         constant_data[var.name] = var_value
 
     return constant_data
+
+
+def patch_nutpie_idata(
+    idata: DataTree,
+    model: "Model",
+    tune: int,
+    sampling_time: float,
+    include_transformed: bool = False,
+) -> None:
+    """Fix up the ``DataTree`` returned by ``nutpie.sample`` in place.
+
+    Work-around for gaps in what nutpie attaches to the returned ``DataTree``:
+
+    - drops transformed variables from ``posterior`` / ``warmup_posterior``
+      (when ``include_transformed`` is ``False``) or moves them into
+      ``unconstrained_posterior`` / ``warmup_unconstrained_posterior``
+      (when ``True``). Drop once
+      https://github.com/pymc-devs/nutpie/pull/298 and
+      https://github.com/pymc-devs/nutpie/issues/78 are released;
+    - attaches ``constant_data`` / ``observed_data`` groups gathered from the
+      model. Drop once https://github.com/pymc-devs/nutpie/issues/74 is released;
+    - stamps ``sampling_time`` / ``tuning_steps`` attrs onto the posterior.
+    """
+    import nutpie
+
+    for src, dst in (
+        ("posterior", "unconstrained_posterior"),
+        ("warmup_posterior", "warmup_unconstrained_posterior"),
+    ):
+        if src not in idata.children:
+            continue
+        ds = idata[src].to_dataset()
+        transformed = [v for v in ds.data_vars if is_transformed_name(v)]
+        if not transformed:
+            continue
+        idata[src] = DataTree(ds.drop_vars(transformed))
+        if include_transformed:
+            unconstrained = ds[transformed].rename(
+                {v: get_untransformed_name(v) for v in transformed}
+            )
+            idata[dst] = DataTree(unconstrained)
+
+    coords, dims = coords_and_dims_for_inferencedata(model)
+    idata["constant_data"] = DataTree(
+        dict_to_dataset(
+            find_constants(model),
+            inference_library=pymc,
+            coords=coords,
+            dims=dims,  # type: ignore[arg-type]
+            sample_dims=[],
+        )
+    )
+    idata["observed_data"] = DataTree(
+        dict_to_dataset(
+            find_observations(model),
+            inference_library=pymc,
+            coords=coords,
+            dims=dims,  # type: ignore[arg-type]
+            sample_dims=[],
+        )
+    )
+
+    attrs = make_attrs(
+        {"sampling_time": sampling_time, "tuning_steps": tune},
+        inference_library=nutpie,
+    )
+    for k, v in attrs.items():
+        idata.posterior.attrs[k] = v
 
 
 def coords_and_dims_for_inferencedata(model: Model) -> tuple[dict[str, Any], dict[str, Any]]:

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -63,6 +63,7 @@ from pymc.pytensorf import (
     gradient,
     hessian,
     join_nonshared_inputs,
+    resolve_backend_compile_kwargs,
     rewrite_pregrad,
 )
 from pymc.util import (
@@ -1668,6 +1669,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
         n=1000,
         point=None,
         profile=True,
+        backend=None,
         **compile_fn_kwargs,
     ) -> ProfileStats:
         """Compile and profile a PyTensor function which returns ``outs`` and takes values of model vars as a dict as an argument.
@@ -1680,6 +1682,8 @@ class Model(WithMemoization, metaclass=ContextMeta):
         point : Point
             Point to pass to the function
         profile : True or ProfileStats
+        backend : str, optional
+            Which computational backend to use. Recommended to be one of "numba", "c", and "jax".
         compile_fn_kwargs
             Compilation kwargs for :func:`pymc.model.core.Model.compile_fn`
 
@@ -1689,6 +1693,7 @@ class Model(WithMemoization, metaclass=ContextMeta):
             Use .summary() to print stats.
         """
         compile_fn_kwargs.setdefault("on_unused_input", "ignore")
+        compile_fn_kwargs = resolve_backend_compile_kwargs(backend, compile_fn_kwargs)
         f = self.compile_fn(
             outs,
             inputs=self.value_vars,

--- a/pymc/progress_bar/__init__.py
+++ b/pymc/progress_bar/__init__.py
@@ -14,6 +14,7 @@
 
 from pymc.progress_bar.progress import (
     MCMCProgressBarManager,
+    NutpieProgressBarManager,
     ProgressBarManager,
     ProgressBarOptions,
     SMCProgressBarManager,

--- a/pymc/progress_bar/progress.py
+++ b/pymc/progress_bar/progress.py
@@ -17,6 +17,8 @@ from abc import ABC, abstractmethod
 from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Literal, Protocol, Self
 
+from rich.progress import TextColumn
+from rich.table import Column
 from rich.theme import Theme
 
 from pymc.progress_bar.marimo_progress import (
@@ -327,6 +329,75 @@ class MCMCProgressBarManager(ProgressBarManager):
             stats=all_step_stats,
             is_last=is_last,
         )
+
+
+class NutpieProgressBarManager(ProgressBarManager):
+    """Progress bar manager for nutpie NUTS sampling.
+
+    Bridges ``nutpie.sample``'s ``progress_callback`` (a callable that receives a
+    list of ``nutpie.ChainProgress`` objects) to PyMC's progress bar backends,
+    so nutpie draws through the same UI as the pymc sampler.
+    """
+
+    step_name: str = "Draw"
+
+    def __init__(
+        self,
+        chains: int,
+        draws: int,
+        tune: int,
+        progressbar: bool | ProgressBarOptions = True,
+        progressbar_theme: Theme | str | None = None,
+    ):
+        super().__init__(
+            n_bars=chains,
+            progressbar=progressbar,
+            progressbar_theme=progressbar_theme,
+        )
+
+        progress_columns = [
+            TextColumn("{task.fields[divergences]}", table_column=Column("Divergences", ratio=1)),
+            TextColumn("{task.fields[step_size]:0.3f}", table_column=Column("Step size", ratio=1)),
+            TextColumn("{task.fields[tree_size]}", table_column=Column("Grad evals", ratio=1)),
+        ]
+        progress_stats = {
+            stat: [0] * chains for stat in ("divergences", "step_size", "tree_size", "draw")
+        }
+
+        self._previous_finished = [0] * chains
+        total_draws = draws + tune
+
+        self._backend = self._create_backend(
+            total=total_draws * chains if self.combined_progress else total_draws,
+            progress_columns=progress_columns,
+            progress_stats=progress_stats,
+        )
+
+    def update(self, chain_progresses) -> None:
+        """Consume a list of ``nutpie.ChainProgress`` objects and advance each bar."""
+        if not self._show_progress:
+            return
+
+        for chain_idx, cp in enumerate(chain_progresses):
+            delta = cp.finished_draws - self._previous_finished[chain_idx]
+            if delta <= 0:
+                continue
+            self._previous_finished[chain_idx] = cp.finished_draws
+            is_last = cp.finished_draws >= cp.total_draws
+            stats = {
+                "divergences": cp.divergences,
+                "step_size": cp.step_size,
+                "tree_size": cp.latest_num_steps,
+                "draw": cp.finished_draws,
+            }
+            task_id = 0 if self.combined_progress else chain_idx
+            self._backend.update(
+                task_id=task_id,
+                advance=delta,
+                failing=cp.divergences > 0,
+                stats=stats,
+                is_last=is_last,
+            )
 
 
 class SMCProgressBarManager(ProgressBarManager):

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -876,6 +876,23 @@ def collect_default_updates(
     return rng_updates
 
 
+def resolve_backend_compile_kwargs(backend: str | None, compile_kwargs: dict | None) -> dict:
+    """Materialize a `backend` shortcut as `compile_kwargs['mode']`.
+
+    Returns a new dict so the caller's input is never mutated. Raises if both
+    `backend` and `compile_kwargs['mode']` are provided.
+    """
+    compile_kwargs = {} if compile_kwargs is None else compile_kwargs.copy()
+    if backend is not None:
+        if "mode" in compile_kwargs:
+            raise ValueError("Can only define one of `backend` or `compile_kwargs['mode']`")
+        # Users associate "c" with pytensor's default C+VM backend.
+        if backend == "c":
+            backend = "cvm"
+        compile_kwargs["mode"] = get_mode(backend)
+    return compile_kwargs
+
+
 def compile(
     inputs,
     outputs,

--- a/pymc/sampling/deterministic.py
+++ b/pymc/sampling/deterministic.py
@@ -19,6 +19,7 @@ from xarray import Dataset
 
 from pymc.backends.arviz import apply_function_over_dataset, coords_and_dims_for_inferencedata
 from pymc.model.core import Model, modelcontext
+from pymc.pytensorf import resolve_backend_compile_kwargs
 
 
 def compute_deterministics(
@@ -29,6 +30,7 @@ def compute_deterministics(
     sample_dims: Sequence[str] = ("chain", "draw"),
     merge_dataset: bool = False,
     progressbar: bool = True,
+    backend: str | None = None,
     compile_kwargs: dict | None = None,
 ) -> Dataset:
     """Compute model deterministics given a dataset with values for model variables.
@@ -50,8 +52,11 @@ def compute_deterministics(
         Whether to display a progress bar in the command line.
     progressbar_theme : Theme, optional
         Custom theme for the progress bar.
+    backend: str, optional
+        Which computational backend to use. Recommended to be one of "numba", "c", and "jax".
     compile_kwargs: dict, optional
         Additional arguments passed to `model.compile_fn`.
+        ``compile_kwargs["mode"]`` cannot be combined with ``backend``.
 
     Returns
     -------
@@ -94,7 +99,7 @@ def compute_deterministics(
         inputs=model.free_RVs,
         outs=deterministics,
         on_unused_input="ignore",
-        **(compile_kwargs or {}),
+        **resolve_backend_compile_kwargs(backend, compile_kwargs),
     )
 
     coords, dims = coords_and_dims_for_inferencedata(model)

--- a/pymc/sampling/forward.py
+++ b/pymc/sampling/forward.py
@@ -49,7 +49,7 @@ from pymc.distributions.shape_utils import change_dist_size
 from pymc.exceptions import ImplicitFreezeWarning
 from pymc.model import Model, modelcontext
 from pymc.progress_bar import create_simple_progress, default_progress_theme
-from pymc.pytensorf import compile, rvs_in_graph
+from pymc.pytensorf import compile, resolve_backend_compile_kwargs, rvs_in_graph
 from pymc.util import (
     RandomState,
     _get_seeds_per_chain,
@@ -389,6 +389,8 @@ def draw(
     vars: Variable | Sequence[Variable],
     draws: int = 1,
     random_seed: RandomState = None,
+    *,
+    backend: str | None = None,
     **kwargs,
 ) -> np.ndarray | list[np.ndarray]:
     """Draw samples for one variable or a list of variables.
@@ -401,6 +403,8 @@ def draw(
         Number of samples needed to draw.
     random_seed : int, RandomState or numpy_Generator, optional
         Seed for the random number generator.
+    backend : str, optional
+        Which computational backend to use. Recommended to be one of "numba", "c", and "jax".
     **kwargs : dict, optional
         Keyword arguments for :func:`pymc.pytensorf.compile`.
 
@@ -436,6 +440,7 @@ def draw(
     if random_seed is not None:
         (random_seed,) = _get_seeds_per_chain(random_seed, 1)
 
+    kwargs = resolve_backend_compile_kwargs(backend, kwargs)
     draw_fn = compile(inputs=[], outputs=vars, random_seed=random_seed, **kwargs)
 
     if draws == 1:
@@ -475,6 +480,7 @@ def sample_prior_predictive(
     random_seed: RandomState = None,
     return_inferencedata: Literal[True] = True,
     idata_kwargs: dict | None = None,
+    backend: str | None = None,
     compile_kwargs: dict | None = None,
 ) -> xarray.DataTree: ...
 @overload
@@ -485,6 +491,7 @@ def sample_prior_predictive(
     random_seed: RandomState = None,
     return_inferencedata: Literal[False] = False,
     idata_kwargs: dict | None = None,
+    backend: str | None = None,
     compile_kwargs: dict | None = None,
 ) -> dict[str, np.ndarray]: ...
 def sample_prior_predictive(
@@ -494,6 +501,7 @@ def sample_prior_predictive(
     random_seed: RandomState = None,
     return_inferencedata: bool = True,
     idata_kwargs: dict | None = None,
+    backend: str | None = None,
     compile_kwargs: dict | None = None,
 ) -> xarray.DataTree | dict[str, np.ndarray]:
     """Generate samples from the prior predictive distribution.
@@ -514,8 +522,11 @@ def sample_prior_predictive(
         Defaults to True.
     idata_kwargs : dict, optional
         Keyword arguments for :func:`pymc.to_inference_data`
+    backend: str, optional
+        Which computational backend to use. Recommended to be one of "numba", "c", and "jax".
     compile_kwargs: dict, optional
         Keyword arguments for :func:`pymc.pytensorf.compile`.
+        ``compile_kwargs["mode"]`` cannot be combined with ``backend``.
 
     Returns
     -------
@@ -549,8 +560,7 @@ def sample_prior_predictive(
     if random_seed is not None:
         (random_seed,) = _get_seeds_per_chain(random_seed, 1)
 
-    if compile_kwargs is None:
-        compile_kwargs = {}
+    compile_kwargs = resolve_backend_compile_kwargs(backend, compile_kwargs)
     compile_kwargs.setdefault("allow_input_downcast", True)
     compile_kwargs.setdefault("accept_inplace", True)
 
@@ -599,6 +609,7 @@ def sample_posterior_predictive(
     extend_inferencedata: bool = False,
     predictions: bool = False,
     idata_kwargs: dict | None = None,
+    backend: str | None = None,
     compile_kwargs: dict | None = None,
 ) -> xarray.DataTree: ...
 @overload
@@ -617,6 +628,7 @@ def sample_posterior_predictive(
     extend_inferencedata: bool = False,
     predictions: bool = False,
     idata_kwargs: dict | None = None,
+    backend: str | None = None,
     compile_kwargs: dict | None = None,
 ) -> dict[str, np.ndarray]: ...
 def sample_posterior_predictive(
@@ -634,6 +646,7 @@ def sample_posterior_predictive(
     extend_inferencedata: bool = False,
     predictions: bool = False,
     idata_kwargs: dict | None = None,
+    backend: str | None = None,
     compile_kwargs: dict | None = None,
 ) -> xarray.DataTree | dict[str, np.ndarray]:
     """Generate forward samples for `var_names`, conditioned on the posterior samples of variables found in the `trace`.
@@ -704,8 +717,11 @@ def sample_posterior_predictive(
     idata_kwargs : dict, optional
         Keyword arguments for :func:`pymc.to_inference_data` if ``predictions=False`` or to
         :func:`pymc.predictions_to_inference_data` otherwise.
+    backend: str, optional
+        Which computational backend to use. Recommended to be one of "numba", "c", and "jax".
     compile_kwargs: dict, optional
         Keyword arguments for :func:`pymc.pytensorf.compile`.
+        ``compile_kwargs["mode"]`` cannot be combined with ``backend``.
 
     Returns
     -------
@@ -1199,8 +1215,7 @@ def sample_posterior_predictive(
     if random_seed is not None:
         (random_seed,) = _get_seeds_per_chain(random_seed, 1)
 
-    if compile_kwargs is None:
-        compile_kwargs = {}
+    compile_kwargs = resolve_backend_compile_kwargs(backend, compile_kwargs)
     compile_kwargs.setdefault("allow_input_downcast", True)
     compile_kwargs.setdefault("accept_inplace", True)
 

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -707,7 +707,7 @@ def sample_jax_nuts(
     if constant_data is not None:
         groups["constant_data"] = constant_data
 
-    if not idata_kwargs:
+    if idata_kwargs:
         warnings.warn(
             "The arguments to `from_dict` have changed with the release of arviz 1.0. "
             "Please refer to the arviz documentation for more details",

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -659,8 +659,8 @@ def sample_jax_nuts(
 
     if idata_kwargs.pop("log_likelihood", False):
         warnings.warn(
-            "`passing log_likelihood` is deprecated and will be removed in future versions. Use "
-            ":func:`pymc.compute_log_likelihood` instead.",
+            "Passing `log_likelihood` via `idata_kwargs` is deprecated and will be removed "
+            "in future versions. Call `pm.compute_log_likelihood(idata)` instead.",
             FutureWarning,
             stacklevel=3,
         )

--- a/pymc/sampling/jax.py
+++ b/pymc/sampling/jax.py
@@ -169,7 +169,15 @@ def _postprocess_samples(
         def process_fn(x):
             return jax.vmap(jax.vmap(jax_fn))(*_device_put(x, postprocessing_backend))
 
-        return jax.jit(process_fn, donate_argnums=0 if donate_samples else None)(raw_mcmc_samples)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Some donated buffers were not usable",
+                category=UserWarning,
+            )
+            return jax.jit(process_fn, donate_argnums=0 if donate_samples else None)(
+                raw_mcmc_samples
+            )
 
     else:
         raise ValueError(f"Unrecognized postprocessing_vectorize: {postprocessing_vectorize}")

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -355,6 +355,7 @@ def _sample_external_nuts(
 
         idata_kwargs = {} if idata_kwargs is None else {**idata_kwargs}
         include_transformed = idata_kwargs.pop("include_transformed", False)
+        log_likelihood = idata_kwargs.pop("log_likelihood", False)
         if idata_kwargs:
             warnings.warn(
                 f"`idata_kwargs` keys {sorted(idata_kwargs)} are currently ignored by the nutpie sampler",
@@ -390,6 +391,23 @@ def _sample_external_nuts(
             sampling_time=t_sample,
             include_transformed=include_transformed,
         )
+        if log_likelihood:
+            warnings.warn(
+                "Passing `log_likelihood` via `idata_kwargs` is deprecated and will be removed "
+                "in future versions. Call `pm.compute_log_likelihood(idata)` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            from pymc.stats.log_density import compute_log_likelihood
+
+            idata = compute_log_likelihood(
+                idata,
+                var_names=None if log_likelihood is True else log_likelihood,
+                extend_inferencedata=True,
+                model=model,
+                sample_dims=["chain", "draw"],
+                progressbar=False,
+            )
         return idata
 
     elif sampler in ("numpyro", "blackjax"):

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -827,7 +827,10 @@ def sample(
     if chains is None:
         chains = max(2, cores)
 
-    mp_ctx = _initialize_multiprocessing_context(mp_ctx, quiet=quiet)
+    compile_kwargs = resolve_backend_compile_kwargs(backend, compile_kwargs)
+    mp_ctx = _initialize_multiprocessing_context(
+        mp_ctx, mode=compile_kwargs.get("mode"), quiet=quiet
+    )
     joined_blas_limiter, cores, num_blas_cores_per_worker = setup_cores_blas_cores(
         blas_cores, chains, cores, mp_ctx
     )
@@ -869,8 +872,6 @@ def sample(
             and issubclass(next(iter(selected_steps)), NUTS)
         )
     )
-
-    compile_kwargs = resolve_backend_compile_kwargs(backend, compile_kwargs)
 
     if nuts_sampler is None:
         # Try to use nutpie by default if no setting is clearly at odds.

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -58,6 +58,7 @@ from pymc.progress_bar import (
     ProgressBarOptions,
     default_progress_theme,
 )
+from pymc.pytensorf import resolve_backend_compile_kwargs
 from pymc.sampling.parallel import Draw, _cpu_count, _initialize_multiprocessing_context
 from pymc.sampling.population import _sample_population
 from pymc.stats.convergence import (
@@ -540,6 +541,7 @@ def sample(
     mp_ctx=None,
     blas_cores: int | None | Literal["auto"] = "auto",
     model: Model | None = None,
+    backend: str | None = None,
     compile_kwargs: dict | None = None,
     **kwargs,
 ) -> DataTree | MultiTrace | ZarrTrace:
@@ -658,9 +660,12 @@ def sample(
         See multiprocessing documentation for details.
     model : Model (optional if in ``with`` context)
         Model to sample from. The model needs to have free random variables.
+    backend: str, optional.
+        Which computational backend to use. Recommended to be one of "numba", "c", and "jax".
+        May require installing extra dependencies.
     compile_kwargs: dict, optional
         Dictionary with keyword argument to pass to the functions compiled by the step methods.
-
+        ``compile_kwargs["mode"]`` cannot be combined with ``backend``.
 
     Returns
     -------
@@ -814,6 +819,8 @@ def sample(
             and issubclass(next(iter(selected_steps)), NUTS)
         )
     )
+
+    compile_kwargs = resolve_backend_compile_kwargs(backend, compile_kwargs)
 
     if nuts_sampler != "pymc":
         if not exclusive_nuts:

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -730,15 +730,6 @@ def sample(
             mean     sd  hdi_3%  hdi_97%
         p  0.609  0.047   0.528    0.699
     """
-    if "start" in kwargs:
-        if initvals is not None:
-            raise ValueError("Passing both `start` and `initvals` is not supported.")
-        warnings.warn(
-            "The `start` kwarg was renamed to `initvals` and can now do more. Please check the docstring.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        initvals = kwargs.pop("start")
     if nuts_sampler_kwargs is None:
         nuts_sampler_kwargs = {}
     if "target_accept" in kwargs:

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -730,6 +730,14 @@ def sample(
             mean     sd  hdi_3%  hdi_97%
         p  0.609  0.047   0.528    0.699
     """
+    if return_inferencedata is False:
+        warnings.warn(
+            "`return_inferencedata=False` is deprecated and will be removed in a future "
+            "release. Use the default `return_inferencedata=True` and work with the "
+            "returned `InferenceData` object.",
+            FutureWarning,
+            stacklevel=2,
+        )
     if nuts_sampler_kwargs is None:
         nuts_sampler_kwargs = {}
     if "target_accept" in kwargs:

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -50,6 +50,7 @@ from pymc.initial_point import PointType, StartDict, make_initial_point_fns_per_
 from pymc.model import Model, modelcontext
 from pymc.progress_bar import (
     MCMCProgressBarManager,
+    NutpieProgressBarManager,
     ProgressBarOptions,
     default_progress_theme,
 )
@@ -328,7 +329,8 @@ def _sample_external_nuts(
     initvals: StartDict | Sequence[StartDict | None] | None,
     model: Model,
     var_names: Sequence[str] | None,
-    progressbar: bool,
+    progressbar: bool | ProgressBarOptions,
+    progressbar_theme: Theme | None,
     quiet: bool,
     idata_kwargs: dict | None,
     compute_convergence_checks: bool,
@@ -372,17 +374,28 @@ def _sample_external_nuts(
             var_names=var_names,
             **compile_kwargs,
         )
-        t_start = time.time()
-        idata = nutpie.sample(
-            compiled_model,
+
+        pb_manager = NutpieProgressBarManager(
+            chains=chains,
             draws=draws,
             tune=tune,
-            chains=chains,
-            target_accept=target_accept,
-            seed=_get_seeds_per_chain(random_seed, 1)[0],
-            progress_bar=progressbar,
-            **nuts_sampler_kwargs,
+            progressbar=progressbar,
+            progressbar_theme=progressbar_theme,
         )
+
+        t_start = time.time()
+        with pb_manager:
+            idata = nutpie.sample(
+                compiled_model,
+                draws=draws,
+                tune=tune,
+                chains=chains,
+                target_accept=target_accept,
+                seed=_get_seeds_per_chain(random_seed, 1)[0],
+                progress_bar=False,
+                progress_callback=pb_manager.update,
+                **nuts_sampler_kwargs,
+            )
         t_sample = time.time() - t_start
         patch_nutpie_idata(
             idata,
@@ -422,7 +435,7 @@ def _sample_external_nuts(
             initvals=initvals,
             model=model,
             var_names=var_names,
-            progressbar=progressbar,
+            progressbar=bool(progressbar),
             quiet=quiet,
             nuts_sampler=sampler,
             idata_kwargs=idata_kwargs,
@@ -830,7 +843,8 @@ def sample(
                 initvals=initvals,
                 model=model,
                 var_names=var_names,
-                progressbar=progress_bool,
+                progressbar=progressbar if nuts_sampler == "nutpie" else progress_bool,
+                progressbar_theme=progressbar_theme,
                 quiet=quiet,
                 idata_kwargs=idata_kwargs,
                 compute_convergence_checks=compute_convergence_checks,

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1057,6 +1057,14 @@ def _sample_return(
 
     Final step of `pm.sampler`.
     """
+    if "log_likelihood" in idata_kwargs:
+        warnings.warn(
+            "Passing `log_likelihood` via `idata_kwargs` is deprecated and will be removed "
+            "in future versions. Call `pm.compute_log_likelihood(idata)` instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+
     if isinstance(traces, ZarrTrace):
         # Split warmup from posterior samples
         traces.split_warmup_groups()
@@ -1084,15 +1092,8 @@ def _sample_return(
 
         if compute_convergence_checks or return_inferencedata:
             idata = traces.to_inferencedata(save_warmup=not discard_tuned_samples)
-            log_likelihood = idata_kwargs.pop("log_likelihood", False)
+            log_likelihood = idata_kwargs.get("log_likelihood", False)
             if log_likelihood:
-                warnings.warn(
-                    "`passing log_likelihood` is deprecated and will be removed in future versions. Use "
-                    ":func:`pymc.compute_log_likelihood` instead.",
-                    FutureWarning,
-                    stacklevel=2,
-                )
-
                 from pymc.stats.log_density import compute_log_likelihood
 
                 idata = compute_log_likelihood(
@@ -1103,6 +1104,7 @@ def _sample_return(
                     sample_dims=["chain", "draw"],
                     progressbar=False,
                 )
+
             if compute_convergence_checks:
                 warns = run_convergence_checks(idata, model)
                 for warn in warns:

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -32,7 +32,6 @@ from typing import (
 import numpy as np
 import pytensor.gradient as tg
 
-from arviz_base import dict_to_dataset, make_attrs
 from pytensor.graph.basic import Variable
 from rich.theme import Theme
 from threadpoolctl import threadpool_limits
@@ -42,11 +41,7 @@ from xarray import DataTree
 import pymc as pm
 
 from pymc.backends import RunType, TraceOrBackend, init_traces
-from pymc.backends.arviz import (
-    coords_and_dims_for_inferencedata,
-    find_constants,
-    find_observations,
-)
+from pymc.backends.arviz import patch_nutpie_idata
 from pymc.backends.base import IBaseTrace, MultiTrace, _choose_chains
 from pymc.backends.zarr import ZarrChain, ZarrTrace
 from pymc.blocking import DictToArrayBijection
@@ -358,9 +353,11 @@ def _sample_external_nuts(
                 UserWarning,
             )
 
-        if idata_kwargs is not None:
+        idata_kwargs = {} if idata_kwargs is None else {**idata_kwargs}
+        include_transformed = idata_kwargs.pop("include_transformed", False)
+        if idata_kwargs:
             warnings.warn(
-                "`idata_kwargs` are currently ignored by the nutpie sampler",
+                f"`idata_kwargs` keys {sorted(idata_kwargs)} are currently ignored by the nutpie sampler",
                 UserWarning,
             )
 
@@ -386,36 +383,12 @@ def _sample_external_nuts(
             **nuts_sampler_kwargs,
         )
         t_sample = time.time() - t_start
-        # Temporary work-around. Revert once https://github.com/pymc-devs/nutpie/issues/74 is fixed
-        # gather observed and constant data as nutpie.sample() has no access to the PyMC model
-        coords, dims = coords_and_dims_for_inferencedata(model)
-        constant_data = dict_to_dataset(
-            find_constants(model),
-            inference_library=pm,
-            coords=coords,
-            dims=dims,
-            sample_dims=[],
-        )
-        observed_data = dict_to_dataset(
-            find_observations(model),
-            inference_library=pm,
-            coords=coords,
-            dims=dims,
-            sample_dims=[],
-        )
-        attrs = make_attrs(
-            {
-                "sampling_time": t_sample,
-                "tuning_steps": tune,
-            },
-            library=nutpie,
-        )
-        for k, v in attrs.items():
-            idata.posterior.attrs[k] = v
-        idata.update(
-            {"constant_data": constant_data, "observed_data": observed_data},
-            coords=coords,
-            dims=dims,
+        patch_nutpie_idata(
+            idata,
+            model,
+            tune=tune,
+            sampling_time=t_sample,
+            include_transformed=include_transformed,
         )
         return idata
 

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 import contextlib
+import importlib.util
 import logging
 import multiprocessing
 import pickle
@@ -32,7 +33,10 @@ from typing import (
 import numpy as np
 import pytensor.gradient as tg
 
+from pytensor.compile.mode import get_mode
 from pytensor.graph.basic import Variable
+from pytensor.link.jax.linker import JAXLinker
+from pytensor.link.numba.linker import NumbaLinker
 from rich.theme import Theme
 from threadpoolctl import threadpool_limits
 from typing_extensions import Protocol
@@ -80,6 +84,9 @@ try:
     from zarr.storage import MemoryStore
 except ImportError:
     MemoryStore = type("MemoryStore", (), {})
+
+NUTPIE_INSTALLED = importlib.util.find_spec("nutpie") is not None
+
 
 sys.setrecursionlimit(10000)
 
@@ -324,7 +331,7 @@ def _sample_external_nuts(
     draws: int,
     tune: int,
     chains: int,
-    target_accept: float,
+    cores: int | None,
     random_seed: RandomState | None,
     initvals: StartDict | Sequence[StartDict | None] | None,
     model: Model,
@@ -332,30 +339,56 @@ def _sample_external_nuts(
     progressbar: bool | ProgressBarOptions,
     progressbar_theme: Theme | None,
     quiet: bool,
-    idata_kwargs: dict | None,
     compute_convergence_checks: bool,
-    nuts_sampler_kwargs: dict | None,
+    discard_tuned_samples: bool,
+    nuts_kwargs: dict,
+    compile_kwargs: dict,
+    idata_kwargs: dict | None,
     **kwargs,
 ):
-    if nuts_sampler_kwargs is None:
-        nuts_sampler_kwargs = {}
+    # Shallow copy dicts so we can safely matute them below
+    nuts_kwargs = nuts_kwargs.copy()
+    compile_kwargs = compile_kwargs.copy()
+    idata_kwargs = {} if idata_kwargs is None else idata_kwargs.copy()
+
+    if "backend" in nuts_kwargs:
+        warnings.warn(
+            "`backend` should be passed as a top-level argument to `pm.sample`, "
+            "not nested in the NUTS step kwargs.",
+            FutureWarning,
+        )
+        compile_kwargs["mode"] = get_mode(nuts_kwargs.pop("backend"))
+
+    if "gradient_backend" in nuts_kwargs:
+        warnings.warn(
+            "`gradient_backend` should be passed via `compile_kwargs` to `pm.sample`, "
+            "not nested in the NUTS step kwargs.",
+            FutureWarning,
+        )
+        compile_kwargs["gradient_backend"] = nuts_kwargs.pop("gradient_backend")
 
     if sampler == "nutpie":
-        try:
-            import nutpie
-        except ImportError as err:
+        if not NUTPIE_INSTALLED:
             raise ImportError(
                 "nutpie not found. Install it with conda install -c conda-forge nutpie"
-            ) from err
+            )
+        import nutpie
 
-        if initvals is not None:
-            warnings.warn(
-                "`initvals` are currently not passed to nutpie sampler. "
-                "Use `init_mean` kwarg following nutpie specification instead.",
-                UserWarning,
+        if isinstance(initvals, dict):
+            compile_kwargs.setdefault("initial_points", initvals)
+        elif initvals is not None:
+            raise NotImplementedError(
+                "nutpie does not support per-chain `initvals`. "
+                "Pass a single dict, or use `nuts_sampler='pymc'`."
             )
 
-        idata_kwargs = {} if idata_kwargs is None else {**idata_kwargs}
+        # nuts-rs asserts `early_end < num_tune`, which panics when `tune == 0`.
+        if tune == 0:
+            tune = 1
+
+        if "max_treedepth" in nuts_kwargs:
+            nuts_kwargs["maxdepth"] = nuts_kwargs.pop("max_treedepth")
+
         include_transformed = idata_kwargs.pop("include_transformed", False)
         log_likelihood = idata_kwargs.pop("log_likelihood", False)
         if idata_kwargs:
@@ -364,11 +397,8 @@ def _sample_external_nuts(
                 UserWarning,
             )
 
-        compile_kwargs = {}
-        nuts_sampler_kwargs = nuts_sampler_kwargs.copy()
-        for kwarg in ("backend", "gradient_backend"):
-            if kwarg in nuts_sampler_kwargs:
-                compile_kwargs[kwarg] = nuts_sampler_kwargs.pop(kwarg)
+        linker = get_mode(compile_kwargs.pop("mode", None)).linker
+        compile_kwargs.setdefault("backend", "jax" if isinstance(linker, JAXLinker) else "numba")
         compiled_model = nutpie.compile_pymc_model(
             model,
             var_names=var_names,
@@ -390,11 +420,12 @@ def _sample_external_nuts(
                 draws=draws,
                 tune=tune,
                 chains=chains,
-                target_accept=target_accept,
-                seed=_get_seeds_per_chain(random_seed, 1)[0],
+                cores=cores,
+                seed=int(random_seed[0]),
+                save_warmup=not discard_tuned_samples,
                 progress_bar=False,
                 progress_callback=pb_manager.update,
-                **nuts_sampler_kwargs,
+                **nuts_kwargs,
             )
         t_sample = time.time() - t_start
         patch_nutpie_idata(
@@ -426,21 +457,25 @@ def _sample_external_nuts(
     elif sampler in ("numpyro", "blackjax"):
         import pymc.sampling.jax as pymc_jax
 
+        jax_nuts_kwargs = dict(nuts_kwargs)
+        jax_target_accept = jax_nuts_kwargs.pop("target_accept", 0.8)
         idata = pymc_jax.sample_jax_nuts(
             draws=draws,
             tune=tune,
             chains=chains,
-            target_accept=target_accept,
-            random_seed=random_seed,
+            target_accept=jax_target_accept,
+            # jax samplers take a single master seed; `random_seed` here is the
+            # per-chain list produced by `pm.sample`, so use the first entry.
+            random_seed=int(random_seed[0]),
             initvals=initvals,
             model=model,
             var_names=var_names,
             progressbar=bool(progressbar),
             quiet=quiet,
             nuts_sampler=sampler,
+            nuts_kwargs=jax_nuts_kwargs,
             idata_kwargs=idata_kwargs,
             compute_convergence_checks=compute_convergence_checks,
-            **nuts_sampler_kwargs,
         )
         return idata
 
@@ -463,7 +498,7 @@ def sample(
     quiet: bool = False,
     step=None,
     var_names: Sequence[str] | None = None,
-    nuts_sampler: Literal["pymc", "nutpie", "numpyro", "blackjax"] = "pymc",
+    nuts_sampler: Literal["pymc", "nutpie", "numpyro", "blackjax"] | None = None,
     initvals: StartDict | Sequence[StartDict | None] | None = None,
     init: str = "auto",
     jitter_max_retries: int = 10,
@@ -496,7 +531,7 @@ def sample(
     quiet: bool = False,
     step=None,
     var_names: Sequence[str] | None = None,
-    nuts_sampler: Literal["pymc", "nutpie", "numpyro", "blackjax"] = "pymc",
+    nuts_sampler: Literal["pymc", "nutpie", "numpyro", "blackjax"] | None = None,
     initvals: StartDict | Sequence[StartDict | None] | None = None,
     init: str = "auto",
     jitter_max_retries: int = 10,
@@ -529,7 +564,7 @@ def sample(
     quiet: bool = False,
     step=None,
     var_names: Sequence[str] | None = None,
-    nuts_sampler: Literal["pymc", "nutpie", "numpyro", "blackjax"] = "pymc",
+    nuts_sampler: Literal["pymc", "nutpie", "numpyro", "blackjax"] | None = None,
     initvals: StartDict | Sequence[StartDict | None] | None = None,
     init: str = "auto",
     jitter_max_retries: int = 10,
@@ -599,10 +634,11 @@ def sample(
         method will be used, if appropriate to the model.
     var_names : list of str, optional
         Names of variables to be stored in the trace. Defaults to all free variables and deterministics.
-    nuts_sampler : str
+    nuts_sampler : str, optional
         Which NUTS implementation to run. One of ["pymc", "nutpie", "blackjax", "numpyro"].
         This requires the chosen sampler to be installed.
         All samplers, except "pymc", require the full model to be continuous.
+        If ``None`` (default), "nutpie" is used if installed and can be compiled to the desired backend.
     blas_cores: int or "auto" or None, default = "auto"
         The total number of threads blas and openmp functions should use during sampling.
         Setting it to "auto" will ensure that the total number of active blas threads is the
@@ -651,8 +687,8 @@ def sample(
     idata_kwargs : dict, optional
         Keyword arguments for :func:`pymc.to_inference_data`
     nuts_sampler_kwargs : dict, optional
-        Keyword arguments for the sampling library that implements nuts.
-        Only used when an external sampler is specified via the `nuts_sampler` kwarg.
+        Deprecated. Pass NUTS keyword arguments via ``nuts={...}`` instead
+        (e.g. ``pm.sample(..., nuts={"target_accept": 0.9})``).
     callback : function, default=None
         A function which gets called for every sample from the trace of a chain. The function is
         called with the trace and the current draw and will contain all samples for a single trace.
@@ -747,8 +783,18 @@ def sample(
             FutureWarning,
             stacklevel=2,
         )
-    if nuts_sampler_kwargs is None:
-        nuts_sampler_kwargs = {}
+    if nuts_sampler_kwargs is not None:
+        warnings.warn(
+            "`nuts_sampler_kwargs` is deprecated. Pass NUTS keyword arguments via the "
+            "`nuts={...}` argument to `pm.sample`.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        if "nuts" in kwargs:
+            raise ValueError(
+                "Cannot pass both `nuts_sampler_kwargs` and `nuts=`. Use `nuts=` only."
+            )
+        kwargs["nuts"] = nuts_sampler_kwargs
     if "target_accept" in kwargs:
         if "nuts" in kwargs and "target_accept" in kwargs["nuts"]:
             raise ValueError(
@@ -826,20 +872,67 @@ def sample(
 
     compile_kwargs = resolve_backend_compile_kwargs(backend, compile_kwargs)
 
-    if nuts_sampler != "pymc":
-        if not exclusive_nuts:
-            raise ValueError(
-                "Model can not be sampled with NUTS alone. It either has discrete variables or a non-differentiable log-probability."
-            )
+    if nuts_sampler is None:
+        # Try to use nutpie by default if no setting is clearly at odds.
+        # Requires all model variables, numba or jax preference,
+        # and must not conflict with pymc sample-only arguments.
+        can_use_nutpie = (
+            exclusive_nuts
+            and not provided_steps
+            and NUTPIE_INSTALLED
+            and init == "auto"
+            and return_inferencedata
+            and trace is None
+            and callback is None
+            and (initvals is None or isinstance(initvals, dict))
+            and isinstance(get_mode(compile_kwargs.get("mode")).linker, NumbaLinker | JAXLinker)
+        )
+        nuts_sampler = "nutpie" if can_use_nutpie else "pymc"
+    elif nuts_sampler != "pymc" and not exclusive_nuts:
+        raise ValueError(
+            f"`nuts_sampler={nuts_sampler!r}` requires all variables to be differentiable "
+            "and not assigned to another step sampler."
+        )
 
+    if nuts_sampler != "pymc":
+        if provided_steps:
+            warnings.warn(
+                f"The provided NUTS `step` is ignored by `nuts_sampler={nuts_sampler!r}`; "
+                "pass `nuts_sampler='pymc'` to use it.",
+                UserWarning,
+                stacklevel=2,
+            )
+        if not return_inferencedata:
+            raise ValueError(
+                f"`return_inferencedata=False` is not supported with `nuts_sampler={nuts_sampler!r}`. "
+                "External NUTS samplers can only return `InferenceData`."
+            )
+        if trace is not None:
+            raise ValueError(
+                f"A custom `trace` backend is not supported with `nuts_sampler={nuts_sampler!r}`. "
+                "Trace backends (e.g. `ZarrTrace`) only work with `nuts_sampler='pymc'`."
+            )
+        if callback is not None:
+            raise ValueError(
+                f"`callback` is not supported with `nuts_sampler={nuts_sampler!r}`. "
+                "External NUTS samplers don't invoke per-draw callbacks."
+            )
+        if init != "auto":
+            warnings.warn(
+                f"`init={init!r}` is ignored by `nuts_sampler={nuts_sampler!r}`; "
+                "the external sampler uses its own initialization.",
+                UserWarning,
+                stacklevel=2,
+            )
+        nuts_kwargs = kwargs.pop("nuts", {})
         with joined_blas_limiter():
             return _sample_external_nuts(
                 sampler=nuts_sampler,
                 draws=draws,
                 tune=tune,
                 chains=chains,
-                target_accept=kwargs.pop("nuts", {}).get("target_accept", 0.8),
-                random_seed=random_seed,
+                cores=cores,
+                random_seed=random_seed_list,
                 initvals=initvals,
                 model=model,
                 var_names=var_names,
@@ -848,7 +941,9 @@ def sample(
                 quiet=quiet,
                 idata_kwargs=idata_kwargs,
                 compute_convergence_checks=compute_convergence_checks,
-                nuts_sampler_kwargs=nuts_sampler_kwargs,
+                discard_tuned_samples=discard_tuned_samples,
+                nuts_kwargs=nuts_kwargs,
+                compile_kwargs=compile_kwargs,
                 **kwargs,
             )
 

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -782,12 +782,6 @@ def sample(
         raise ValueError(
             "Setting random_seed = -1 is not allowed. Pass `None` to not specify a seed."
         )
-    elif isinstance(random_seed, tuple | list):
-        warnings.warn(
-            "A list or tuple of random_seed no longer specifies the specific random_seed of each chain. "
-            "Use a single seed instead.",
-            UserWarning,
-        )
     rngs = get_random_generator(random_seed).spawn(chains)
     random_seed_list = [rng.integers(2**30) for rng in rngs]
 

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -19,6 +19,7 @@ import multiprocessing.sharedctypes
 import platform
 import time
 import traceback
+import warnings
 
 from collections import namedtuple
 from collections.abc import Sequence
@@ -28,6 +29,8 @@ from typing import cast
 import cloudpickle
 import numpy as np
 
+from pytensor.compile import get_mode
+from pytensor.link.jax.linker import JAXLinker
 from rich.theme import Theme
 from threadpoolctl import threadpool_limits
 
@@ -78,8 +81,14 @@ def rebuild_exc(exc, tb):
 
 
 def _initialize_multiprocessing_context(
-    mp_ctx: str | multiprocessing.context.BaseContext | None, quiet: bool = False
+    mp_ctx: str | multiprocessing.context.BaseContext | None,
+    *,
+    mode=None,
+    quiet: bool = False,
 ) -> multiprocessing.context.BaseContext:
+    user_specified = mp_ctx is not None
+    jax_mode = mode is not None and isinstance(get_mode(mode).linker, JAXLinker)
+
     if mp_ctx is None or isinstance(mp_ctx, str):
         # Closes issue https://github.com/pymc-devs/pymc/issues/3849
         # Related issue https://github.com/pymc-devs/pymc/issues/5339
@@ -95,6 +104,21 @@ def _initialize_multiprocessing_context(
                 mp_ctx = "forkserver"
 
         mp_ctx = multiprocessing.get_context(mp_ctx)
+
+    if jax_mode and mp_ctx.get_start_method() == "fork":
+        if user_specified:
+            warnings.warn(
+                "Using a JAX backend with multiprocessing start method 'fork' is unsafe "
+                "and may deadlock. Consider passing `mp_ctx='forkserver'` or `mp_ctx='spawn'`.",
+                UserWarning,
+                stacklevel=2,
+            )
+        else:
+            # JAX is not fork-safe: pick a non-fork default when user didn't specify.
+            new_method = (
+                "forkserver" if "forkserver" in multiprocessing.get_all_start_methods() else "spawn"
+            )
+            mp_ctx = multiprocessing.get_context(new_method)
 
     return mp_ctx
 

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -179,7 +179,8 @@ def sample_smc(
     else:
         cores = min(chains, cores)
 
-    kernel_kwargs["compile_kwargs"] = resolve_backend_compile_kwargs(backend, compile_kwargs)
+    compile_kwargs = resolve_backend_compile_kwargs(backend, compile_kwargs)
+    kernel_kwargs["compile_kwargs"] = compile_kwargs
 
     random_seed = _get_seeds_per_chain(random_state=random_seed, chains=chains)
 
@@ -187,7 +188,7 @@ def sample_smc(
 
     logger.info("Initializing SMC sampler...")
 
-    mp_ctx = _initialize_multiprocessing_context(mp_ctx)
+    mp_ctx = _initialize_multiprocessing_context(mp_ctx, mode=compile_kwargs.get("mode"))
     joined_blas_limiter, cores, num_blas_cores_per_worker = setup_cores_blas_cores(
         blas_cores, chains, cores, mp_ctx
     )

--- a/pymc/smc/sampling.py
+++ b/pymc/smc/sampling.py
@@ -28,6 +28,7 @@ from pymc.backends.arviz import dict_to_dataset, to_inference_data
 from pymc.backends.base import MultiTrace
 from pymc.model import Model, modelcontext
 from pymc.progress_bar import SMCProgressBarManager, default_progress_theme
+from pymc.pytensorf import resolve_backend_compile_kwargs
 from pymc.sampling.mcmc import setup_cores_blas_cores
 from pymc.sampling.parallel import _cpu_count, _initialize_multiprocessing_context
 from pymc.smc.kernels import IMH
@@ -53,6 +54,7 @@ def sample_smc(
     idata_kwargs=None,
     progressbar=True,
     progressbar_theme: Theme | None = default_progress_theme,
+    backend: str | None = None,
     compile_kwargs: dict | None = None,
     mp_ctx=None,
     **kernel_kwargs,
@@ -101,8 +103,11 @@ def sample_smc(
         Whether or not to display a progress bar in the command line.
     progressbar_theme : Theme, optional
         Custom theme for progress bar. Defaults to the standard PyMC progress bar theme.
+    backend: str, optional
+        Which computational backend to use. Recommended to be one of "numba", "c", and "jax".
     compile_kwargs: dict, optional
-        Keyword arguments to pass to pytensor.function
+        Keyword arguments to pass to pytensor.function.
+        ``compile_kwargs["mode"]`` cannot be combined with ``backend``.
     mp_ctx : multiprocessing.context or str, optional
         Multiprocessing context for parallel chains. Can be a context object or a string
         ("fork", "spawn", or "forkserver"). If None, defaults to "fork" on macOS ARM and
@@ -174,10 +179,7 @@ def sample_smc(
     else:
         cores = min(chains, cores)
 
-    if compile_kwargs is None:
-        compile_kwargs = {}
-
-    kernel_kwargs["compile_kwargs"] = compile_kwargs
+    kernel_kwargs["compile_kwargs"] = resolve_backend_compile_kwargs(backend, compile_kwargs)
 
     random_seed = _get_seeds_per_chain(random_state=random_seed, chains=chains)
 

--- a/pymc/stats/log_density.py
+++ b/pymc/stats/log_density.py
@@ -21,6 +21,7 @@ from pymc.backends.arviz import (
     coords_and_dims_for_inferencedata,
 )
 from pymc.model import Model, modelcontext
+from pymc.pytensorf import resolve_backend_compile_kwargs
 
 __all__ = ("compute_log_likelihood", "compute_log_prior")
 
@@ -35,6 +36,7 @@ def compute_log_likelihood(
     model: Model | None = None,
     sample_dims: Sequence[str] = ("chain", "draw"),
     progressbar=True,
+    backend: str | None = None,
     compile_kwargs: dict[str, Any] | None = None,
 ):
     """Compute elemwise log_likelihood of model given InferenceData with posterior group.
@@ -51,8 +53,11 @@ def compute_log_likelihood(
     model : Model, optional
     sample_dims : sequence of str, default ("chain", "draw")
     progressbar : bool, default True
+    backend : str, optional
+        Which computational backend to use. Recommended to be one of "numba", "c", and "jax".
     compile_kwargs : dict[str, Any] | None
-        Extra compilation arguments to supply to :py:func:`~pymc.stats.compute_log_density`
+        Extra compilation arguments to supply to :py:func:`~pymc.stats.compute_log_density`.
+        ``compile_kwargs["mode"]`` cannot be combined with ``backend``.
 
     Returns
     -------
@@ -67,6 +72,7 @@ def compute_log_likelihood(
         kind="likelihood",
         sample_dims=sample_dims,
         progressbar=progressbar,
+        backend=backend,
         compile_kwargs=compile_kwargs,
     )
 
@@ -79,6 +85,7 @@ def compute_log_prior(
     model: Model | None = None,
     sample_dims: Sequence[str] = ("chain", "draw"),
     progressbar=True,
+    backend: str | None = None,
     compile_kwargs=None,
 ):
     """Compute elemwise log_prior of model given InferenceData with posterior group.
@@ -95,8 +102,11 @@ def compute_log_prior(
     model : Model, optional
     sample_dims : sequence of str, default ("chain", "draw")
     progressbar : bool, default True
+    backend : str, optional
+        Which computational backend to use. Recommended to be one of "numba", "c", and "jax".
     compile_kwargs : dict[str, Any] | None
-        Extra compilation arguments to supply to :py:func:`~pymc.stats.compute_log_density`
+        Extra compilation arguments to supply to :py:func:`~pymc.stats.compute_log_density`.
+        ``compile_kwargs["mode"]`` cannot be combined with ``backend``.
 
     Returns
     -------
@@ -111,6 +121,7 @@ def compute_log_prior(
         kind="prior",
         sample_dims=sample_dims,
         progressbar=progressbar,
+        backend=backend,
         compile_kwargs=compile_kwargs,
     )
 
@@ -124,6 +135,7 @@ def compute_log_density(
     kind: Literal["likelihood", "prior"] = "likelihood",
     sample_dims: Sequence[str] = ("chain", "draw"),
     progressbar=True,
+    backend: str | None = None,
     compile_kwargs=None,
 ) -> DataTree | Dataset:
     """
@@ -145,8 +157,11 @@ def compute_log_density(
         parameter determines the group that gets added to the returned `~arviz.InferenceData` object.
     sample_dims : sequence of str, default ("chain", "draw")
     progressbar : bool, default True
+    backend : str, optional
+        Which computational backend to use. Recommended to be one of "numba", "c", and "jax".
     compile_kwargs : dict[str, Any] | None
-        Extra compilation arguments to supply to :py:func:`pymc.model.core.Model.compile_fn`
+        Extra compilation arguments to supply to :py:func:`pymc.model.core.Model.compile_fn`.
+        ``compile_kwargs["mode"]`` cannot be combined with ``backend``.
 
     Returns
     -------
@@ -157,8 +172,7 @@ def compute_log_density(
     posterior = idata["posterior"]
 
     model = modelcontext(model)
-    if compile_kwargs is None:
-        compile_kwargs = {}
+    compile_kwargs = resolve_backend_compile_kwargs(backend, compile_kwargs)
 
     if kind not in ("likelihood", "prior"):
         raise ValueError("kind must be either 'likelihood' or 'prior'")

--- a/pymc/variational/inference.py
+++ b/pymc/variational/inference.py
@@ -24,6 +24,7 @@ from rich.progress import Progress, TextColumn, track
 import pymc as pm
 
 from pymc.progress_bar import CustomProgress, default_progress_theme
+from pymc.pytensorf import resolve_backend_compile_kwargs
 from pymc.variational import test_functions
 from pymc.variational.approximations import Empirical, FullRank, MeanField
 from pymc.variational.operators import KL, KSD
@@ -80,7 +81,7 @@ class Inference:
             pass
         return score
 
-    def run_profiling(self, n=1000, score=None, **kwargs):
+    def run_profiling(self, n=1000, score=None, *, backend=None, **kwargs):
         score = self._maybe_score(score)
         if "fn_kwargs" in kwargs:
             warnings.warn(
@@ -88,8 +89,9 @@ class Inference:
             )
             compile_kwargs = kwargs.pop("fn_kwargs")
         else:
-            compile_kwargs = kwargs.pop("compile_kwargs", {})
+            compile_kwargs = kwargs.pop("compile_kwargs", None)
 
+        compile_kwargs = resolve_backend_compile_kwargs(backend, compile_kwargs)
         compile_kwargs["profile"] = True
         step_func = self.objective.step_function(
             score=score, compile_kwargs=compile_kwargs, **kwargs
@@ -108,6 +110,8 @@ class Inference:
         callbacks=None,
         progressbar=True,
         progressbar_theme=default_progress_theme,
+        *,
+        backend=None,
         **kwargs,
     ):
         """Perform Operator Variational Inference.
@@ -124,6 +128,8 @@ class Inference:
             whether to show progressbar or not
         progressbar_theme : Theme
             Custom theme for the progress bar
+        backend : str, optional
+            Which computational backend to use. Recommended to be one of "numba", "c", and "jax".
 
         Other Parameters
         ----------------
@@ -144,7 +150,8 @@ class Inference:
         total_grad_norm_constraint: `float`
             Bounds gradient norm, prevents exploding gradient problem
         compile_kwargs: `dict`
-            Add kwargs to pytensor.function (e.g. `{'profile': True}`)
+            Add kwargs to pytensor.function (e.g. `{'profile': True}`).
+            ``compile_kwargs["mode"]`` cannot be combined with ``backend``.
         more_replacements: `dict`
             Apply custom replacements before calculating gradients
 
@@ -155,6 +162,9 @@ class Inference:
         if callbacks is None:
             callbacks = []
         score = self._maybe_score(score)
+        kwargs["compile_kwargs"] = resolve_backend_compile_kwargs(
+            backend, kwargs.get("compile_kwargs")
+        )
         step_func = self.objective.step_function(score=score, **kwargs)
 
         if score:
@@ -686,6 +696,8 @@ def fit(
     start=None,
     start_sigma=None,
     inf_kwargs=None,
+    *,
+    backend=None,
     **kwargs,
 ):
     r"""Handy shortcut for using inference methods in functional way.
@@ -711,6 +723,8 @@ def fit(
         starting point for inference
     start_sigma: `dict[str, np.ndarray]`
         starting standard deviation for inference, only available for method 'advi'
+    backend: str, optional
+        Which computational backend to use. Recommended to be one of "numba", "c", and "jax".
 
     Other Parameters
     ----------------
@@ -739,7 +753,8 @@ def fit(
     total_grad_norm_constraint: `float`
         Bounds gradient norm, prevents exploding gradient problem
     compile_kwargs: `dict`
-        Add kwargs to pytensor.function (e.g. `{'profile': True}`)
+        Add kwargs to pytensor.function (e.g. `{'profile': True}`).
+        ``compile_kwargs["mode"]`` cannot be combined with ``backend``.
     more_replacements: `dict`
         Apply custom replacements before calculating gradients
 
@@ -772,4 +787,4 @@ def fit(
         inference = method
     else:
         raise TypeError(f"method should be one of {set(_select.keys())} or Inference instance")
-    return inference.fit(n, **kwargs)
+    return inference.fit(n, backend=backend, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,10 @@ with open(REQUIREMENTS_FILE) as f:
 
 test_reqs = ["pytest", "pytest-cov"]
 
+extras_require = {
+    "nutpie": ["nutpie>=0.16.8"],
+}
+
 if __name__ == "__main__":
     setup(
         name="pymc",
@@ -72,5 +76,6 @@ if __name__ == "__main__":
         classifiers=classifiers,
         python_requires=">=3.12",
         install_requires=install_reqs,
+        extras_require=extras_require,
         tests_require=test_reqs,
     )

--- a/tests/backends/test_arviz.py
+++ b/tests/backends/test_arviz.py
@@ -39,6 +39,7 @@ pytestmark = pytest.mark.filterwarnings(
     # Related to https://github.com/arviz-devs/arviz/issues/2327
     "ignore:datetime.datetime.utcnow():DeprecationWarning",
     r"ignore::numba.NumbaPerformanceWarning",
+    r"ignore:This process .* is multi-threaded:DeprecationWarning",
 )
 
 
@@ -240,7 +241,7 @@ class TestDataPyMC:
             idata.update(pm.sample_posterior_predictive(thinned_idata))
         test_dict = {
             "posterior": ["mu", "tau", "eta", "theta"],
-            "sample_stats": ["diverging", "lp", "~log_likelihood"],
+            "sample_stats": ["diverging", "~log_likelihood"],
             "posterior_predictive": ["obs"],
             "observed_data": ["obs"],
         }
@@ -412,7 +413,7 @@ class TestDataPyMC:
             "posterior": ["x"],
             "observed_data": ["y1", "y2"],
             "log_likelihood": ["y1", "y2"],
-            "sample_stats": ["diverging", "lp", "~log_likelihood"],
+            "sample_stats": ["diverging", "~log_likelihood"],
         }
         if not log_likelihood:
             test_dict.pop("log_likelihood")
@@ -630,7 +631,7 @@ class TestDataPyMC:
                 )
         test_dict = {
             "posterior": ["p"],
-            "sample_stats": ["lp"],
+            "sample_stats": ["diverging"],
             "log_likelihood": ["y"],
             "observed_data": ["y"],
         }

--- a/tests/backends/test_arviz.py
+++ b/tests/backends/test_arviz.py
@@ -83,11 +83,12 @@ class TestDataPyMC:
                 sigma=eight_schools_params["sigma"],
                 observed=eight_schools_params["y"],
             )
-            trace = pm.sample(
-                draws,
-                chains=chains,
-                return_inferencedata=False,
-            )
+            with pytest.warns(FutureWarning, match="return_inferencedata=False"):
+                trace = pm.sample(
+                    draws,
+                    chains=chains,
+                    return_inferencedata=False,
+                )
 
         return self.Data(model, trace)
 
@@ -276,15 +277,16 @@ class TestDataPyMC:
                 "likelihood", mu=city_temperature, sigma=0.5, observed=data, dims=data_dims
             )
 
-            trace = pm.sample(
-                return_inferencedata=False,
-                compute_convergence_checks=False,
-                cores=1,
-                chains=1,
-                tune=20,
-                draws=30,
-                step=pm.Metropolis(),
-            )
+            with pytest.warns(FutureWarning, match="return_inferencedata=False"):
+                trace = pm.sample(
+                    return_inferencedata=False,
+                    compute_convergence_checks=False,
+                    cores=1,
+                    chains=1,
+                    tune=20,
+                    draws=30,
+                    step=pm.Metropolis(),
+                )
             if use_context:
                 with warnings.catch_warnings():
                     warnings.filterwarnings("ignore", "More chains .* than draws.*", UserWarning)
@@ -313,7 +315,8 @@ class TestDataPyMC:
             x = pm.Data("x", x_data, dims=("dim1", "dim2"))
             beta = pm.Normal("beta", 0, 1, dims="dim1")
             _ = pm.Normal("obs", x * beta, 1, observed=y, dims=("dim1", "dim2"))
-            trace = pm.sample(100, tune=100, return_inferencedata=False)
+            with pytest.warns(FutureWarning, match="return_inferencedata=False"):
+                trace = pm.sample(100, tune=100, return_inferencedata=False)
             idata1 = to_inference_data(trace)
             idata2 = to_inference_data(trace, coords={"dim1": new_dim1}, dims={"beta": ["dim2"]})
 
@@ -446,7 +449,8 @@ class TestDataPyMC:
             beta_sigma = pm.Data("beta_sigma", 1)
             beta = pm.Normal("beta", 0, beta_sigma)
             obs = pm.Normal("obs", x * beta, 1, observed=y)
-            trace = pm.sample(100, chains=2, tune=100, return_inferencedata=False)
+            with pytest.warns(FutureWarning, match="return_inferencedata=False"):
+                trace = pm.sample(100, chains=2, tune=100, return_inferencedata=False)
             if use_context:
                 inference_data = to_inference_data(trace=trace, log_likelihood=True)
 
@@ -493,7 +497,8 @@ class TestDataPyMC:
             y = pm.Data("y", [1.0, 2.0, 3.0])
             beta = pm.Normal("beta", 0, 1)
             obs = pm.Normal("obs", x * beta, 1, observed=y)
-            trace = pm.sample(100, tune=100, return_inferencedata=False)
+            with pytest.warns(FutureWarning, match="return_inferencedata=False"):
+                trace = pm.sample(100, tune=100, return_inferencedata=False)
             inference_data = to_inference_data(trace)
 
         test_dict = {"posterior": ["beta"], "observed_data": ["obs"], "constant_data": ["x"]}
@@ -656,14 +661,15 @@ class TestDataPyMC:
             # The model tracks coord values as (immutable) tuples
             assert isinstance(pmodel.coords["city"], tuple)
             pm.Normal("x", dims="city")
-            mtrace = pm.sample(
-                return_inferencedata=False,
-                compute_convergence_checks=False,
-                step=pm.Metropolis(),
-                cores=1,
-                tune=7,
-                draws=15,
-            )
+            with pytest.warns(FutureWarning, match="return_inferencedata=False"):
+                mtrace = pm.sample(
+                    return_inferencedata=False,
+                    compute_convergence_checks=False,
+                    step=pm.Metropolis(),
+                    cores=1,
+                    tune=7,
+                    draws=15,
+                )
             # The converter must convert coord values them to numpy arrays
             # because tuples as coordinate values causes problems with xarray.
             converter = DataTreeConverter(trace=mtrace)
@@ -772,7 +778,10 @@ class TestPyMCWarmupHandling:
         with pm.Model():
             pm.Uniform("u1")
             pm.Normal("n1")
-            with warnings.catch_warnings():
+            with (
+                warnings.catch_warnings(),
+                pytest.warns(FutureWarning, match="return_inferencedata=False"),
+            ):
                 warnings.filterwarnings("ignore", "Tuning samples will be included.*", UserWarning)
                 trace = pm.sample(
                     tune=100,

--- a/tests/backends/test_arviz.py
+++ b/tests/backends/test_arviz.py
@@ -340,9 +340,13 @@ class TestDataPyMC:
             x = pm.Normal("x", 1, 1)
             with pytest.warns(ImputationWarning):
                 y = pm.Normal("y", x, 1, observed=data)
-            inference_data = pm.sample(
-                100, chains=2, return_inferencedata=True, idata_kwargs={"log_likelihood": True}
-            )
+            with pytest.warns(FutureWarning, match="Passing `log_likelihood` via `idata_kwargs`"):
+                inference_data = pm.sample(
+                    100,
+                    chains=2,
+                    return_inferencedata=True,
+                    idata_kwargs={"log_likelihood": True},
+                )
 
         # make sure that data is really missing
         assert "y_unobserved" in model.named_vars
@@ -369,13 +373,14 @@ class TestDataPyMC:
             chol, *_ = pm.LKJCholeskyCov("chol_cov", n=2, eta=1, sd_dist=sd_dist)
             with pytest.warns(ImputationWarning):
                 y = pm.MvNormal("y", mu=mu, chol=chol, observed=data)
-            inference_data = pm.sample(
-                tune=10,
-                draws=10,
-                chains=2,
-                step=pm.Metropolis(),
-                idata_kwargs={"log_likelihood": True},
-            )
+            with pytest.warns(FutureWarning, match="Passing `log_likelihood` via `idata_kwargs`"):
+                inference_data = pm.sample(
+                    tune=10,
+                    draws=10,
+                    chains=2,
+                    step=pm.Metropolis(),
+                    idata_kwargs={"log_likelihood": True},
+                )
 
         # make sure that data is really missing
         assert isinstance(y.owner.inputs[0].owner.op, AdvancedIncSubtensor | AdvancedIncSubtensor1)
@@ -396,12 +401,13 @@ class TestDataPyMC:
             x = pm.Normal("x", 1, 1)
             pm.Normal("y1", x, 1, observed=y1_data)
             pm.Normal("y2", x, 1, observed=y2_data)
-            inference_data = pm.sample(
-                100,
-                chains=2,
-                return_inferencedata=True,
-                idata_kwargs={"log_likelihood": log_likelihood},
-            )
+            with pytest.warns(FutureWarning, match="Passing `log_likelihood` via `idata_kwargs`"):
+                inference_data = pm.sample(
+                    100,
+                    chains=2,
+                    return_inferencedata=True,
+                    idata_kwargs={"log_likelihood": log_likelihood},
+                )
         test_dict = {
             "posterior": ["x"],
             "observed_data": ["y1", "y2"],
@@ -425,9 +431,13 @@ class TestDataPyMC:
         with pm.Model():
             p = pm.Uniform("p", 0, 1)
             pm.Binomial("w", p=p, n=2, observed=[1])
-            inference_data = pm.sample(
-                500, chains=2, return_inferencedata=True, idata_kwargs={"log_likelihood": True}
-            )
+            with pytest.warns(FutureWarning, match="Passing `log_likelihood` via `idata_kwargs`"):
+                inference_data = pm.sample(
+                    500,
+                    chains=2,
+                    return_inferencedata=True,
+                    idata_kwargs={"log_likelihood": True},
+                )
 
         assert inference_data
         assert inference_data.log_likelihood["w"].shape == (2, 500, 1)
@@ -606,7 +616,10 @@ class TestDataPyMC:
             p = pm.Beta("p", 1, 1, size=(3,))
             p = p / p.sum()
             pm.Multinomial("y", 20, p, dims=("experiment", "direction"), observed=data)
-            with warnings.catch_warnings():
+            with (
+                warnings.catch_warnings(),
+                pytest.warns(FutureWarning, match="Passing `log_likelihood` via `idata_kwargs`"),
+            ):
                 warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
                 idata = pm.sample(
                     draws=50,

--- a/tests/backends/test_zarr.py
+++ b/tests/backends/test_zarr.py
@@ -14,6 +14,7 @@
 import itertools
 
 from dataclasses import asdict
+from importlib.metadata import version
 
 import numpy as np
 import pytest
@@ -27,6 +28,16 @@ from pymc.stats.convergence import SamplerWarning
 from pymc.step_methods import NUTS, CompoundStep, Metropolis
 from pymc.step_methods.state import equal_dataclass_values
 from tests.helpers import equal_sampling_states
+
+# PyMC's `ZarrTrace` still uses zarr 2 module-level APIs (`zarr.TempStore`,
+# `zarr.MemoryStore`) and the removed `synchronizer` kwarg. When a dependency
+# (e.g., installed nutpie) pulls in zarr>=3, the whole suite fails on import /
+# attribute access. xfail the module in that case until the port lands.
+pytestmark = pytest.mark.xfail(
+    int(version("zarr").split(".", 1)[0]) >= 3,
+    reason="PyMC's ZarrTrace is not yet ported to zarr 3",
+    strict=False,
+)
 
 
 @pytest.fixture(scope="module")

--- a/tests/distributions/test_custom.py
+++ b/tests/distributions/test_custom.py
@@ -151,7 +151,9 @@ class TestCustomDist:
             assert isinstance(y_dist.owner.op, CustomDistRV)
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
-                sample(draws=5, tune=1, mp_ctx="spawn")
+                # nutpie can't handle RNG in deterministics
+                # https://github.com/pymc-devs/nutpie/issues/4
+                sample(draws=5, tune=1, mp_ctx="spawn", nuts_sampler="pymc")
 
         cloudpickle.loads(cloudpickle.dumps(y))
         cloudpickle.loads(cloudpickle.dumps(y_dist))

--- a/tests/progress_bar/test_manager.py
+++ b/tests/progress_bar/test_manager.py
@@ -56,6 +56,8 @@ def test_mcmc_split_bar_starts_at_zero_ends_at_total():
                 cores=1,
                 progressbar=True,
                 compute_convergence_checks=False,
+                # Test is patching the progress bar used for pymc nuts_sampler
+                nuts_sampler="pymc",
             )
 
     manager = captured["manager"]
@@ -86,6 +88,8 @@ def test_mcmc_combined_bar_ends_at_total():
                 cores=1,
                 progressbar="combined+stats",
                 compute_convergence_checks=False,
+                # Test is patching the progress bar used for pymc nuts_sampler
+                nuts_sampler="pymc",
             )
 
     manager = captured["manager"]

--- a/tests/sampling/test_deterministic.py
+++ b/tests/sampling/test_deterministic.py
@@ -25,7 +25,8 @@ from pymc.sampling.forward import sample_prior_predictive
 pytestmark = pytest.mark.filterwarnings("error")
 
 
-def test_compute_deterministics():
+@pytest.mark.parametrize("via", ["compile_kwargs", "backend"])
+def test_compute_deterministics(via):
     with Model(coords={"group": (0, 2, 4)}) as m:
         mu_raw = Normal("mu_raw", 0, 1, dims="group")
         mu = Deterministic("mu", mu_raw.cumsum(), dims="group")
@@ -47,13 +48,18 @@ def test_compute_deterministics():
     assert_allclose(all_dets["sigma"], np.exp(dataset["sigma_raw"]))
 
     # Test custom arguments
+    mode_kwargs = (
+        {"compile_kwargs": {"mode": "FAST_COMPILE"}}
+        if via == "compile_kwargs"
+        else {"backend": "FAST_COMPILE"}
+    )
     extended_with_mu = compute_deterministics(
         dataset,
         var_names=["mu"],
         merge_dataset=True,
         model=m,
-        compile_kwargs={"mode": "FAST_COMPILE"},
         progressbar=False,
+        **mode_kwargs,
     )
     assert set(extended_with_mu.data_vars.variables) == {"mu_raw", "sigma_raw", "mu"}
     assert extended_with_mu["mu"].dims == ("chain", "draw", "group")

--- a/tests/sampling/test_forward.py
+++ b/tests/sampling/test_forward.py
@@ -823,7 +823,7 @@ class TestSamplePPC:
 
         base_test_dict = {
             "posterior": ["mu", "~a"],
-            "sample_stats": ["diverging", "lp"],
+            "sample_stats": ["diverging"],
             "observed_data": ["a"],
         }
         test_dict = {"~posterior_predictive": [], "~predictions": [], **base_test_dict}

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -78,26 +78,27 @@ class TestSample:
     def test_random_seed(self, chains, seeds, cores, init):
         with pm.Model():
             x = pm.Normal("x", 0, 10, initval="prior")
-            tr1 = pm.sample(
-                chains=chains,
-                random_seed=seeds,
-                cores=cores,
-                init=init,
-                tune=0,
-                draws=10,
-                return_inferencedata=False,
-                compute_convergence_checks=False,
-            )
-            tr2 = pm.sample(
-                chains=chains,
-                random_seed=seeds,
-                cores=cores,
-                init=init,
-                tune=0,
-                draws=10,
-                return_inferencedata=False,
-                compute_convergence_checks=False,
-            )
+            with pytest.warns(FutureWarning, match="return_inferencedata=False"):
+                tr1 = pm.sample(
+                    chains=chains,
+                    random_seed=seeds,
+                    cores=cores,
+                    init=init,
+                    tune=0,
+                    draws=10,
+                    return_inferencedata=False,
+                    compute_convergence_checks=False,
+                )
+                tr2 = pm.sample(
+                    chains=chains,
+                    random_seed=seeds,
+                    cores=cores,
+                    init=init,
+                    tune=0,
+                    draws=10,
+                    return_inferencedata=False,
+                    compute_convergence_checks=False,
+                )
 
         allequal = np.all(tr1["x"] == tr2["x"])
         if seeds is None:
@@ -128,7 +129,10 @@ class TestSample:
             "return_inferencedata": False,
         }
         with self.model:
-            with warnings.catch_warnings():
+            with (
+                warnings.catch_warnings(),
+                pytest.warns(FutureWarning, match="return_inferencedata=False"),
+            ):
                 warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
                 np.random.seed(1)
                 idata11 = pm.sample(chains=1, **kwargs)
@@ -254,7 +258,10 @@ class TestSample:
                 raise KeyboardInterrupt()
 
         with self.model:
-            with warnings.catch_warnings():
+            with (
+                warnings.catch_warnings(),
+                pytest.warns(FutureWarning, match="return_inferencedata=False"),
+            ):
                 warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
                 trace = pm.sample(
                     10,
@@ -307,7 +314,10 @@ class TestSample:
                 bounds_fn=lambda *inputs: (inputs[-2], inputs[-1])
             )
             y = pm.Uniform("y", lower=0, upper=x, transform=transform, default_transform=None)
-            with warnings.catch_warnings():
+            with (
+                warnings.catch_warnings(),
+                pytest.warns(FutureWarning, match="return_inferencedata=False"),
+            ):
                 warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
                 trace = pm.sample(tune=10, draws=50, return_inferencedata=False, random_seed=336)
 
@@ -340,7 +350,10 @@ class TestSampleReturn:
             pm.Normal("n")
 
             # Get a MultiTrace with warmup
-            with pytest.warns(UserWarning, match="will be included"):
+            with (
+                pytest.warns(UserWarning, match="will be included"),
+                pytest.warns(FutureWarning, match="return_inferencedata=False"),
+            ):
                 mtrace = pm.sample(
                     draws=100,
                     tune=50,

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -683,8 +683,14 @@ def test_init_jitter(initval, jitter_max_retries, expectation):
 
 
 def test_step_args():
+    # pymc-NUTS names it `acceptance_rate`, nutpie names it `mean_tree_accept`.
+    def accept(idata):
+        stats = idata.sample_stats
+        return stats.acceptance_rate if "acceptance_rate" in stats else stats.mean_tree_accept
+
     with pm.Model() as model:
         a = pm.Normal("a")
+        idata_default = pm.sample(random_seed=1410)
         idata0 = pm.sample(target_accept=0.5, random_seed=1410)
         idata1 = pm.sample(nuts={"target_accept": 0.5}, random_seed=1410 * 2)
         idata2 = pm.sample(target_accept=0.5, nuts={"max_treedepth": 10}, random_seed=1410)
@@ -692,9 +698,12 @@ def test_step_args():
         with pytest.raises(ValueError, match="`target_accept` was defined twice."):
             pm.sample(target_accept=0.5, nuts={"target_accept": 0.95}, random_seed=1410)
 
-    npt.assert_almost_equal(idata0.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
-    npt.assert_almost_equal(idata1.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
-    npt.assert_almost_equal(idata2.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
+    # Negative control: default target_accept (0.8) must land far from 0.5, so the
+    # positive assertions below can only pass when `target_accept=0.5` was honored.
+    assert accept(idata_default).mean() > 0.6
+    npt.assert_almost_equal(accept(idata0).mean(), 0.5, decimal=1)
+    npt.assert_almost_equal(accept(idata1).mean(), 0.5, decimal=1)
+    npt.assert_almost_equal(accept(idata2).mean(), 0.5, decimal=1)
 
     with pm.Model() as model:
         a = pm.Normal("a")
@@ -708,8 +717,8 @@ def test_step_args():
                 nuts={"target_accept": 0.5}, metropolis={"scaling": 0}, random_seed=1418 * 2
             )
 
-    npt.assert_almost_equal(idata0.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
-    npt.assert_almost_equal(idata1.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
+    npt.assert_almost_equal(accept(idata0).mean(), 0.5, decimal=1)
+    npt.assert_almost_equal(accept(idata1).mean(), 0.5, decimal=1)
     npt.assert_allclose(idata1.sample_stats.scaling, 0)
 
 
@@ -718,7 +727,8 @@ def test_init_nuts(caplog):
         a = pm.Normal("a")
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
-            pm.sample(10, tune=10)
+            # `init_nuts` is a pymc-sampler-only code path.
+            pm.sample(10, tune=10, nuts_sampler="pymc")
         assert "Initializing NUTS" in caplog.text
 
 
@@ -927,7 +937,8 @@ class TestShared:
             pm.Normal("obs", b * x_shared, np.sqrt(1e-2), observed=y, shape=x_shared.shape)
             prior_trace0 = pm.sample_prior_predictive(1000)
 
-            idata = pm.sample(1000, tune=1000, chains=1)
+            # Nutpie fails with unnamed shared variables
+            idata = pm.sample(1000, tune=1000, chains=1, nuts_sampler="pymc")
             pp_trace0 = pm.sample_posterior_predictive(idata)
 
             x_shared.set_value(x_pred)

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -84,7 +84,7 @@ def test_step_args():
         idata = sample(
             nuts_sampler="numpyro",
             target_accept=0.5,
-            nuts={"max_treedepth": 10},
+            nuts={"max_tree_depth": 10},
             random_seed=1411,
             progressbar=False,
         )

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -13,15 +13,29 @@
 #   limitations under the License.
 
 import unittest.mock as mock
+import warnings
 
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import numpy as np
 import numpy.testing as npt
+import pytensor.tensor as pt
 import pytest
 import xarray as xr
 
-from pymc import Data, Deterministic, HalfNormal, Model, Normal, sample
+from pymc import (
+    NUTS,
+    Data,
+    Deterministic,
+    HalfNormal,
+    Metropolis,
+    Model,
+    Normal,
+    Potential,
+    sample,
+)
+from pymc.exceptions import SamplingError
 from pymc.progress_bar import NutpieProgressBarManager
 
 pytestmark = pytest.mark.filterwarnings(
@@ -31,10 +45,8 @@ pytestmark = pytest.mark.filterwarnings(
 )
 
 
-# temporarily skip nutpie
-@pytest.mark.parametrize("nuts_sampler", ["pymc", "blackjax", "numpyro"])
-# @pytest.mark.parametrize("nuts_sampler", ["pymc", "nutpie", "blackjax", "numpyro"])
-def test_external_nuts_sampler(recwarn, nuts_sampler):
+@pytest.mark.parametrize("nuts_sampler", ["pymc", "nutpie", "blackjax", "numpyro"])
+def test_external_nuts_sampler(nuts_sampler):
     if nuts_sampler != "pymc":
         pytest.importorskip(nuts_sampler)
 
@@ -145,6 +157,52 @@ def test_sample_var_names(nuts_sampler):
         xr.testing.assert_allclose(idata_1.posterior[var], idata_2.posterior[var])
 
 
+@pytest.mark.parametrize(
+    "initvals",
+    [
+        None,
+        {"x1": 10000.0, "x2": 0.0},
+        {"x1": 10000.0},
+        {"x1_log__": np.log(10000.0)},
+    ],
+    ids=["negative_control", "full_constrained", "partial_constrained", "unconstrained_partial"],
+)
+@pytest.mark.parametrize("nuts_sampler", ["pymc", "nutpie", "blackjax", "numpyro"])
+def test_initvals(nuts_sampler, initvals):
+    if nuts_sampler != "pymc":
+        pytest.importorskip(nuts_sampler)
+
+    # `x1` has a log transform; we pin it to 10000. Three guards check the value
+    # is mapped through the transform correctly:
+    #   - the `x1 - x2 > 1000` constraint excludes log(10000) ≈ 9.2 (wrong:
+    #     `x1_log__` value taken as constrained), and excludes default init
+    #     (x1 ≈ 79.8 ± jitter < 1000),
+    #   - the `x1 < 1e6` upper bound excludes exp(10000) (wrong: dict value
+    #     taken as if it were already on the transformed/unconstrained space).
+    with Model():
+        x1 = HalfNormal("x1", 100)
+        x2 = Normal("x2", 0, 1)
+        Potential("c", pt.where(x1 - x2 > 1000, 0.0, -np.inf))
+
+        with pytest.raises((SamplingError, RuntimeError)) if initvals is None else nullcontext():
+            idata = sample(
+                nuts_sampler=nuts_sampler,
+                tune=1,
+                draws=3,
+                chains=2,
+                progressbar=False,
+                random_seed=0,
+                compute_convergence_checks=False,
+                initvals=initvals,
+            )
+        if initvals is None:
+            return
+
+    assert idata.posterior.chain.size == 2
+    assert ((idata.posterior["x1"] - idata.posterior["x2"]) > 1000).all()
+    assert (idata.posterior["x1"] < 1e6).all()
+
+
 def test_nutpie_progress_bar_manager_update():
     pb = NutpieProgressBarManager(chains=2, draws=10, tune=10, progressbar=False)
     pb._backend = mock.Mock()
@@ -187,13 +245,6 @@ def test_nutpie_progress_bar_manager_update():
 
 
 def test_nutpie_end_to_end():
-    # Released nutpie 0.16.8 references `arviz.InferenceData` which arviz 1.0 removed,
-    # so `import nutpie` raises AttributeError on the current CI matrix. Skip until a
-    # nutpie release compatible with arviz 1.0 ships.
-    try:
-        import nutpie  # noqa: F401
-    except (ImportError, AttributeError):
-        pytest.skip("nutpie unavailable or incompatible with the installed arviz")
     with Model() as m:
         HalfNormal("sigma")
         Normal("mu")
@@ -209,3 +260,158 @@ def test_nutpie_end_to_end():
     assert {"posterior", "sample_stats", "observed_data"} <= set(idata.children)
     assert set(idata.posterior.data_vars) == {"mu", "sigma"}
     assert idata.posterior.sizes == {"chain": 2, "draw": 20}
+
+
+@pytest.fixture
+def patched_sampler():
+    """Pretend nutpie is installed and intercept any dispatch to it."""
+    with (
+        mock.patch("pymc.sampling.mcmc.NUTPIE_INSTALLED", True),
+        mock.patch("pymc.sampling.mcmc._sample_external_nuts") as mock_ext,
+    ):
+        yield mock_ext
+
+
+class TestExternalSamplerKwargCompat:
+    """Validate how `pm.sample` handles kwargs that external samplers don't fully honor."""
+
+    with Model() as _model:
+        Normal("x")
+
+    _BASE_KWARGS = {
+        "tune": 2,
+        "draws": 2,
+        "chains": 1,
+        "progressbar": False,
+        "compile_kwargs": {"mode": "NUMBA"},
+    }
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            {"return_inferencedata": False},
+            {"trace": object()},
+            {"callback": lambda **kw: None},
+        ],
+        ids=["return_inferencedata_false", "custom_trace", "callback"],
+    )
+    def test_explicit_nutpie_raises_on_incompatible(self, patched_sampler, extra):
+        pytest.importorskip("nutpie")
+
+        # Filter the separate FutureWarning for return_inferencedata=False; we only
+        # care that pm.sample raises the external-sampler ValueError.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", ".*return_inferencedata=False.*", FutureWarning)
+            with self._model:
+                with pytest.raises(ValueError, match="`nuts_sampler='nutpie'`"):
+                    sample(nuts_sampler="nutpie", **self._BASE_KWARGS, **extra)
+        patched_sampler.assert_not_called()
+
+    def test_explicit_nutpie_raises_on_non_nuts_step(self, patched_sampler):
+        pytest.importorskip("nutpie")
+        with self._model:
+            step = Metropolis()
+            with pytest.raises(ValueError, match="not assigned to another step sampler"):
+                sample(nuts_sampler="nutpie", step=step, **self._BASE_KWARGS)
+        patched_sampler.assert_not_called()
+
+    def test_explicit_nutpie_warns_on_non_default_init(self, patched_sampler):
+        pytest.importorskip("nutpie")
+        with self._model:
+            with pytest.warns(UserWarning, match="`init='advi'` is ignored"):
+                sample(nuts_sampler="nutpie", init="advi", **self._BASE_KWARGS)
+        patched_sampler.assert_called_once()
+
+    def test_explicit_nutpie_warns_on_provided_nuts_step(self, patched_sampler):
+        pytest.importorskip("nutpie")
+        with self._model:
+            step = NUTS()
+            with pytest.warns(UserWarning, match="NUTS `step` is ignored"):
+                sample(nuts_sampler="nutpie", step=step, **self._BASE_KWARGS)
+        patched_sampler.assert_called_once()
+
+    def test_explicit_nutpie_raises_on_per_chain_initvals(self):
+        pytest.importorskip("nutpie")
+        with self._model, pytest.raises(NotImplementedError, match="per-chain"):
+            sample(
+                nuts_sampler="nutpie",
+                initvals=[{"x": 0.0}, {"x": 1.0}],
+                tune=1,
+                draws=1,
+                chains=2,
+                progressbar=False,
+            )
+
+
+class TestNutpieAutoSelection:
+    """Validate when `pm.sample` auto-selects nutpie based on env/compile mode."""
+
+    with Model() as _model:
+        Normal("x")
+
+    _BASE_KWARGS = {
+        "tune": 10,
+        "draws": 10,
+        "chains": 1,
+        "progressbar": False,
+    }
+
+    @pytest.mark.parametrize("mode", ["NUMBA", "JAX"])
+    @pytest.mark.parametrize("via", ["compile_kwargs", "backend"])
+    def test_auto_selects_nutpie_when_installed(self, patched_sampler, mode, via):
+        extra = {"compile_kwargs": {"mode": mode}} if via == "compile_kwargs" else {"backend": mode}
+        with self._model:
+            sample(**self._BASE_KWARGS, **extra)
+        assert patched_sampler.call_args.kwargs["sampler"] == "nutpie"
+
+    def test_falls_back_to_pymc_when_nutpie_missing(self):
+        with (
+            mock.patch("pymc.sampling.mcmc.NUTPIE_INSTALLED", False),
+            mock.patch("pymc.sampling.mcmc._sample_external_nuts") as mock_ext,
+        ):
+            with self._model:
+                sample(**self._BASE_KWARGS)
+        mock_ext.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "arg_name,arg",
+        [
+            ("return_inferencedata", False),
+            ("trace", object()),
+            ("callback", lambda **kw: None),
+            ("init", "advi"),
+            ("step", Metropolis),
+            # Non numba/jax backends
+            ("backend", "c"),
+            ("compile_kwargs", {"mode": "FAST_COMPILE"}),
+            # Per-chain initvals
+            ("initvals", [{"x": 0.0}, {"x": 1.0}]),
+        ],
+    )
+    def test_falls_back_to_pymc_for_disqualifying_kwargs(self, patched_sampler, arg_name, arg):
+        # Each of these kwargs disqualifies nutpie auto-selection; pm.sample should
+        # route to the pymc sampler (external stub never called) instead of raising.
+        # Numba is the default linker, so we don't need to set `compile_kwargs` to
+        # qualify for nutpie auto-pick — that means each entry can stand alone here.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", ".*return_inferencedata=False.*", FutureWarning)
+            with self._model:
+                try:
+                    sample(**self._BASE_KWARGS, **{arg_name: arg})
+                except Exception:
+                    # The pymc path may error on the stand-in objects (dummy trace, etc.);
+                    # we only care that nutpie wasn't dispatched.
+                    pass
+        patched_sampler.assert_not_called()
+
+    def test_falls_back_to_pymc_for_configured_nuts_step(self, patched_sampler):
+        # A pre-built NUTS instance with a non-default argument (here a custom
+        # mass-matrix potential) carries user state that nutpie cannot consume.
+        # Auto-selection must fall back to the pymc sampler rather than silently
+        # dropping the configuration.
+        from pymc.step_methods.hmc.quadpotential import QuadPotentialDiag
+
+        with self._model:
+            step = NUTS(potential=QuadPotentialDiag(np.ones(1)))
+            sample(step=step, **self._BASE_KWARGS)
+        patched_sampler.assert_not_called()

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -19,6 +19,12 @@ import xarray as xr
 
 from pymc import Data, Deterministic, HalfNormal, Model, Normal, sample
 
+pytestmark = pytest.mark.filterwarnings(
+    "error",
+    "ignore:There are not enough devices to run parallel chains:UserWarning",
+    "ignore:os.fork\\(\\) was called:RuntimeWarning",
+)
+
 
 # temporarily skip nutpie
 @pytest.mark.parametrize("nuts_sampler", ["pymc", "blackjax", "numpyro"])
@@ -51,21 +57,6 @@ def test_external_nuts_sampler(recwarn, nuts_sampler):
         reference_kwargs["nuts_sampler"] = "pymc"
         idata_reference = sample(**reference_kwargs)
 
-    warns = {
-        (warn.category, warn.message.args[0])
-        for warn in recwarn
-        if warn.category not in (FutureWarning, DeprecationWarning, RuntimeWarning)
-    }
-    expected = set()
-    if nuts_sampler == "nutpie":
-        expected.add(
-            (
-                UserWarning,
-                "`initvals` are currently not passed to nutpie sampler. "
-                "Use `init_mean` kwarg following nutpie specification instead.",
-            )
-        )
-    assert warns == expected
     assert "y" in idata1.constant_data
     assert "z" in idata1.constant_data
     assert "L" in idata1.observed_data

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -100,9 +100,7 @@ def test_step_args():
     npt.assert_almost_equal(idata.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
 
 
-# temporarily skip nutpie
-@pytest.mark.parametrize("nuts_sampler", ["pymc", "blackjax", "numpyro"])
-# @pytest.mark.parametrize("nuts_sampler", ["pymc", "nutpie", "blackjax", "numpyro"])
+@pytest.mark.parametrize("nuts_sampler", ["pymc", "nutpie", "blackjax", "numpyro"])
 def test_sample_var_names(nuts_sampler):
     if nuts_sampler != "pymc":
         pytest.importorskip(nuts_sampler)

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -12,12 +12,17 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import unittest.mock as mock
+
+from types import SimpleNamespace
+
 import numpy as np
 import numpy.testing as npt
 import pytest
 import xarray as xr
 
 from pymc import Data, Deterministic, HalfNormal, Model, Normal, sample
+from pymc.progress_bar import NutpieProgressBarManager
 
 pytestmark = pytest.mark.filterwarnings(
     "error",
@@ -138,3 +143,69 @@ def test_sample_var_names(nuts_sampler):
         assert var in idata_2.posterior
 
         xr.testing.assert_allclose(idata_1.posterior[var], idata_2.posterior[var])
+
+
+def test_nutpie_progress_bar_manager_update():
+    pb = NutpieProgressBarManager(chains=2, draws=10, tune=10, progressbar=False)
+    pb._backend = mock.Mock()
+    pb._show_progress = True  # force the update path even without a real backend
+
+    cp0 = SimpleNamespace(
+        finished_draws=5,
+        total_draws=20,
+        divergences=0,
+        step_size=0.5,
+        latest_num_steps=3,
+    )
+    cp1 = SimpleNamespace(
+        finished_draws=4,
+        total_draws=20,
+        divergences=1,
+        step_size=0.4,
+        latest_num_steps=7,
+    )
+    pb.update([cp0, cp1])
+    assert pb._backend.update.call_count == 2
+    first_call = pb._backend.update.call_args_list[0].kwargs
+    assert first_call["task_id"] == 0
+    assert first_call["advance"] == 5
+    assert first_call["stats"]["divergences"] == 0
+    second_call = pb._backend.update.call_args_list[1].kwargs
+    assert second_call["task_id"] == 1
+    assert second_call["advance"] == 4
+    assert second_call["failing"] is True
+
+    # A second update only advances by the delta since the previous call.
+    cp0.finished_draws = 20
+    cp1.finished_draws = 20
+    pb._backend.update.reset_mock()
+    pb.update([cp0, cp1])
+    deltas = [c.kwargs["advance"] for c in pb._backend.update.call_args_list]
+    is_last_flags = [c.kwargs["is_last"] for c in pb._backend.update.call_args_list]
+    assert deltas == [15, 16]
+    assert is_last_flags == [True, True]
+
+
+def test_nutpie_end_to_end():
+    # Released nutpie 0.16.8 references `arviz.InferenceData` which arviz 1.0 removed,
+    # so `import nutpie` raises AttributeError on the current CI matrix. Skip until a
+    # nutpie release compatible with arviz 1.0 ships.
+    try:
+        import nutpie  # noqa: F401
+    except (ImportError, AttributeError):
+        pytest.skip("nutpie unavailable or incompatible with the installed arviz")
+    with Model() as m:
+        HalfNormal("sigma")
+        Normal("mu")
+        Normal("y", mu=0, sigma=1, observed=[1.0, 2.0, 3.0])
+        idata = sample(
+            nuts_sampler="nutpie",
+            tune=20,
+            draws=20,
+            chains=2,
+            progressbar=False,
+            random_seed=1411,
+        )
+    assert {"posterior", "sample_stats", "observed_data"} <= set(idata.children)
+    assert set(idata.posterior.data_vars) == {"mu", "sigma"}
+    assert idata.posterior.sizes == {"chain": 2, "draw": 20}

--- a/tests/sampling/test_parallel.py
+++ b/tests/sampling/test_parallel.py
@@ -41,6 +41,42 @@ def test_context():
             pm.sample(tune=2, draws=2, chains=2, cores=2, mp_ctx=ctx)
 
 
+class TestMpCtxJaxSwitch:
+    def test_switches_default_away_from_fork_under_jax(self):
+        if ps._initialize_multiprocessing_context(None).get_start_method() != "fork":
+            pytest.skip("platform default is not fork")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            ctx = ps._initialize_multiprocessing_context(None, mode="JAX")
+        assert ctx.get_start_method() != "fork"
+        assert not any("JAX backend" in str(x.message) for x in w)
+
+    def test_warns_when_user_explicitly_picks_fork_under_jax(self):
+        if "fork" not in multiprocessing.get_all_start_methods():
+            pytest.skip("fork start method not available on this platform")
+        with pytest.warns(UserWarning, match="JAX backend"):
+            ctx = ps._initialize_multiprocessing_context("fork", mode="JAX")
+        assert ctx.get_start_method() == "fork"
+
+    def test_leaves_non_jax_default_alone(self):
+        expected = ps._initialize_multiprocessing_context(None).get_start_method()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            ctx = ps._initialize_multiprocessing_context(None, mode="NUMBA")
+        assert ctx.get_start_method() == expected
+        assert not any("JAX backend" in str(x.message) for x in w)
+
+    @pytest.mark.parametrize("explicit", ["spawn", "forkserver"])
+    def test_no_warn_when_user_picks_safe_method(self, explicit):
+        if explicit not in multiprocessing.get_all_start_methods():
+            pytest.skip(f"{explicit} start method not available on this platform")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            ctx = ps._initialize_multiprocessing_context(explicit, mode="JAX")
+        assert ctx.get_start_method() == explicit
+        assert not any("JAX backend" in str(x.message) for x in w)
+
+
 class NoUnpickle:
     def __getstate__(self):
         return self.__dict__.copy()

--- a/tests/stats/test_log_density.py
+++ b/tests/stats/test_log_density.py
@@ -18,6 +18,7 @@ import pytest
 import scipy.stats as st
 
 from arviz_base import from_dict
+from pytensor.compile import get_mode
 
 from pymc.distributions import Dirichlet, Normal
 from pymc.distributions.transforms import log
@@ -177,22 +178,31 @@ class TestComputeLogLikelihood:
             st.norm(0, 1).logpdf(idata.posterior["x"].values),
         )
 
-    def test_compilation_kwargs(self):
+    @pytest.mark.parametrize("via", ["compile_kwargs", "backend"])
+    def test_compilation_kwargs(self, via):
         with Model() as m:
             x = Normal("x")
             Deterministic("d", 2 * x)
             Normal("y", x, observed=[0, 1, 2])
 
             idata = from_dict({"posterior": {"x": np.arange(100).reshape(4, 25)}})
+            prior_kwargs = (
+                {"compile_kwargs": {"mode": "JAX"}}
+                if via == "compile_kwargs"
+                else {"backend": "JAX"}
+            )
+            lik_kwargs = (
+                {"compile_kwargs": {"mode": "NUMBA"}}
+                if via == "compile_kwargs"
+                else {"backend": "NUMBA"}
+            )
             with (
                 # apply_function_over_dataset fails with patched `compile_pymc`
                 patch("pymc.stats.log_density.apply_function_over_dataset"),
                 patch("pymc.model.core.compile") as patched_compile,
             ):
-                compute_log_prior(idata, compile_kwargs={"mode": "JAX"}, extend_inferencedata=False)
-                compute_log_likelihood(
-                    idata, compile_kwargs={"mode": "NUMBA"}, extend_inferencedata=False
-                )
+                compute_log_prior(idata, extend_inferencedata=False, **prior_kwargs)
+                compute_log_likelihood(idata, extend_inferencedata=False, **lik_kwargs)
         assert len(patched_compile.call_args_list) == 2
-        assert patched_compile.call_args_list[0].kwargs["mode"] == "JAX"
-        assert patched_compile.call_args_list[1].kwargs["mode"] == "NUMBA"
+        assert get_mode(patched_compile.call_args_list[0].kwargs["mode"]) == get_mode("JAX")
+        assert get_mode(patched_compile.call_args_list[1].kwargs["mode"]) == get_mode("NUMBA")

--- a/tests/step_methods/hmc/test_nuts.py
+++ b/tests/step_methods/hmc/test_nuts.py
@@ -115,14 +115,16 @@ class TestNutsCheckTrace:
         with pm.Model():
             pm.HalfNormal("a", sigma=1, initval=-1, default_transform=None)
             with pytest.raises(SamplingError) as error:
-                pm.sample(chains=1, random_seed=1)
+                # Testing PyMC NUTS pipeline
+                pm.sample(chains=1, random_seed=1, nuts_sampler="pymc")
             error.match("Initial evaluation")
 
     def test_bad_init_parallel(self):
         with pm.Model():
             pm.HalfNormal("a", sigma=1, initval=-1, default_transform=None)
             with pytest.raises(SamplingError) as error:
-                pm.sample(cores=2, random_seed=1)
+                # Testing PyMC NUTS pipeline
+                pm.sample(cores=2, random_seed=1, nuts_sampler="pymc")
             error.match("Initial evaluation")
 
     def test_emits_energy_warnings(self, caplog):
@@ -134,7 +136,8 @@ class TestNutsCheckTrace:
             caplog.clear()
             # The logger name must be specified for DEBUG level capturing to work
             with caplog.at_level(logging.DEBUG, logger="pymc"):
-                idata = pm.sample(20, tune=5, chains=2, random_seed=526)
+                # Testing PyMC NUTS behavior
+                idata = pm.sample(20, tune=5, chains=2, random_seed=526, nuts_sampler="pymc")
             assert any("Energy change" in w.msg for w in caplog.records)
 
     def test_sampler_stats(self):

--- a/tests/test_pytensorf.py
+++ b/tests/test_pytensorf.py
@@ -25,6 +25,7 @@ from pytensor import scan, shared
 from pytensor.compile import UnusedInputError
 from pytensor.compile.builders import OpFromGraph
 from pytensor.graph.basic import Variable, equal_computations
+from pytensor.link.vm import VMLinker
 from pytensor.tensor.subtensor import AdvancedIncSubtensor
 
 import pymc as pm
@@ -46,6 +47,7 @@ from pymc.pytensorf import (
     replace_rng_nodes,
     replace_vars_in_graphs,
     reseed_rngs,
+    resolve_backend_compile_kwargs,
 )
 from pymc.vartypes import int_types
 
@@ -566,6 +568,31 @@ class TestCompile:
         assert collect_default_updates([x]) == {rng: next_rng}
         assert collect_default_updates([y]) == {rng: next_rng}
         assert collect_default_updates([x, y]) == {rng: next_rng}
+
+
+class TestResolveBackendCompileKwargs:
+    def test_backend_materializes_as_mode(self):
+        out = resolve_backend_compile_kwargs("numba", None)
+        assert isinstance(out["mode"], pytensor.compile.Mode)
+
+    def test_passthrough_when_backend_none(self):
+        assert resolve_backend_compile_kwargs(None, None) == {}
+        assert resolve_backend_compile_kwargs(None, {"profile": True}) == {"profile": True}
+
+    def test_does_not_mutate_caller(self):
+        original = {"profile": True}
+        resolve_backend_compile_kwargs("numba", original)
+        assert original == {"profile": True}
+
+    def test_raises_when_backend_conflicts_with_mode(self):
+        with pytest.raises(ValueError, match="Can only define one of"):
+            resolve_backend_compile_kwargs("numba", {"mode": "FAST_RUN"})
+
+    def test_backend_c_aliases_cvm(self):
+        out = resolve_backend_compile_kwargs("c", None)
+        linker = out["mode"].linker
+        assert isinstance(linker, VMLinker)
+        assert linker.use_cloop is True
 
 
 def test_replace_rng_nodes():


### PR DESCRIPTION
Other goodies (git history is clean, check commit-per-commit if you want):
* `pip install pymc[nutpie]`
* backend="numba"|"jax"|"c" argument. More user friendly than compile_kwargs=dict(mode="jax").
* Tries as best as possible avoid fork when jax is requested (doesn't cover all paths or jitted functions in op perform method), but should be strictly better. Python is dropping fork so it's temp aid (Closes #7668).
* More deliberate choice on whether to ignore/warn/fail when external nuts sampler are requested alongside exotic sample arguments that aren't supported. Closes #7923

This will create a bit of a tricky pymc-nutpie circular optional dependency. We have to make sure neither breaks the other before we release. There's also a soft warning machinery now to ask users to update, before we totally remove support for old nutpie functionality/API


Closes #8079
Closes #8111 
Closes #8250 
Closes #7923
Closes #7497
Closes #7668