### PR TITLE
Fix ZeroSumTransform logp for non-trailing zero-sum axes

### DIFF
--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -683,6 +683,11 @@ class ZeroSumTransform(Transform):
             value = self.extend_axis(value, axis=axis)
         return value
 
+    # Zero-summed axes, used by `transformed_value_logprob` to reduce the matching logp axes.
+    @property
+    def jacobian_reduce_axes(self):
+        return self.zerosum_axes
+
     def log_jac_det(self, value, *rv_inputs):
         return value.sum(self.zerosum_axes).zeros_like()
 

--- a/pymc/logprob/transform_value.py
+++ b/pymc/logprob/transform_value.py
@@ -102,10 +102,14 @@ def transformed_value_logprob(op, values, *rv_outs, use_jacobian=True, **kwargs)
         log_jac_det = transform.log_jac_det(original_forward_value, *rv_inputs).copy()
         # The jacobian determinant has less dims than the logp
         # when a multivariate transform (like Simplex or Ordered) is applied to univariate distributions.
-        # In this case we have to reduce the last logp dimensions, as they are no longer independent
+        # In this case we have to reduce those logp dimensions, as they are no longer independent.
+        # Default to the trailing axes; transforms may override which axes via `jacobian_reduce_axes`.
         if log_jac_det.ndim < logp.ndim:
             diff_ndims = logp.ndim - log_jac_det.ndim
-            logp = logp.sum(axis=np.arange(-diff_ndims, 0))
+            reduce_axes = getattr(transform, "jacobian_reduce_axes", None)
+            if reduce_axes is None:
+                reduce_axes = np.arange(-diff_ndims, 0)
+            logp = logp.sum(axis=tuple(reduce_axes))
         # This case is sometimes, but not always, trivial to accommodate depending on the "space rank" of the
         # multivariate distribution. See https://proceedings.mlr.press/v130/radul21a.html
         elif log_jac_det.ndim > logp.ndim:

--- a/tests/distributions/test_multivariate.py
+++ b/tests/distributions/test_multivariate.py
@@ -1780,6 +1780,26 @@ class TestZeroSumNormal:
         assert m.logp(sum=False)[0].type.shape == (3,)
         assert m.logp(sum=False, jacobian=False)[0].type.shape == (3,)
 
+    def test_zerosum_transform_non_trailing_axis(self):
+        # Regression: zero-summing a non-trailing axis must reduce the logp over that axis, else
+        # logp and jacobian shapes mismatch once dims are static (e.g. after freeze_dims_and_data).
+        from pymc.distributions.transforms import ZeroSumTransform
+        from pymc.model.transform.optimization import freeze_dims_and_data
+
+        # Static shape: reduced over the zero-summed (leading) axis, keeping the trailing axis.
+        with pm.Model() as m_static:
+            pm.Normal("x", 0.0, 1.0, shape=(3, 2), transform=ZeroSumTransform([0]))
+        assert m_static.logp(sum=False)[0].type.shape == (2,)
+
+        # Dynamic dims build fine; freezing makes shapes static and must not raise.
+        with pm.Model(coords={"a": range(3), "b": range(2)}) as m:
+            pm.Normal("x", 0.0, 1.0, dims=("a", "b"), transform=ZeroSumTransform([0]))
+        frozen = freeze_dims_and_data(m)
+        np.testing.assert_allclose(
+            m.compile_logp()(m.initial_point()),
+            frozen.compile_logp()(frozen.initial_point()),
+        )
+
 
 class TestMvStudentTCov(BaseTestDistributionRandom):
     def mvstudentt_rng_fn(self, size, nu, mu, scale, rng):


### PR DESCRIPTION


<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->
`transformed_value_logprob` reduces the logp's *trailing* axes to match a lower-dim Jacobian, assuming (as for Simplex/Ordered) that a multivariate transform acts on the trailing axes. `ZeroSumTransform` may zero-sum *arbitrary* axes, so for a non-trailing axis the reduced logp keeps the wrong axis and disagrees with `log_jac_det` (which drops `zerosum_axes`). The shapes then differ, e.g. `(3,) + (2,)`. This is silent with symbolic dims (both broadcastable) but raises `Incompatible Elemwise input shapes` once dims are static -- e.g. after `freeze_dims_and_data`, which the numba/jax sampling backends apply.

Fix: expose the integrated-out axes via `ZeroSumTransform.jacobian_reduce_axes` and have `transformed_value_logprob` reduce those axes (falling back to the trailing axes for transforms that don't define them). `ZeroSumNormal` is unaffected (it only zero-sums trailing axes); batched transformed-logp shapes are preserved.

Minimal repro (raised before, builds after)::

```python
    with pm.Model() as m:
        pm.Normal("x", 0.0, 1.0, shape=(3, 2),
                  transform=ZeroSumTransform([0]))
        m.logp()
```

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #8335 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [x] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [x] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
