### PR TITLE
Update installation instructions to use pip

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -1,15 +1,44 @@
 (installation)=
 # Installation
 
-We recommend using [Anaconda](https://www.anaconda.com/) (or [Miniforge](https://github.com/conda-forge/miniforge)) to install Python on your local machine, which allows for packages to be installed using its `conda` utility.
+As of PyMC v6, PyMC compiles models with the [Numba](https://numba.pydata.org/) backend by
+default, so no extra system setup (compiler or BLAS) is required, and PyMC can
+be installed with `pip`.
 
-Once you have installed one of the above, PyMC can be installed into a new conda environment as follows:
+We also recommend installing [nutpie](https://github.com/pymc-devs/nutpie), a
+fast NUTS sampler written in Rust. When nutpie is installed, PyMC selects it as
+the default NUTS sampler automatically — typically about 2x faster than PyMC's
+built-in NUTS:
+
+```console
+pip install "pymc[nutpie]"
+```
+
+To install PyMC on its own:
+
+```console
+pip install pymc
+```
+
+## Installing with conda
+
+As an alternative, PyMC can be installed with `conda` using
+[Anaconda](https://www.anaconda.com/) or
+[Miniforge](https://github.com/conda-forge/miniforge). We recommend a fresh
+conda environment:
 
 ```console
 conda create -c conda-forge -n pymc_env "pymc>=6"
 conda activate pymc_env
 ```
+
 If you like, replace the name `pymc_env` with whatever environment name you prefer.
+
+To enable nutpie when using conda:
+
+```console
+conda install -c conda-forge nutpie
+```
 
 :::{seealso}
 The [conda-forge tips & tricks](https://conda-forge.org/docs/user/tipsandtricks.html#using-multiple-channels) page to avoid installation
@@ -22,20 +51,11 @@ If you wish to enable sampling using the JAX backend via NumPyro,
 you need to install it manually as it is an optional dependency:
 
 ```console
-conda install numpyro
+pip install numpyro
 ```
 
-Similarly, to use BlackJAX sampler instead:
+Similarly, to use the BlackJAX sampler instead:
 
 ```console
-conda install blackjax
-```
-
-## Nutpie sampling
-
-You can also enable sampling with [nutpie](https://github.com/pymc-devs/nutpie).
-Nutpie uses numba as the compiler and a sampler written in Rust for faster performance.
-
-```console
-conda install -c conda-forge nutpie
+pip install blackjax
 ```

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -1,14 +1,11 @@
 (installation)=
 # Installation
 
-As of PyMC v6, PyMC compiles models with the [Numba](https://numba.pydata.org/) backend by
-default, so no extra system setup (compiler or BLAS) is required, and PyMC can
-be installed with `pip`.
+PyMC can be installed with `pip`.
 
 We also recommend installing [nutpie](https://github.com/pymc-devs/nutpie), a
 fast NUTS sampler written in Rust. When nutpie is installed, PyMC selects it as
-the default NUTS sampler automatically — typically about 2x faster than PyMC's
-built-in NUTS:
+the default NUTS sampler automatically.
 
 ```console
 pip install "pymc[nutpie]"

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -21,7 +21,7 @@ pip install pymc
 
 As an alternative, PyMC can be installed with `conda` using
 [Anaconda](https://www.anaconda.com/) or
-[Miniforge](https://github.com/conda-forge/miniforge). This is still recommended if you
+[Miniforge](https://github.com/conda-forge/miniforge). This is recommended if you
 want to use the legacy C backend or need control over the BLAS library.
 
 We recommend a fresh

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -21,7 +21,10 @@ pip install pymc
 
 As an alternative, PyMC can be installed with `conda` using
 [Anaconda](https://www.anaconda.com/) or
-[Miniforge](https://github.com/conda-forge/miniforge). We recommend a fresh
+[Miniforge](https://github.com/conda-forge/miniforge). This is still recommended if you
+want to use the legacy C backend or need control over the BLAS library.
+
+We recommend a fresh
 conda environment:
 
 ```console


### PR DESCRIPTION
 ## Description
Updates the installation guide to lead with `pip` now that PyMC v6  compiles with the Numba
backend by default (no compiler/BLAS needed).
Recommends `pip install "pymc[nutpie]"` as the default, since nutpie is selected
as the default NUTS sampler automatically when installed. conda is kept as a
documented alternative, and the JAX-sampler install commands were switched to pip.

## Related Issue
- [x] Closes #8315
- [ ] Related to #

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] (N/A -docs only)  Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change]

## Type of change
- [ ] New feature / enhancement
- [ ] Bug fix
- [x] Documentation
- [ ] Maintenance
- [ ] Other (please specify):

