### PR TITLE
Drop `divergence_message` in `drop_warning_stat`

### DIFF
--- a/pymc/util.py
+++ b/pymc/util.py
@@ -257,7 +257,8 @@ def drop_warning_stat(dt: DataTree) -> DataTree:
             warning_vars = [
                 name
                 for name in ds.data_vars
-                if name == "warning" or re.match(r"sampler_\d+__warning", str(name))
+                if name in ("warning", "divergence_message")
+                or re.match(r"sampler_\d+__warning", str(name))
             ]
             ds = ds.drop_vars(names=[*warning_vars, "warning_dim_0"], errors="ignore")
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -189,6 +189,32 @@ def test_drop_warning_stat():
         assert "warning_dim_0" not in ss
 
 
+def test_drop_divergence_message_stat():
+    # nutpie emits a string-valued "divergence_message" sample stat that breaks
+    # to_netcdf(); it must be dropped while ordinary sample stats are kept.
+    idata = arviz.from_dict(
+        {
+            "sample_stats": {
+                "diverging": np.zeros((2, 5), dtype=bool),
+                "divergence_message": np.full((2, 5), "", dtype=object),
+            },
+            "warmup_sample_stats": {
+                "diverging": np.zeros((2, 5), dtype=bool),
+                "divergence_message": np.full((2, 5), "", dtype=object),
+            },
+        },
+        save_warmup=True,
+    )
+
+    new = drop_warning_stat(idata)
+
+    for gname in ["sample_stats", "warmup_sample_stats"]:
+        ss = new[gname].dataset
+        assert isinstance(ss, xarray.Dataset), gname
+        assert "diverging" in ss
+        assert "divergence_message" not in ss
+
+
 def test_get_seeds_per_chain():
     ret = _get_seeds_per_chain(None, chains=1)
     assert len(ret) == 1 and isinstance(ret[0], int)


### PR DESCRIPTION
## Description

`nutpie` can add a string-valued `divergence_message` variable to `sample_stats`, which keeps `keep_warning_stat=False` from producing an `InferenceData` object that can be serialized cleanly.

This updates `drop_warning_stat()` to drop `divergence_message` alongside the existing warning stats, while preserving ordinary sampler stats like `diverging`. A regression test covers both `sample_stats` and `warmup_sample_stats`.

AI assistance was used under my direction.

## Related Issue
- [x] Closes #8321
- [ ] Related to #

## Checklist
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [x] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)

## Type of change
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):

## Local checks
- `uv run --with-editable . --with pytest python -m pytest tests/test_util.py::test_drop_warning_stat tests/test_util.py::test_drop_divergence_message_stat -q`
- `uv run --with ruff ruff check pymc/util.py tests/test_util.py`
- `uv run --with ruff ruff format --check pymc/util.py tests/test_util.py`
- `git diff --check origin/main...HEAD`