### PR TITLE
Add Model.table() method

### DIFF
--- a/docs/source/api/misc.rst
+++ b/docs/source/api/misc.rst
@@ -10,3 +10,4 @@ Other utils
    compute_log_prior
    find_constrained_prior
    DictToArrayBijection
+   model_table

--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -2036,6 +2036,26 @@ class Model(WithMemoization, metaclass=ContextMeta):
             dpi=dpi,
         )
 
+    def table(
+        self,
+        *,
+        split_groups: bool = True,
+        truncate_deterministic: int | None = None,
+        parameter_count: bool = True,
+    ):
+        """Create a rich table summarizing the model's variables and their expressions.
+
+        See :func:`pymc.model_table` for details.
+        """
+        from pymc.printing import model_table
+
+        return model_table(
+            self,
+            split_groups=split_groups,
+            truncate_deterministic=truncate_deterministic,
+            parameter_count=parameter_count,
+        )
+
 
 class BlockModelAccess(Model):
     """Can be used to prevent user access to Model contexts."""

--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -15,22 +15,29 @@
 
 import re
 
+from collections.abc import Iterable
 from functools import partial
 
 import numpy as np
+import pytensor.tensor as pt
 
 from pytensor.compile import SharedVariable
 from pytensor.graph.basic import Constant, Variable
 from pytensor.graph.traversal import walk
+from pytensor.graph.type import HasShape
 from pytensor.tensor.elemwise import DimShuffle
 from pytensor.tensor.random.type import RandomType
 from pytensor.tensor.type_other import NoneTypeT
 from pytensor.tensor.variable import TensorVariable
+from rich.box import SIMPLE_HEAD
+from rich.table import Table
 
 from pymc.logprob.abstract import MeasurableOp
 from pymc.model import Model
+from pymc.pytensorf import _cheap_eval_mode
 
 __all__ = [
+    "model_table",
     "str_for_data_var",
     "str_for_dist",
     "str_for_model",
@@ -366,3 +373,185 @@ except (ModuleNotFoundError, AttributeError):
 def _format_underscore(variable: str) -> str:
     """Escapes all unescaped underscores in the variable name for LaTeX representation."""
     return re.sub(r"(?<!\\)_", r"\\_", variable)
+
+
+def _variable_expression(
+    model: Model,
+    var: Variable,
+    truncate_deterministic: int | None,
+    named_vars: set[Variable],
+) -> str:
+    """Get the expression of a variable in a human-readable format."""
+    if var in model.data_vars:
+        var_expr = "Data"
+    elif var in model.deterministics:
+        str_repr = str_for_potential_or_deterministic(var, dist_name="", named_vars=named_vars)
+        _, var_expr = str_repr.split(" = ")
+        var_expr = var_expr[1:-1]
+        if truncate_deterministic is not None and len(var_expr) > truncate_deterministic:
+            contents = var_expr[2:-1].split(", ")
+            str_len = 0
+            for show_n, content in enumerate(contents):
+                str_len += len(content) + 2
+                if str_len > truncate_deterministic:
+                    break
+            var_expr = f"f({', '.join(contents[:show_n])}, ...)"
+    elif var in model.potentials:
+        var_expr = str_for_potential_or_deterministic(
+            var, dist_name="Potential", named_vars=named_vars
+        ).split(" ~ ")[1]
+    else:
+        var_expr = str_for_dist(var, named_vars=named_vars).split(" ~ ")[1]
+    return var_expr
+
+
+def _dims_expression(model: Model, var: Variable) -> str:
+    """Get the dimensions of a variable in a human-readable format."""
+
+    def _extract_dim_value(var: Variable) -> np.ndarray:
+        if isinstance(var, SharedVariable):
+            return var.get_value(borrow=True)
+        if isinstance(var, Constant):
+            return var.data
+        return var.eval(mode=_cheap_eval_mode)
+
+    if (dims := model.named_vars_to_dims.get(var.name)) is not None:
+        dim_sizes = {dim: _extract_dim_value(model.dim_lengths[dim]) for dim in dims}
+        return " × ".join(f"{dim}[{dim_size}]" for dim, dim_size in dim_sizes.items())
+    if not isinstance(var.type, HasShape):
+        return ""
+    shape_values = list(pt.as_tensor(var.shape).eval(mode=_cheap_eval_mode))
+    return f"[{', '.join(map(str, shape_values))}]" if shape_values else ""
+
+
+def _model_parameter_count(model: Model) -> int:
+    """Count the number of parameters in the model."""
+    rv_shapes = model.eval_rv_shapes()  # Includes transformed variables
+    return sum(int(np.prod(rv_shapes[free_rv.name])) for free_rv in model.free_RVs)
+
+
+def model_table(
+    model: Model,
+    *,
+    split_groups: bool = True,
+    truncate_deterministic: int | None = None,
+    parameter_count: bool = True,
+) -> Table:
+    """Create a rich table with a summary of the model's variables and their expressions.
+
+    Parameters
+    ----------
+    model : Model
+        The PyMC model to summarize.
+    split_groups : bool
+        If True, each group of variables (data, free_RVs, deterministics, potentials, observed_RVs)
+        will be separated by a section.
+    truncate_deterministic : int | None
+        If not None, truncate the expression of deterministic variables that go beyond this length.
+    parameter_count : bool
+        If True, add a row with the total number of parameters in the model.
+
+    Returns
+    -------
+    Table
+        A rich table with the model's variables, their expressions and dims.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import numpy as np
+        import pymc as pm
+
+        from pymc import model_table
+
+        coords = {"subject": range(20), "param": ["a", "b"]}
+        with pm.Model(coords=coords) as m:
+            x = pm.Data("x", np.random.normal(size=(20, 2)), dims=("subject", "param"))
+            y = pm.Data("y", np.random.normal(size=(20,)), dims="subject")
+
+            beta = pm.Normal("beta", mu=0, sigma=1, dims="param")
+            mu = pm.Deterministic("mu", pm.math.dot(x, beta), dims="subject")
+            sigma = pm.HalfNormal("sigma", sigma=1)
+
+            y_obs = pm.Normal("y_obs", mu=mu, sigma=sigma, observed=y, dims="subject")
+
+        table = model_table(m)
+        table  # Displays the following table in an interactive environment
+        '''
+         Variable  Expression         Dimensions
+        ─────────────────────────────────────────────────────
+              x =  Data               subject[20] × param[2]
+              y =  Data               subject[20]
+
+           beta ~  Normal(0, 1)       param[2]
+          sigma ~  HalfNormal(0, 1)
+                                      Parameter count = 3
+
+             mu =  f(beta)            subject[20]
+
+          y_obs ~  Normal(mu, sigma)  subject[20]
+        '''
+
+    Output can be explicitly rendered in a rich console or exported to text, html or svg.
+
+    .. code-block:: python
+
+        from rich.console import Console
+
+        console = Console(record=True)
+        console.print(table)
+        text_export = console.export_text()
+        html_export = console.export_html()
+        svg_export = console.export_svg()
+
+    """
+    table = Table(
+        show_header=True,
+        show_edge=False,
+        box=SIMPLE_HEAD,
+        highlight=False,
+        collapse_padding=True,
+    )
+    table.add_column("Variable", justify="right")
+    table.add_column("Expression", justify="left")
+    table.add_column("Dimensions")
+
+    groups: tuple[Iterable[Variable], ...]
+    if split_groups:
+        groups = (
+            model.data_vars,
+            model.free_RVs,
+            model.deterministics,
+            model.potentials,
+            model.observed_RVs,
+        )
+    else:
+        # Show variables in the order they were defined
+        groups = (model.named_vars.values(),)
+
+    named_vars: set[Variable] = set()
+    named_vars.update(model.data_vars)
+    named_vars.update(model.free_RVs)
+    named_vars.update(model.observed_RVs)
+    named_vars.update(model.deterministics)
+    named_vars.update(model.potentials)
+
+    for group in groups:
+        if not group:
+            continue
+
+        for var in group:
+            var_name = var.name
+            sep = f"[b]{' ~' if (var in model.basic_RVs) else ' ='}[/b]"
+            var_expr = _variable_expression(model, var, truncate_deterministic, named_vars)
+            dims_expr = _dims_expression(model, var)
+            table.add_row(var_name + sep, var_expr, dims_expr)
+
+        if parameter_count and (not split_groups or group == model.free_RVs):
+            n_parameters = _model_parameter_count(model)
+            table.add_row("", "", f"[i]Parameter count = {n_parameters}[/i]")
+
+        table.add_section()
+
+    return table

--- a/pymc/printing.py
+++ b/pymc/printing.py
@@ -420,7 +420,7 @@ def _dims_expression(model: Model, var: Variable) -> str:
         return " × ".join(f"{dim}[{dim_size}]" for dim, dim_size in dim_sizes.items())
     if not isinstance(var.type, HasShape):
         return ""
-    shape_values = list(pt.as_tensor(var.shape).eval(mode=_cheap_eval_mode))
+    shape_values = list(pt.as_tensor(var.shape).eval(mode=_cheap_eval_mode))  # type: ignore[attr-defined]
     return f"[{', '.join(map(str, shape_values))}]" if shape_values else ""
 
 

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -135,7 +135,7 @@ def dataframe_to_tensor_variable(df: pd.DataFrame, *args, **kwargs) -> TensorVar
     return pt.as_tensor_variable(df.to_numpy(), *args, **kwargs)
 
 
-_cheap_eval_mode = Mode(linker="py", optimizer="minimum_compile")
+_cheap_eval_mode = Mode(linker="py", optimizer=None)
 
 
 def extract_obs_data(x: TensorVariable) -> np.ndarray:

--- a/tests/dims/test_model.py
+++ b/tests/dims/test_model.py
@@ -22,6 +22,7 @@ import pymc as pm
 from pymc import dims as pmd
 from pymc import observe
 from pymc.model.transform.optimization import freeze_dims_and_data
+from tests.test_printing import table_to_text
 
 pytestmark = pytest.mark.filterwarnings("error")
 
@@ -260,3 +261,55 @@ def test_freeze_dims_and_data():
     assert isinstance(frozen_m["x"], XTensorConstant)
     assert frozen_m["x"].type.shape == (5, 3)
     assert frozen_m["y"].type.shape == (5, 3)
+
+
+def test_model_table_dims():
+    coords = {"subject": range(20), "param": ["a", "b"]}
+    with pm.Model(coords=coords) as m:
+        x = pmd.Data("x", np.random.normal(size=(20, 2)), dims=("subject", "param"))
+        y_obs_data = pmd.Data("y_obs_data", np.random.normal(size=(20,)), dims="subject")
+
+        beta = pmd.Normal("beta", mu=0, sigma=1, dims="param")
+        mu = pmd.Deterministic("mu", (x * beta).sum("param"))
+        sigma = pmd.HalfNormal("sigma", sigma=1)
+        zsn = pmd.ZeroSumNormal("zsn", sigma=1.0, core_dims="subject")
+        pmd.Normal("y_obs", mu=mu + zsn, sigma=sigma, observed=y_obs_data)
+        pmd.Potential("beta_penalty", -beta)
+
+    text = table_to_text(m.table())
+    expected = """\
+       Variable  Expression                             Dimensions
+───────────────────────────────────────────────────────────────────────────────
+            x =  Data                                   subject[20] × param[2]
+   y_obs_data =  Data                                   subject[20]
+
+         beta ~  Normal(0, 1)                           param[2]
+        sigma ~  HalfNormal(0, 1)
+          zsn ~  ZeroSumNormal(<constant>, <constant>)  subject[20]
+                                                        Parameter count = 23
+
+           mu =  f(beta, x)                             subject[20]
+
+ beta_penalty =  Potential(f(beta))                     param[2]
+
+        y_obs ~  Normal(f(mu, zsn), sigma)              subject[20]
+"""
+    assert [s.rstrip() for s in text.splitlines()] == expected.splitlines()
+
+
+def test_model_table_xtensor_without_registered_dims():
+    with pm.Model(coords={"subject": range(5)}) as m:
+        beta = pmd.Normal("beta", 0, 1, dims="subject")
+        pm.Deterministic("det", beta * 2)
+
+    assert m.named_vars_to_dims.get("det") is None
+    text = table_to_text(m.table())
+    expected = """\
+ Variable  Expression    Dimensions
+─────────────────────────────────────────────
+   beta ~  Normal(0, 1)  subject[5]
+                         Parameter count = 5
+
+    det =  f(beta)       [5]
+"""
+    assert [s.rstrip() for s in text.splitlines()] == expected.splitlines()

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -17,6 +17,10 @@ import re
 import numpy as np
 
 from pytensor.tensor.random import normal
+from rich.console import Console
+from rich.table import Table
+
+import pymc as pm
 
 from pymc import (
     Bernoulli,
@@ -29,6 +33,7 @@ from pymc import (
     Mixture,
     StudentT,
     Truncated,
+    model_table,
 )
 from pymc.distributions import (
     Dirichlet,
@@ -469,3 +474,97 @@ class TestLatexRepr:
         model_str = model.str_repr(formatting="latex")
         assert "\\_" in model_str
         assert "_" not in model_str.replace("\\_", "")
+
+
+def table_to_text(table: Table, width: int = 80) -> str:
+    """Render a rich ``Table`` to a plain-text string at a fixed width."""
+    console = Console(width=width)
+    with console.capture() as capture:
+        console.print(table)
+    return capture.get()
+
+
+def test_model_table():
+    with pm.Model(coords={"trial": range(6), "subject": range(20)}) as model:
+        x_data = pm.Data("x_data", np.random.normal(size=(6, 20)), dims=("trial", "subject"))
+        y_data = pm.Data("y_data", np.random.normal(size=(6, 20)), dims=("trial", "subject"))
+
+        mu = pm.Normal("mu", mu=0, sigma=1)
+        sigma = pm.HalfNormal("sigma", sigma=1)
+        global_intercept = pm.Normal("global_intercept", mu=0, sigma=1)
+        intercept_subject = pm.Normal("intercept_subject", mu=0, sigma=1, shape=(20, 1))
+        beta_subject = pm.Normal("beta_subject", mu=mu, sigma=sigma, dims="subject")
+
+        mu_trial = pm.Deterministic(
+            "mu_trial",
+            global_intercept.squeeze() + intercept_subject + beta_subject * x_data,
+            dims=["trial", "subject"],
+        )
+        noise = pm.Exponential("noise", lam=1)
+        y = pm.Normal("y", mu=mu_trial, sigma=noise, observed=y_data, dims=("trial", "subject"))
+
+        pm.Potential("beta_subject_penalty", -pm.math.abs(beta_subject), dims="subject")
+
+    table_txt = table_to_text(model_table(model))
+    expected = """               Variable  Expression                      Dimensions
+────────────────────────────────────────────────────────────────────────────────
+               x_data =  Data                            trial[6] × subject[20]
+               y_data =  Data                            trial[6] × subject[20]
+
+                   mu ~  Normal(0, 1)
+                sigma ~  HalfNormal(0, 1)
+     global_intercept ~  Normal(0, 1)
+    intercept_subject ~  Normal(0, 1)                    [20, 1]
+         beta_subject ~  Normal(mu, sigma)               subject[20]
+                noise ~  Exponential(<constant>)
+                                                         Parameter count = 44
+
+             mu_trial =  f(x_data, intercept_subject,    trial[6] × subject[20]
+                         beta_subject,
+                         global_intercept)
+
+ beta_subject_penalty =  Potential(f(beta_subject))      subject[20]
+
+                    y ~  Normal(mu_trial, noise)         trial[6] × subject[20]
+"""
+    assert [s.strip() for s in table_txt.splitlines()] == [s.strip() for s in expected.splitlines()]
+
+    table_txt = table_to_text(model_table(model, split_groups=False))
+    expected = """               Variable  Expression                      Dimensions
+────────────────────────────────────────────────────────────────────────────────
+               x_data =  Data                            trial[6] × subject[20]
+               y_data =  Data                            trial[6] × subject[20]
+                   mu ~  Normal(0, 1)
+                sigma ~  HalfNormal(0, 1)
+     global_intercept ~  Normal(0, 1)
+    intercept_subject ~  Normal(0, 1)                    [20, 1]
+         beta_subject ~  Normal(mu, sigma)               subject[20]
+             mu_trial =  f(x_data, intercept_subject,    trial[6] × subject[20]
+                         beta_subject,
+                         global_intercept)
+                noise ~  Exponential(<constant>)
+                    y ~  Normal(mu_trial, noise)         trial[6] × subject[20]
+ beta_subject_penalty =  Potential(f(beta_subject))      subject[20]
+                                                         Parameter count = 44
+"""
+    assert [s.strip() for s in table_txt.splitlines()] == [s.strip() for s in expected.splitlines()]
+
+    table_txt = table_to_text(
+        model_table(model, split_groups=False, truncate_deterministic=30, parameter_count=False)
+    )
+    expected = """               Variable  Expression                      Dimensions
+────────────────────────────────────────────────────────────────────────────────
+               x_data =  Data                            trial[6] × subject[20]
+               y_data =  Data                            trial[6] × subject[20]
+                   mu ~  Normal(0, 1)
+                sigma ~  HalfNormal(0, 1)
+     global_intercept ~  Normal(0, 1)
+    intercept_subject ~  Normal(0, 1)                    [20, 1]
+         beta_subject ~  Normal(mu, sigma)               subject[20]
+             mu_trial =  f(x_data, intercept_subject,    trial[6] × subject[20]
+                         ...)
+                noise ~  Exponential(<constant>)
+                    y ~  Normal(mu_trial, noise)         trial[6] × subject[20]
+ beta_subject_penalty =  Potential(f(beta_subject))      subject[20]
+"""
+    assert [s.strip() for s in table_txt.splitlines()] == [s.strip() for s in expected.splitlines()]


### PR DESCRIPTION
## Description

Moved model_table from pymc-extras into pymc.

  - pymc/printing.py — added public model_table returning a rich.table.Table, plus
  four underscore-prefixed helpers
  - tests/test_printing.py — added test_model_table covering all three call shapes.
  - docs/source/api/misc.rst — registered in autosummary.

Some linting errors related to pixi(?)

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
