### PR TITLE
Reject variable names with `/`

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -448,6 +448,8 @@ class Model(WithMemoization, metaclass=ContextMeta):
     def _validate_name(name):
         if name.endswith(":"):
             raise KeyError("name should not end with `:`")
+        if "/" in name:
+            raise ValueError(f"Variable name '{name}' cannot contain '/'.")
         return name
 
     def __init__(

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -243,7 +243,7 @@ class TestNested:
 
     def test_variable_name_with_slash(self):
         with pm.Model():
-            with pytest.raises(ValueError, match="cannot contain '/' "):
+            with pytest.raises(ValueError, match="cannot contain '/'"):
                 pm.Normal("a/b")
 
 

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -241,6 +241,11 @@ class TestNested:
             with pm.Model("scope::") as model:
                 b = pm.Normal("v")
 
+    def test_variable_name_with_slash(self):
+        with pm.Model():
+            with pytest.raises(ValueError, match="cannot contain '/' "):
+                pm.Normal("a/b")
+
 
 class TestObserved:
     def test_observed_rv_fail(self):


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
As we can see in this issue Xarray / DataTree treat this as hierarchical delimiters, so we can't have them for regular variable names.
So, to resolve it we can add a validation in _validate_name() to check if "/" exists in the variable name and raise a ValueError if it does. This ensures all variable names are filtered at a central point  and adding a corresponding test for it.
The test checks that creating a variable like "a/b" raises a ValueError.


## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #8253
- [x] Related to #8253 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
