### PR TITLE
docs: fix RST in Model.debug docstring numbered list

### DIFF
--- a/pymc/model/core.py
+++ b/pymc/model/core.py
@@ -1833,9 +1833,10 @@ class Model(WithMemoization, metaclass=ContextMeta):
 
         The method will evaluate the `fn` for each variable at a time.
         When an evaluation fails or produces a non-finite value we print:
-         1. The graph of the parameters
-         2. The value of the parameters (if those can be evaluated)
-         3. The output of `fn` (if it can be evaluated)
+
+        1. The graph of the parameters
+        2. The value of the parameters (if those can be evaluated)
+        3. The output of `fn` (if it can be evaluated)
 
         This function should help to quickly narrow down invalid parametrizations.
 


### PR DESCRIPTION
## Description

The numbered list in the `Model.debug` docstring uses a single leading space on each item, with no blank line separating it from the preceding paragraph. Sphinx/docutils reads that single-space indent as the start of an indented block and emits `WARNING: Unexpected indentation. [docutils]`.

This was caught while working on the [CausalPy](https://github.com/pymc-labs/CausalPy) repo: building the CausalPy docs surfaces this warning multiple times because the build pulls in the `pymc.Model` autodoc reference.

This PR adds a blank line before the list and removes the single-space indent so docutils parses it as a proper enumerated list.

Before:

```
When an evaluation fails or produces a non-finite value we print:
 1. The graph of the parameters
 2. The value of the parameters (if those can be evaluated)
 3. The output of `fn` (if it can be evaluated)
```

After:

```
When an evaluation fails or produces a non-finite value we print:

1. The graph of the parameters
2. The value of the parameters (if those can be evaluated)
3. The output of `fn` (if it can be evaluated)
```

## Related Issue

None.

## Checklist

- [x] Checked that the pre-commit linting/style checks pass
- [ ] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)

Tests are not applicable: this is a docstring RST formatting fix, no behavior change.

## Type of change

- [x] Documentation