### PR TITLE
docs: fix math nesting by removing redundant delimiters

### DIFF
--- a/docs/source/learn/core_notebooks/pymc_overview.ipynb
+++ b/docs/source/learn/core_notebooks/pymc_overview.ipynb
@@ -3363,14 +3363,12 @@
     "\n",
     "Finally, to allow the NUTS sampler to sample the $\\beta_i$ more efficiently, we will re-parameterize it as follows:\n",
     "\n",
-    "$$\n",
     "\\begin{align*}\n",
     "    z_i\n",
     "        & \\sim N(0, 1), \\\\\n",
     "     \\beta_i\n",
     "         & = z_i \\cdot \\tau \\cdot \\tilde{\\lambda_i}.\n",
     "\\end{align*}\n",
-    "$$\n",
     "\n",
     "You will run into this reparameterization a lot in practice.\n"
    ]


### PR DESCRIPTION

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

Fixing the rendering in documentation - 

<img width="885" height="222" alt="image" src="https://github.com/user-attachments/assets/8acdb84c-9251-4759-aadf-d24ce50cdc4d" />

