### PR TITLE
use Scalar op monotonic properties instead of hardcoded tuples

### DIFF
--- a/pymc/logprob/transforms.py
+++ b/pymc/logprob/transforms.py
@@ -230,10 +230,6 @@ def measurable_transform_logprob(op: MeasurableTransform, values, *inputs, **kwa
     return pt.switch(pt.isnan(jacobian), -np.inf, input_logprob + jacobian)
 
 
-MONOTONICALLY_INCREASING_OPS = (Exp, Log, Add, Sinh, Tanh, ArcSinh, ArcCosh, ArcTanh, Erf, Sigmoid)
-MONOTONICALLY_DECREASING_OPS = (Erfc, Erfcx)
-
-
 @_logcdf.register(MeasurableTransform)
 def measurable_transform_logcdf(op: MeasurableTransform, value, *inputs, **kwargs):
     """Compute the log-CDF graph for a `MeasurabeTransform`."""
@@ -255,9 +251,9 @@ def measurable_transform_logcdf(op: MeasurableTransform, value, *inputs, **kwarg
     else:
         logccdf = _logccdf_helper(measurable_input, backward_value)
 
-    if isinstance(op.scalar_op, MONOTONICALLY_INCREASING_OPS):
+    if isinstance(op.scalar_op, Add) or getattr(op.scalar_op, "monotonic_increasing", False):
         pass
-    elif isinstance(op.scalar_op, MONOTONICALLY_DECREASING_OPS):
+    elif getattr(op.scalar_op, "monotonic_decreasing", False):
         logcdf = logccdf
     # mul is monotonically increasing for scale > 0, and monotonically decreasing otherwise
     elif isinstance(op.scalar_op, Mul):
@@ -295,9 +291,9 @@ def measurable_transform_icdf(op: MeasurableTransform, value, *inputs, **kwargs)
     if measurable_input.type.dtype.startswith("int"):
         raise NotImplementedError("icdf of transformed discrete variables not implemented")
 
-    if isinstance(op.scalar_op, MONOTONICALLY_INCREASING_OPS):
+    if isinstance(op.scalar_op, Add) or getattr(op.scalar_op, "monotonic_increasing", False):
         pass
-    elif isinstance(op.scalar_op, MONOTONICALLY_DECREASING_OPS):
+    elif getattr(op.scalar_op, "monotonic_decreasing", False):
         value = 1 - value
     elif isinstance(op.scalar_op, Mul):
         [scale] = other_inputs


### PR DESCRIPTION
C## Description

Removes the hardcoded `MONOTONICALLY_INCREASING_OPS` and `MONOTONICALLY_DECREASING_OPS` tuples in `pymc/logprob/transforms.py` in favor of the `monotonic_increasing` / `monotonic_decreasing` attributes added to `UnaryScalarOp` in pymc-devs/pytensor#2053.

`Add` is kept as an explicit `isinstance` check since it is a `BinaryScalarOp` and does not carry the new properties, consistent with the discussion on #8259 about handling `Add`, `Mul`, and `Pow` separately.

Existing tests in `tests/logprob/test_transforms.py` pass unchanged (79 passed, 1 xfailed).

## Related Issue

- [x] Closes #8259
- [ ] Related to #

## Checklist

- [x] Checked that the pre-commit linting/style checks pass
- [ ] Included tests that prove the fix is effective or that the new feature works — existing tests cover the behavior (see above)
- [ ] Added necessary documentation (docstrings and/or example notebooks) — N/A, internal refactor with no API change
- [ ] If you are a pro: each commit corresponds to a relevant logical change

## Type of change

- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):