### PR TITLE
fix: ensure raveled array uses float64 dtype in DictToArrayBijection (closes #8337)

### DIFF
--- a/pymc/blocking.py
+++ b/pymc/blocking.py
@@ -69,9 +69,9 @@ class DictToArrayBijection:
         """Map a dictionary of names and variables to a concatenated 1D array space."""
         vars_info = tuple((v, k, v.shape, v.size, v.dtype) for k, v in var_dict.items())
         if vars_info:
-            result = np.concatenate(tuple(v[0].ravel() for v in vars_info))
+            result = np.concatenate(tuple(v[0].ravel().astype(np.float64) for v in vars_info))
         else:
-            result = np.array([])
+            result = np.array([], dtype=np.float64)
         return RaveledVars(result, tuple(v[1:] for v in vars_info))
 
     @staticmethod


### PR DESCRIPTION
## What
When a PyMC model uses a length-one dimensioned vector RV as a non-sequence in `pytensor.scan`, the raveled NUTS setup fails because `DictToArrayBijection.map` does not enforce a consistent float64 dtype. The original code used `np.concatenate` on raveled arrays that may have incompatible dtypes (e.g., object from a 1-element vector), causing downstream errors.

## Fix
Forced the raveled arrays to `np.float64` before concatenation, and initialized the empty array with `dtype=np.float64`. This ensures the bijection always works with the expected numeric type.

Closes #8337