### PR TITLE
Implement icdf for Poisson, Binomial, and NegativeBinomial

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -638,6 +638,7 @@ class Poisson(Discrete):
             lambda k: logcdf(dist, k),
             value,
             lower=0,
+            start=mu,
         )
         res = check_icdf_value(res, value)
         return check_icdf_parameters(
@@ -800,6 +801,7 @@ class NegativeBinomial(Discrete):
             lambda k: logcdf(dist, k),
             value,
             lower=0,
+            start=n * (1 - p) / p,
         )
         res = check_icdf_value(res, value)
         return check_icdf_parameters(

--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -40,6 +40,7 @@ from pymc.distributions.dist_math import (
     check_icdf_parameters,
     check_icdf_value,
     check_parameters,
+    discrete_icdf_via_search,
     factln,
     log_diff_normal_cdf,
     logpow,
@@ -167,6 +168,23 @@ class Binomial(Discrete):
         )
 
         return check_parameters(
+            res,
+            n >= 0,
+            0 <= p,
+            p <= 1,
+            msg="n >= 0, 0 <= p <= 1",
+        )
+
+    def icdf(value, n, p):
+        dist = Binomial.dist(n=n, p=p)
+        res = discrete_icdf_via_search(
+            lambda k: logcdf(dist, k),
+            value,
+            lower=0,
+            upper=n,
+        )
+        res = check_icdf_value(res, value)
+        return check_icdf_parameters(
             res,
             n >= 0,
             0 <= p,
@@ -614,6 +632,20 @@ class Poisson(Discrete):
             msg="mu >= 0",
         )
 
+    def icdf(value, mu):
+        dist = Poisson.dist(mu=mu)
+        res = discrete_icdf_via_search(
+            lambda k: logcdf(dist, k),
+            value,
+            lower=0,
+        )
+        res = check_icdf_value(res, value)
+        return check_icdf_parameters(
+            res,
+            mu >= 0,
+            msg="mu >= 0",
+        )
+
 
 class NegativeBinomial(Discrete):
     R"""
@@ -755,6 +787,22 @@ class NegativeBinomial(Discrete):
             pt.log(pt.betainc(n, pt.floor(value) + 1, p)),
         )
         return check_parameters(
+            res,
+            n > 0,
+            0 <= p,
+            p <= 1,
+            msg="n > 0, 0 <= p <= 1",
+        )
+
+    def icdf(value, n, p):
+        dist = NegativeBinomial.dist(n=n, p=p)
+        res = discrete_icdf_via_search(
+            lambda k: logcdf(dist, k),
+            value,
+            lower=0,
+        )
+        res = check_icdf_value(res, value)
+        return check_icdf_parameters(
             res,
             n > 0,
             0 <= p,

--- a/pymc/distributions/dist_math.py
+++ b/pymc/distributions/dist_math.py
@@ -89,7 +89,7 @@ def check_icdf_value(expr: Variable, value: Variable) -> Variable:
     return expr
 
 
-def discrete_icdf_via_search(logcdf, value, lower, upper=None, *, max_iters=64):
+def discrete_icdf_via_search(logcdf, value, lower, upper=None, *, start=None, max_iters=64):
     """Numerically invert a discrete CDF by bisecting the (monotone) ``logcdf``.
 
     Returns the smallest integer ``k`` in the support such that
@@ -118,6 +118,13 @@ def discrete_icdf_via_search(logcdf, value, lower, upper=None, *, max_iters=64):
     upper : tensor_like, optional
         Largest value in the support. If ``None`` (unbounded support), a finite
         upper bracket is first found by geometric expansion.
+    start : tensor_like, optional
+        Initial guess for the upper bracket when ``upper`` is ``None``,
+        typically the distribution mean. The geometric expansion starts from
+        ``max(floor(start), lower + 1)`` instead of ``lower + 1``, so that
+        elements whose quantile is near or below the guess converge in fewer
+        effective iterations. The guess does not need to be accurate for the
+        result to be exact. Ignored when ``upper`` is given.
     max_iters : int
         Number of search iterations per phase. This needs to exceed ``log2`` of
         the largest reachable quantile; the default of 64 covers the full range
@@ -127,6 +134,11 @@ def discrete_icdf_via_search(logcdf, value, lower, upper=None, *, max_iters=64):
     lower = pt.zeros_like(value) + pt.as_tensor_variable(lower, dtype="float64")
 
     if upper is None:
+        hi_init = lower + 1.0
+        if start is not None:
+            start = pt.zeros_like(value) + pt.as_tensor_variable(start, dtype="float64")
+            hi_init = pt.maximum(pt.floor(start), hi_init)
+
         # Phase 1: geometrically expand an upper bracket until cdf(hi) >= value.
         def expand(lo, hi):
             insufficient = logcdf(hi) < log_value
@@ -134,7 +146,7 @@ def discrete_icdf_via_search(logcdf, value, lower, upper=None, *, max_iters=64):
 
         lo, hi = pytensor.scan(
             expand,
-            outputs_info=[lower, lower + 1.0],
+            outputs_info=[lower, hi_init],
             n_steps=max_iters,
             return_updates=False,
         )

--- a/pymc/distributions/dist_math.py
+++ b/pymc/distributions/dist_math.py
@@ -99,10 +99,9 @@ def discrete_icdf_via_search(logcdf, value, lower, upper=None, *, start=None, ma
     whose quantile function has no closed form (e.g. ``Poisson``, ``Binomial``,
     ``NegativeBinomial``).
 
-    The search uses fixed-length ``scan`` loops (rather than a data-dependent
-    ``while``) so that the resulting graph remains convertible to the C, Numba
-    and JAX backends. Each step is idempotent once an element has converged, so
-    running the full ``max_iters`` iterations does not change the result.
+    The search uses fixed-length ``scan`` loops rather than a data-dependent
+    ``until`` condition. Each step is idempotent once an element has converged,
+    so running the full ``max_iters`` iterations does not change the result.
 
     Parameters
     ----------
@@ -131,12 +130,21 @@ def discrete_icdf_via_search(logcdf, value, lower, upper=None, *, start=None, ma
         of integers exactly representable as float64.
     """
     log_value = pt.log(value)
-    lower = pt.zeros_like(value) + pt.as_tensor_variable(lower, dtype="float64")
+    lower = pt.as_tensor_variable(lower).astype("float64")
+
+    # The scan below carries (lo, hi) as recurrent state, whose shape must stay
+    # fixed across iterations. Since logcdf(k) broadcasts k against the
+    # distribution parameters, the state must start at the full broadcast shape
+    # of value and the parameters. Probing logcdf gives that shape; only the
+    # shape is used, so the probe computation itself is pruned from the graph.
+    result_shape = logcdf(pt.broadcast_arrays(lower, log_value)[0]).shape
+    log_value = pt.broadcast_to(log_value, result_shape)
+    lower = pt.broadcast_to(lower, result_shape)
 
     if upper is None:
         hi_init = lower + 1.0
         if start is not None:
-            start = pt.zeros_like(value) + pt.as_tensor_variable(start, dtype="float64")
+            start = pt.broadcast_to(pt.as_tensor_variable(start).astype("float64"), result_shape)
             hi_init = pt.maximum(pt.floor(start), hi_init)
 
         # Phase 1: geometrically expand an upper bracket until cdf(hi) >= value.
@@ -153,7 +161,7 @@ def discrete_icdf_via_search(logcdf, value, lower, upper=None, *, start=None, ma
         lo, hi = lo[-1], hi[-1]
     else:
         lo = lower
-        hi = pt.zeros_like(value) + pt.as_tensor_variable(upper, dtype="float64")
+        hi = pt.broadcast_to(pt.as_tensor_variable(upper).astype("float64"), result_shape)
 
     # Phase 2: bisect [lo, hi] keeping the invariant cdf(hi) >= value > cdf(lo - 1).
     def bisect(lo, hi):

--- a/pymc/distributions/dist_math.py
+++ b/pymc/distributions/dist_math.py
@@ -89,6 +89,75 @@ def check_icdf_value(expr: Variable, value: Variable) -> Variable:
     return expr
 
 
+def discrete_icdf_via_search(logcdf, value, lower, upper=None, *, max_iters=64):
+    """Numerically invert a discrete CDF by bisecting the (monotone) ``logcdf``.
+
+    Returns the smallest integer ``k`` in the support such that
+    ``cdf(k) >= value``, i.e. the quantile function evaluated at ``value``.
+    This is the discrete counterpart of inverting a continuous CDF with a
+    special function (e.g. ``betaincinv``), and is meant for distributions
+    whose quantile function has no closed form (e.g. ``Poisson``, ``Binomial``,
+    ``NegativeBinomial``).
+
+    The search uses fixed-length ``scan`` loops (rather than a data-dependent
+    ``while``) so that the resulting graph remains convertible to the C, Numba
+    and JAX backends. Each step is idempotent once an element has converged, so
+    running the full ``max_iters`` iterations does not change the result.
+
+    Parameters
+    ----------
+    logcdf : callable
+        Function mapping an integer-valued tensor ``k`` to ``logcdf(k)`` of the
+        target distribution.
+    value : tensor_like
+        Cumulative probabilities at which to evaluate the quantile function.
+        Assumed to lie in the open interval ``(0, 1)``; edge handling for
+        ``value`` is the responsibility of :func:`check_icdf_value`.
+    lower : tensor_like
+        Smallest value in the support of the distribution.
+    upper : tensor_like, optional
+        Largest value in the support. If ``None`` (unbounded support), a finite
+        upper bracket is first found by geometric expansion.
+    max_iters : int
+        Number of search iterations per phase. This needs to exceed ``log2`` of
+        the largest reachable quantile; the default of 64 covers the full range
+        of integers exactly representable as float64.
+    """
+    log_value = pt.log(value)
+    lower = pt.zeros_like(value) + pt.as_tensor_variable(lower, dtype="float64")
+
+    if upper is None:
+        # Phase 1: geometrically expand an upper bracket until cdf(hi) >= value.
+        def expand(lo, hi):
+            insufficient = logcdf(hi) < log_value
+            return pt.switch(insufficient, hi + 1.0, lo), pt.switch(insufficient, hi * 2.0, hi)
+
+        lo, hi = pytensor.scan(
+            expand,
+            outputs_info=[lower, lower + 1.0],
+            n_steps=max_iters,
+            return_updates=False,
+        )
+        lo, hi = lo[-1], hi[-1]
+    else:
+        lo = lower
+        hi = pt.zeros_like(value) + pt.as_tensor_variable(upper, dtype="float64")
+
+    # Phase 2: bisect [lo, hi] keeping the invariant cdf(hi) >= value > cdf(lo - 1).
+    def bisect(lo, hi):
+        mid = pt.floor((lo + hi) / 2.0)
+        covers = logcdf(mid) >= log_value
+        return pt.switch(covers, lo, mid + 1.0), pt.switch(covers, mid, hi)
+
+    lo, _ = pytensor.scan(
+        bisect,
+        outputs_info=[lo, hi],
+        n_steps=max_iters,
+        return_updates=False,
+    )
+    return lo[-1]
+
+
 def logpow(x, m):
     """Calculate log(x**m) since m*log(x) will fail when m, x = 0."""
     # return m * log(x)

--- a/pymc/distributions/truncated.py
+++ b/pymc/distributions/truncated.py
@@ -124,7 +124,9 @@ class TruncatedRV(SymbolicRandomVariable):
                 size=rv_.shape,
                 return_next_rng=True,
             )
-            truncated_rv_ = icdf(rv_, uniform_, warn_rvs=False)
+            # icdf graphs are always float-typed (they use nan for invalid values),
+            # so restore the base RV dtype for discrete distributions
+            truncated_rv_ = icdf(rv_, uniform_, warn_rvs=False).astype(rv_.type.dtype)
             return TruncatedRV(
                 base_rv_op=dist.owner.op,
                 inputs=graph_inputs_,

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -228,6 +228,11 @@ class TestMatchesScipy:
             Nat,
             {"mu": Rplus, "alpha": Rplus},
         )
+        check_icdf(
+            pm.NegativeBinomial,
+            {"p": Unit, "n": Rplus},
+            lambda q, p, n: st.nbinom.ppf(q, n, p),
+        )
 
     @pytest.mark.parametrize(
         "mu, p, alpha, n, expected",
@@ -266,6 +271,11 @@ class TestMatchesScipy:
             pm.Binomial,
             Nat,
             {"n": NatSmall, "p": Unit},
+        )
+        check_icdf(
+            pm.Binomial,
+            {"n": NatSmall, "p": Unit},
+            lambda q, n, p: st.binom.ppf(q, n, p),
         )
 
     def test_beta_binomial(self):
@@ -368,6 +378,11 @@ class TestMatchesScipy:
             pm.Poisson,
             Nat,
             {"mu": Rplus},
+        )
+        check_icdf(
+            pm.Poisson,
+            {"mu": Rplus},
+            st.poisson.ppf,
         )
 
     @pytest.mark.parametrize("n", [2, 3, 4])

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -399,6 +399,27 @@ class TestMatchesScipy:
             st.poisson.ppf(q, 1e4),
         )
 
+    def test_discrete_icdf_batched_params(self):
+        # The search state must be broadcast against the distribution
+        # parameters, not just the quantile, or scan fails / misbroadcasts
+        mu = np.array([2.0, 5.0, 20.0])
+        np.testing.assert_array_equal(
+            icdf(pm.Poisson.dist(mu=mu), 0.5).eval(),
+            st.poisson.ppf(0.5, mu),
+        )
+
+        q = np.array([[0.1], [0.5], [0.9]])
+        n = np.array([10, 40])
+        p = np.array([0.3, 0.6])  # broadcasts with q to shape (3, 2)
+        np.testing.assert_array_equal(
+            icdf(pm.Binomial.dist(n=n, p=p), q).eval(),
+            st.binom.ppf(q, n, p),
+        )
+        np.testing.assert_array_equal(
+            icdf(pm.NegativeBinomial.dist(n=n, p=p), q).eval(),
+            st.nbinom.ppf(q, n, p),
+        )
+
     @pytest.mark.parametrize("n", [2, 3, 4])
     def test_categorical(self, n):
         domain = Domain(range(n), dtype="int64", edges=(0, n))

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -233,6 +233,12 @@ class TestMatchesScipy:
             {"p": Unit, "n": Rplus},
             lambda q, p, n: st.nbinom.ppf(q, n, p),
         )
+        # Large mean, where the icdf search relies on the mean-seeded bracket
+        q = np.array([0.001, 0.5, 0.999])
+        np.testing.assert_array_equal(
+            icdf(pm.NegativeBinomial.dist(n=10, p=1e-3), q).eval(),
+            st.nbinom.ppf(q, 10, 1e-3),
+        )
 
     @pytest.mark.parametrize(
         "mu, p, alpha, n, expected",
@@ -383,6 +389,14 @@ class TestMatchesScipy:
             pm.Poisson,
             {"mu": Rplus},
             st.poisson.ppf,
+        )
+        # Large mu, where the icdf search relies on the mean-seeded bracket.
+        # mu is kept at 1e4 because the C implementation of gammaincc (used by
+        # logcdf inside the search) loses precision for larger arguments.
+        q = np.array([0.001, 0.5, 0.999])
+        np.testing.assert_array_equal(
+            icdf(pm.Poisson.dist(mu=1e4), q).eval(),
+            st.poisson.ppf(q, 1e4),
         )
 
     @pytest.mark.parametrize("n", [2, 3, 4])


### PR DESCRIPTION
## Description

Adds `icdf` (quantile / inverse-CDF) methods for four discrete distributions:

- **Bernoulli** — closed form, `icdf(q) = 0 if q ≤ 1 − p else 1`.
- **Poisson**, **Binomial**, **NegativeBinomial** — these have no closed-form quantile, and the special-function inverses (`gammaincinv`/`betaincinv`) don't apply since they invert the CDF in its continuous probability argument rather than over the integer support. This adds a shared `discrete_icdf_via_search` helper (in `dist_math.py`) that inverts the monotone `logcdf` by bisection, with geometric bracket expansion for the unbounded-support cases (Poisson, NegativeBinomial).

The helper uses fixed-length `scan` loops (no data-dependent `until`) so the graph remains convertible to the C, Numba, and JAX backends — verified for all three. As a side effect this enables `pm.Truncated` for these distributions, which falls back to `icdf` for inverse-transform sampling.

Tests compare against SciPy's `ppf` using the existing `check_icdf` helper.

A few other distributions in the same family (BetaBinomial, HyperGeometric) could reuse the same helper if you all want! This was very fun to work on. I met Daniel Lee at the Sloan conf back in March and have been using PyMc ever since--though I still enjoy Stan. 

## Related Issue
- [x] Related to #6612

## Checklist
- [x] Checked that the pre-commit linting/style checks pass
- [x] Included tests that prove the feature works
- [x] Added necessary documentation (docstrings)

## Type of change
- [x] New feature / enhancement
