### PR TITLE
Propagate dims in LatentKron GP prior

### DIFF
--- a/pymc/gp/gp.py
+++ b/pymc/gp/gp.py
@@ -976,7 +976,9 @@ class LatentKron(Base):
         mu = self.mean_func(cartesian(*Xs))
         chols = [cholesky(stabilize(cov(X), jitter)) for cov, X in zip(self.cov_funcs, Xs)]
         v = pm.Normal(name + "_rotated_", mu=0.0, sigma=1.0, size=self.N, **kwargs)
-        f = pm.Deterministic(name, mu + pt.flatten(kron_dot(chols, v)))
+        f = pm.Deterministic(
+            name, mu + pt.flatten(kron_dot(chols, v)), dims=kwargs.get("dims", None)
+        )
         return f
 
     def prior(self, name, Xs, jitter=JITTER_DEFAULT, **kwargs):
@@ -995,9 +997,14 @@ class LatentKron(Base):
         jitter : float, default 1e-6
             A small correction added to the diagonal of positive semi-definite
             covariance matrices to ensure numerical stability.
+        dims : str or tuple of str, optional
+            Dimension name(s) for the GP random variable, passed to
+            :func:`~pymc.Deterministic`. Allows the GP to be identified
+            by named coordinates in the model, consistent with
+            :class:`~pymc.gp.Latent` and :class:`~pymc.gp.HSGP`.
         **kwargs
-            Extra keyword arguments that are passed to the :class:`~pymc.KroneckerNormal`
-            distribution constructor.
+            Extra keyword arguments that are passed to the internal
+            :class:`~pymc.Normal` rotated variable.
         """
         if len(Xs) != len(self.cov_funcs):
             raise ValueError("Must provide a covariance function for each X")

--- a/tests/gp/test_gp.py
+++ b/tests/gp/test_gp.py
@@ -454,6 +454,15 @@ class TestLatentKron:
         with pytest.raises(ValueError):
             gp.prior("f", Xs=[np.linspace(0, 1, 7)[:, None], np.linspace(0, 1, 5)[:, None]])
 
+    def testLatentKronDims(self):
+        """Test that LatentKron.prior correctly passes dims to the Deterministic GP variable."""
+        n_points = int(np.prod([len(X) for X in self.Xs]))
+        with pm.Model(coords={"gp_dim": np.arange(n_points)}) as kron_model:
+            kron_gp = pm.gp.LatentKron(mean_func=self.mean, cov_funcs=self.cov_funcs)
+            f = kron_gp.prior("f", self.Xs, dims="gp_dim")
+        assert f.name == "f"
+        assert kron_model.named_vars_to_dims["f"] == ("gp_dim",)
+
 
 class TestMarginalKron:
     """


### PR DESCRIPTION
LatentKron._build_prior was passing **kwargs (including dims) to the internal pm.Normal rotated variable, but was not forwarding dims to the final pm.Deterministic node representing the GP function f.

This made it inconsistent with gp.Latent and gp.TP, which already correctly pass dims to their Deterministic outputs.

Fixes: #6649

Changes:
- Pass `dims=kwargs.get('dims', None)` to `pm.Deterministic` in `LatentKron._build_prior`
- Document `dims` in `LatentKron.prior`'s docstring
- Add test `testLatentKronDims` to verify that the GP variable returned by `LatentKron.prior` carries the correct named dimensions

<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
This PR resolves an inconsistency in the Gaussian Process API where `LatentKron` failed to propagate the `dims` keyword argument to its output `Deterministic` variable. This prevented users from using named dimensions correctly with `LatentKron`, breaking xarray compatibilities for the GP node.

## Related Issue
- [x] Closes #6649

## Checklist
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
