### PR TITLE
Add helper to extract and reinsert deterministics in a model

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,6 +109,7 @@ jobs:
             tests/model/test_fgraph.py
             tests/model/transform/test_basic.py
             tests/model/transform/test_conditioning.py
+            tests/model/transform/test_deterministic.py
             tests/model/transform/test_optimization.py
             tests/model/test_transform_values.py
             tests/test_model_graph.py

--- a/docs/source/api/model.rst
+++ b/docs/source/api/model.rst
@@ -9,5 +9,6 @@ Model
    model/core
    model/conditioning
    model/transform_values
+   model/deterministics
    model/optimization
    model/fgraph

--- a/docs/source/api/model/conditioning.rst
+++ b/docs/source/api/model/conditioning.rst
@@ -1,7 +1,7 @@
 Model Conditioning
 ------------------
 
-.. currentmodule:: pymc.model.transform.conditioning
+.. currentmodule:: pymc.model.transform
 .. autosummary::
    :toctree: generated/
 

--- a/docs/source/api/model/deterministics.rst
+++ b/docs/source/api/model/deterministics.rst
@@ -1,0 +1,9 @@
+Deterministic Surgery
+---------------------
+
+.. currentmodule:: pymc.model.transform.deterministic
+.. autosummary::
+   :toctree: generated/
+
+   extract_deterministics
+   insert_deterministics

--- a/docs/source/api/model/deterministics.rst
+++ b/docs/source/api/model/deterministics.rst
@@ -1,7 +1,7 @@
 Deterministic Surgery
 ---------------------
 
-.. currentmodule:: pymc.model.transform.deterministic
+.. currentmodule:: pymc.model.transform
 .. autosummary::
    :toctree: generated/
 

--- a/docs/source/api/model/optimization.rst
+++ b/docs/source/api/model/optimization.rst
@@ -1,6 +1,6 @@
 Model Optimization
 ------------------
-.. currentmodule:: pymc.model.transform.optimization
+.. currentmodule:: pymc.model.transform
 .. autosummary::
    :toctree: generated/
 

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -3892,11 +3892,16 @@ class Interpolated(BoundedContinuous):
 
     def logp(value, x_points, pdf_points, cdf_points):
         # x_points and pdf_points are expected to be non-symbolic arrays wrapped
-        # within a tensor.constant. We use the .data method to retrieve them
+        # within a tensor.constant. We use the .data method to retrieve them.
+        # Squeeze to 1-D in case size broadcasting prepended length-1 batch dims;
+        # the spline is always defined over a single set of points, and scipy's
+        # integral bounds must be 0-dimensional.
+        x_points_data = np.squeeze(x_points.data)
+        pdf_points_data = np.squeeze(pdf_points.data)
         interp = interpolate.InterpolatedUnivariateSpline(
-            x_points.data, pdf_points.data, k=1, ext="zeros"
+            x_points_data, pdf_points_data, k=1, ext="zeros"
         )
-        Z = interp.integral(x_points.data[..., 0], x_points.data[..., -1])
+        Z = interp.integral(x_points_data[0], x_points_data[-1])
 
         # interp and Z are converted to symbolic variables here
         interp_op = SplineWrapper(interp)

--- a/pymc/model/fgraph.py
+++ b/pymc/model/fgraph.py
@@ -15,7 +15,6 @@ import warnings
 
 from copy import copy, deepcopy
 
-from pytensor.basic import as_symbolic
 from pytensor.compile import SharedVariable, ViewOp, view_op
 from pytensor.graph import Apply, FunctionGraph, Op, node_rewriter
 from pytensor.graph.basic import Variable
@@ -23,23 +22,28 @@ from pytensor.graph.rewriting.basic import out2in
 
 from pymc.logprob.transforms import Transform
 from pymc.model.core import Model
-from pymc.pytensorf import StringType, find_rng_nodes, toposort_replace
+from pymc.pytensorf import find_rng_nodes, toposort_replace
 
 
 class ModelVar(Op):
-    """A dummy Op that describes the purpose of a Model variable and contains meta-information as additional inputs (value and dims)."""
+    """A dummy Op that describes the purpose of a Model variable.
 
-    def make_node(self, rv, *dims):
+    The variable's ``name`` and ``dims`` are stored as Op properties (meta-information
+    needed to reconstruct the Model), while the wrapped variable (and value) are inputs.
+    """
+
+    __props__ = ("name", "dims")
+
+    def __init__(self, name: str, dims: tuple[str, ...] = ()):
+        dims = tuple(dims)
+        assert all(isinstance(dim, str) for dim in dims)
+        self.name = name
+        self.dims = dims
+
+    def make_node(self, rv):
         assert isinstance(rv, Variable)
-        dims = self._parse_dims(rv, *dims)
-        return Apply(self, [rv, *dims], [rv.type(name=rv.name)])
-
-    def _parse_dims(self, rv, *dims):
-        if dims:
-            dims = [as_symbolic(dim) for dim in dims]
-            assert all(isinstance(dim.type, StringType) for dim in dims)
-            assert len(dims) == rv.type.ndim
-        return dims
+        assert not self.dims or len(self.dims) == rv.type.ndim
+        return Apply(self, [rv], [rv.type(name=self.name)])
 
     def infer_shape(self, fgraph, node, inputs_shape):
         return [inputs_shape[0]]
@@ -52,21 +56,21 @@ class ModelVar(Op):
 
 
 class ModelValuedVar(ModelVar):
-    __props__ = ("transform",)
+    __props__ = ("name", "dims", "transform")
 
-    def __init__(self, transform: Transform | None = None):
+    def __init__(self, name: str, dims: tuple[str, ...] = (), transform: Transform | None = None):
         if transform is not None and not isinstance(transform, Transform):
             raise TypeError(f"transform must be None or RVTransform type, got {type(transform)}")
         self.transform = transform
-        super().__init__()
+        super().__init__(name, dims)
 
-    def make_node(self, rv, value, *dims):
+    def make_node(self, rv, value):
         assert isinstance(rv, Variable)
-        dims = self._parse_dims(rv, *dims)
+        assert not self.dims or len(self.dims) == rv.type.ndim
         if value is not None:
             assert isinstance(value, Variable)
             assert rv.type.dtype == value.type.dtype
-            return Apply(self, [rv, value, *dims], [rv.type(name=rv.name)])
+            return Apply(self, [rv, value], [rv.type(name=self.name)])
 
 
 class ModelFreeRV(ModelValuedVar):
@@ -89,14 +93,24 @@ class ModelNamed(ModelVar):
     pass
 
 
-def model_free_rv(rv, value, transform, *dims):
-    return ModelFreeRV(transform=transform)(rv, value, *dims)
+def model_free_rv(rv, value, transform, name, *dims):
+    return ModelFreeRV(name=name, dims=dims, transform=transform)(rv, value)
 
 
-model_observed_rv = ModelObservedRV()
-model_potential = ModelPotential()
-model_deterministic = ModelDeterministic()
-model_named = ModelNamed()
+def model_observed_rv(rv, value, name, *dims):
+    return ModelObservedRV(name=name, dims=dims)(rv, value)
+
+
+def model_potential(rv, name, *dims):
+    return ModelPotential(name=name, dims=dims)(rv)
+
+
+def model_deterministic(rv, name, *dims):
+    return ModelDeterministic(name=name, dims=dims)(rv)
+
+
+def model_named(rv, name, *dims):
+    return ModelNamed(name=name, dims=dims)(rv)
 
 
 @node_rewriter([ViewOp])
@@ -240,19 +254,20 @@ def fgraph_from_model(
     vars = fgraph.outputs
     new_vars = []
     for var in vars:
-        dims = named_vars_to_dims.get(var.name, ())
+        name = var.name
+        dims = named_vars_to_dims.get(name, ())
         if var in free_rvs_to_values:
             new_var = model_free_rv(
-                var, free_rvs_to_values[var], free_rvs_to_transforms[var], *dims
+                var, free_rvs_to_values[var], free_rvs_to_transforms[var], name, *dims
             )
         elif var in observed_rvs_to_values:
-            new_var = model_observed_rv(var, observed_rvs_to_values[var], *dims)
+            new_var = model_observed_rv(var, observed_rvs_to_values[var], name, *dims)
         elif var in potentials:
-            new_var = model_potential(var, *dims)
+            new_var = model_potential(var, name, *dims)
         elif var in deterministics:
-            new_var = model_deterministic(var, *dims)
+            new_var = model_deterministic(var, name, *dims)
         elif var in named_vars:
-            new_var = model_named(var, *dims)
+            new_var = model_named(var, name, *dims)
         else:
             # Unnamed value variables
             new_var = var
@@ -335,35 +350,35 @@ def model_from_fgraph(fgraph: FunctionGraph, mutate_fgraph: bool = False) -> Mod
 
     # Populate new PyMC model mappings
     for model_var in model_dummy_vars:
-        if isinstance(model_var.owner.op, ModelFreeRV):
-            var, value, *dims = model_var.owner.inputs
-            transform = model_var.owner.op.transform
+        op = model_var.owner.op
+        if isinstance(op, ModelFreeRV):
+            var, value = model_var.owner.inputs
             model.free_RVs.append(var)
             model.create_value_var(
-                var, transform=transform, default_transform=None, value_var=value
+                var, transform=op.transform, default_transform=None, value_var=value
             )
             model.set_initval(var, initval=None)
-        elif isinstance(model_var.owner.op, ModelObservedRV):
-            var, value, *dims = model_var.owner.inputs
+        elif isinstance(op, ModelObservedRV):
+            var, value = model_var.owner.inputs
             model.observed_RVs.append(var)
             model.create_value_var(var, transform=None, default_transform=None, value_var=value)
-        elif isinstance(model_var.owner.op, ModelPotential):
-            var, *dims = model_var.owner.inputs
+        elif isinstance(op, ModelPotential):
+            [var] = model_var.owner.inputs
             model.potentials.append(var)
-        elif isinstance(model_var.owner.op, ModelDeterministic):
-            var, *dims = model_var.owner.inputs
+        elif isinstance(op, ModelDeterministic):
+            [var] = model_var.owner.inputs
             # If a Deterministic is a direct view on an RV, view it
             if var in model.basic_RVs:
                 var = view_op(var)
             model.deterministics.append(var)
-        elif isinstance(model_var.owner.op, ModelNamed):
-            var, *dims = model_var.owner.inputs
+        elif isinstance(op, ModelNamed):
+            [var] = model_var.owner.inputs
             model.data_vars.append(var)
         else:
             raise TypeError(f"Unexpected ModelVar type {type(model_var)}")
 
-        var.name = model_var.name
-        dims = [dim.data for dim in dims] if dims else None
+        var.name = op.name
+        dims = list(op.dims) if op.dims else None
         model.add_named_variable(var, dims=dims)
 
     return model
@@ -397,17 +412,6 @@ def clone_model(model: Model) -> Model:
 
     """
     return model_from_fgraph(fgraph_from_model(model)[0], mutate_fgraph=True)
-
-
-def extract_dims(var) -> tuple:
-    dims = ()
-    node = var.owner
-    if node and isinstance(node.op, ModelVar):
-        if isinstance(node.op, ModelValuedVar):
-            dims = node.inputs[2:]
-        else:
-            dims = node.inputs[1:]
-    return dims
 
 
 __all__ = (

--- a/pymc/model/transform/__init__.py
+++ b/pymc/model/transform/__init__.py
@@ -13,3 +13,31 @@
 #   limitations under the License.
 
 """Model transforms."""
+
+from pymc.model.transform.basic import (
+    prune_vars_detached_from_observed,
+    remove_minibatched_nodes,
+)
+from pymc.model.transform.conditioning import (
+    change_value_transforms,
+    do,
+    observe,
+    remove_value_transforms,
+)
+from pymc.model.transform.deterministic import (
+    extract_deterministics,
+    insert_deterministics,
+)
+from pymc.model.transform.optimization import freeze_dims_and_data
+
+__all__ = (
+    "change_value_transforms",
+    "do",
+    "extract_deterministics",
+    "freeze_dims_and_data",
+    "insert_deterministics",
+    "observe",
+    "prune_vars_detached_from_observed",
+    "remove_minibatched_nodes",
+    "remove_value_transforms",
+)

--- a/pymc/model/transform/basic.py
+++ b/pymc/model/transform/basic.py
@@ -74,11 +74,9 @@ def remove_minibatched_nodes(model: Model) -> Model:
                 replacements[out] = inp
 
     old_outs, old_coords, old_dim_lengths = fgraph.outputs, fgraph._coords, fgraph._dim_lengths  # type: ignore[attr-defined]
-    # Using `rebuild_strict=False` means all coords, names, and dim information is lost
-    # So we need to restore it from the old fgraph
+    # Using `rebuild_strict=False` means coords and dim information is lost (variable
+    # names are carried by the ModelVar Ops), so we restore it from the old fgraph
     new_outs = clone_replace(old_outs, replacements, rebuild_strict=False)  # type: ignore[arg-type]
-    for old_out, new_out in zip(old_outs, new_outs):
-        new_out.name = old_out.name
     fgraph = FunctionGraph(outputs=new_outs, clone=False)
     fgraph._coords = old_coords  # type: ignore[attr-defined]
     fgraph._dim_lengths = old_dim_lengths  # type: ignore[attr-defined]

--- a/pymc/model/transform/conditioning.py
+++ b/pymc/model/transform/conditioning.py
@@ -27,7 +27,6 @@ from pymc.model.fgraph import (
     ModelDeterministic,
     ModelFreeRV,
     ModelValuedVar,
-    extract_dims,
     fgraph_from_model,
     model_deterministic,
     model_free_rv,
@@ -114,9 +113,8 @@ def observe(
         assert model_var in fgraph.variables
 
         var = model_var.owner.inputs[0]
-        var.name = model_var.name
-        dims = extract_dims(model_var)
-        model_obs_rv = model_observed_rv(var, var.type.filter_variable(obs), *dims)
+        op = model_var.owner.op
+        model_obs_rv = model_observed_rv(var, var.type.filter_variable(obs), op.name, *op.dims)
         replacements[model_var] = model_obs_rv
 
     toposort_replace(fgraph, tuple(replacements.items()))
@@ -204,22 +202,22 @@ def do(
         # Just a sanity check
         assert model_var in fgraph.variables
 
+        op = model_var.owner.op
         # If the intervention references the original variable we must give it a different name
         if model_var in ancestors([intervention]):
-            intervention.name = f"do_{model_var.name}"
+            name = f"do_{op.name}"
             warnings.warn(
-                f"Intervention expression references the variable that is being intervened: {model_var.name}. "
-                f"Intervention will be given the name: {intervention.name}"
+                f"Intervention expression references the variable that is being intervened: {op.name}. "
+                f"Intervention will be given the name: {name}"
             )
         else:
-            intervention.name = model_var.name
-        dims = extract_dims(model_var)
+            name = op.name
         # If there are any RVs in the graph we introduce the intervention as a deterministic
         if rvs_in_graph([intervention]):
-            new_var = model_deterministic(intervention.copy(name=intervention.name), *dims)
+            new_var = model_deterministic(intervention.copy(), name, *op.dims)
         # Otherwise as a named variable (Constant or Shared data)
         else:
-            new_var = model_named(intervention, *dims)
+            new_var = model_named(intervention, name, *op.dims)
 
         replacements[model_var] = new_var
 
@@ -296,7 +294,7 @@ def change_value_transforms(
 
         transform = vars_to_transforms[dummy_rv]
 
-        rv, value, *dims = node.inputs
+        rv, value = node.inputs
 
         new_value = rv.type()
         try:
@@ -309,7 +307,7 @@ def change_value_transforms(
             new_name = untransformed_name
         new_value.name = new_name
 
-        new_dummy_rv = model_free_rv(rv, new_value, transform, *dims)
+        new_dummy_rv = model_free_rv(rv, new_value, transform, node.op.name, *node.op.dims)
         replacements[dummy_rv] = new_dummy_rv
 
     toposort_replace(fgraph, tuple(replacements.items()))

--- a/pymc/model/transform/conditioning.py
+++ b/pymc/model/transform/conditioning.py
@@ -255,7 +255,7 @@ def change_value_transforms(
 
         import pymc as pm
         from pymc.distributions.transforms import logodds
-        from pymc.model.transform.conditioning import change_value_transforms
+        from pymc.model.transform import change_value_transforms
 
         with pm.Model() as base_m:
             p = pm.Uniform("p", 0, 1, default_transform=None)
@@ -338,7 +338,7 @@ def remove_value_transforms(
     .. code-block:: python
 
         import pymc as pm
-        from pymc.model.transform.conditioning import remove_value_transforms
+        from pymc.model.transform import remove_value_transforms
 
         with pm.Model() as transformed_m:
             p = pm.Uniform("p", 0, 1)

--- a/pymc/model/transform/deterministic.py
+++ b/pymc/model/transform/deterministic.py
@@ -1,0 +1,223 @@
+#   Copyright 2024 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+from collections.abc import Sequence
+
+from pytensor.graph import Apply, Op, ancestors
+from pytensor.graph.basic import Variable
+from pytensor.graph.fg import FrozenFunctionGraph, FunctionGraph
+from pytensor.graph.rewriting.basic import in2out, node_rewriter
+
+from pymc.model.core import Model
+from pymc.model.fgraph import (
+    ModelDeterministic,
+    ModelVar,
+    fgraph_from_model,
+    model_from_fgraph,
+)
+
+
+class ModelAnchor(Op):
+    """Placeholder that tags a variable by name in a detached Deterministic subgraph.
+
+    It marks the surrounding Model variables a Deterministic depends on, so that
+    :func:`insert_deterministics` can splice the subgraph back into a Model by matching
+    these names against the target Model variables. Anchors are always removed before the
+    Deterministic is reinserted, so they never appear in a final Model graph.
+    """
+
+    __props__ = ("name",)
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def make_node(self, var):
+        assert isinstance(var, Variable)
+        return Apply(self, [var], [var.type()])
+
+    def perform(self, *args, **kwargs):
+        raise RuntimeError("ModelAnchors should never be in a final graph!")
+
+
+@node_rewriter([ModelAnchor])
+def local_remove_anchor(fgraph, node):
+    [inp] = node.inputs
+    inp.name = node.op.name
+    return [inp]
+
+
+remove_anchors = in2out(local_remove_anchor, ignore_newtrees=True)
+
+
+def extract_deterministics(
+    model: Model, var_names: str | Sequence[str] | None = None
+) -> tuple[Model, list[FrozenFunctionGraph]]:
+    """Remove Deterministics from a Model, returning them as detached subgraphs.
+
+    The Deterministic computations are inlined into the variables that depend on them,
+    so the returned Model is equivalent to the original one but without the Deterministic
+    labels. The removed Deterministics are returned as standalone graphs that can later be
+    spliced back into a (possibly different) Model with :func:`insert_deterministics`.
+
+    Parameters
+    ----------
+    model : Model
+        The model to extract Deterministics from.
+    var_names : str or sequence of str, optional
+        The names of the Deterministics to extract. Defaults to all the Deterministics
+        in the model.
+
+    Returns
+    -------
+    new_model : Model
+        A copy of the model without the extracted Deterministics.
+    deterministics : list of FrozenFunctionGraph
+        The extracted Deterministics, as standalone graphs. The order is topological,
+        so that Deterministics that depend on other extracted Deterministics come later.
+
+    See Also
+    --------
+    insert_deterministics : Splice Deterministics back into a Model.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import numpy as np
+        import pymc as pm
+        from pymc.model.transform import (
+            extract_deterministics,
+            insert_deterministics,
+        )
+
+        with pm.Model() as model:
+            x = pm.Data("x", np.ones((10, 3)))
+            beta = pm.Normal("beta", shape=(3,))
+            mu = pm.Deterministic("mu", x @ beta)
+            pm.Normal("y", mu=mu, sigma=1, observed=np.ones(10))
+
+        # Drop the ``mu`` Deterministic (it gets inlined into ``y``)
+        no_det_model, deterministics = extract_deterministics(model)
+
+        # Put it back
+        model_again = insert_deterministics(no_det_model, deterministics)
+
+    """
+    dets: Sequence[Variable]
+    if var_names is None:
+        dets = model.deterministics
+    else:
+        if isinstance(var_names, str):
+            var_names = (var_names,)
+        dets = [model[name] for name in var_names]
+        if any(det not in model.deterministics for det in dets):
+            raise ValueError("At least one var is not a Deterministic in the model")
+
+    if not dets:
+        return model.copy(), []
+
+    fgraph, memo = fgraph_from_model(model, inlined_views=True)
+    memo_dets = [memo[d] for d in dets]
+
+    replacements = []
+    deterministics = []
+    model_vars: list = []
+    for node in fgraph.toposort():
+        if not isinstance(node.op, ModelVar):
+            continue
+        [model_var] = node.outputs
+        if isinstance(node.op, ModelDeterministic) and model_var in memo_dets:
+            # Inline the Deterministic into its dependents
+            replacements.append((model_var, model_var.owner.inputs[0]))
+            # Capture the Deterministic subgraph up to the surrounding Model variables
+            det_inputs = [a for a in ancestors([model_var], blockers=model_vars) if a in model_vars]
+            det_memo: dict = {}
+            det_fgraph = FunctionGraph(det_inputs, [model_var], memo=det_memo)
+            # Tag the surrounding Model variables by name so the subgraph can be re-attached
+            det_fgraph.replace_all(
+                # Model variables always have a name, and the single-output Op call
+                # returns a Variable (mypy infers the broad Op.__call__ return type).
+                [(det_memo[i], ModelAnchor(i.name)(det_memo[i])) for i in det_inputs]  # type: ignore[arg-type, misc]
+            )
+            deterministics.append(
+                FrozenFunctionGraph(inputs=det_fgraph.inputs, outputs=det_fgraph.outputs)
+            )
+        model_vars.append(model_var)
+
+    fgraph.replace_all(replacements, reason="extract_deterministics")
+    return model_from_fgraph(fgraph, mutate_fgraph=True), deterministics
+
+
+def insert_deterministics(model: Model, deterministics: Sequence[FrozenFunctionGraph]) -> Model:
+    """Splice detached Deterministics into a Model.
+
+    This is the inverse of :func:`extract_deterministics`. The Deterministics are attached
+    by matching the names of the Model variables they depend on against the variables in
+    the target Model.
+
+    Parameters
+    ----------
+    model : Model
+        The model to insert the Deterministics into.
+    deterministics : sequence of FrozenFunctionGraph
+        The Deterministics to insert, as returned by :func:`extract_deterministics`. They
+        must be provided in topological order (Deterministics that depend on other inserted
+        Deterministics come later), which is how ``extract_deterministics`` returns them.
+
+    Returns
+    -------
+    new_model : Model
+        A copy of the model with the Deterministics inserted.
+
+    See Also
+    --------
+    extract_deterministics : Remove Deterministics from a Model as detached subgraphs.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import numpy as np
+        import pymc as pm
+        from pymc.model.transform import (
+            extract_deterministics,
+            insert_deterministics,
+        )
+
+        with pm.Model() as model:
+            x = pm.Data("x", np.ones((10, 3)))
+            beta = pm.Normal("beta", shape=(3,))
+            mu = pm.Deterministic("mu", x @ beta)
+            pm.Normal("y", mu=mu, sigma=1, observed=np.ones(10))
+
+        # Drop the ``mu`` Deterministic (it gets inlined into ``y``)
+        no_det_model, deterministics = extract_deterministics(model)
+
+        # Put it back
+        model_again = insert_deterministics(no_det_model, deterministics)
+
+    """
+    fgraph, _ = fgraph_from_model(model)
+    named_vars = {
+        node.outputs[0].name: node.outputs[0]
+        for node in fgraph.toposort()
+        if isinstance(node.op, ModelVar)
+    }
+    for det in deterministics:
+        anchors = [node for node in det.toposort() if isinstance(node.op, ModelAnchor)]
+        [det_live] = det.bind({a.inputs[0]: named_vars[a.op.name] for a in anchors})
+        fgraph.add_output(det_live)
+        # Expose the inserted Deterministic by name so dependent Deterministics can attach to it
+        named_vars[det_live.owner.op.name] = det_live
+    remove_anchors.apply(fgraph)
+    return model_from_fgraph(fgraph, mutate_fgraph=True)

--- a/pymc/model/transform/optimization.py
+++ b/pymc/model/transform/optimization.py
@@ -98,8 +98,6 @@ def freeze_dims_and_data(
     old_outs, old_coords, old_dim_lenghts = fg.outputs, fg._coords, fg._dim_lengths  # type: ignore[attr-defined]
     # Rebuild strict will force the recreation of RV nodes with updated static types
     new_outs = clone_replace(old_outs, replace=frozen_replacements, rebuild_strict=False)  # type: ignore[arg-type]
-    for old_out, new_out in zip(old_outs, new_outs):
-        new_out.name = old_out.name
     fg = FunctionGraph(outputs=new_outs, clone=False)
     fg._coords = old_coords  # type: ignore[attr-defined]
     fg._dim_lengths = {  # type: ignore[attr-defined]

--- a/pymc/model/transform/optimization.py
+++ b/pymc/model/transform/optimization.py
@@ -17,7 +17,7 @@ from pytensor.compile import SharedVariable
 from pytensor.graph import Constant, FunctionGraph
 from pytensor.graph.replace import clone_replace
 
-from pymc import Model
+from pymc.model.core import Model
 from pymc.model.fgraph import ModelFreeRV, fgraph_from_model, model_from_fgraph
 
 
@@ -62,7 +62,7 @@ def freeze_dims_and_data(
         import pymc as pm
         import pytensor.tensor as pt
 
-        from pymc.model.transform.optimization import freeze_dims_and_data
+        from pymc.model.transform import freeze_dims_and_data
 
         with pm.Model() as m:
             x = pm.Data("x", [0, 1, 2] * 1000)

--- a/pymc/pytensorf.py
+++ b/pymc/pytensorf.py
@@ -25,7 +25,7 @@ import pytensor.tensor as pt
 from pytensor.compile import Function, Mode, get_mode
 from pytensor.compile.builders import OpFromGraph
 from pytensor.gradient import grad
-from pytensor.graph import Type, rewrite_graph
+from pytensor.graph import rewrite_graph
 from pytensor.graph.basic import (
     Apply,
     Constant,
@@ -1034,36 +1034,6 @@ def get_symbolic_rv_shapes(
 def rewrite_pregrad(graph):
     """Apply simplifying or stabilizing rewrites to graph that are safe to use pre-grad."""
     return rewrite_graph(graph, include=("canonicalize", "stabilize"))
-
-
-class StringType(Type[str]):
-    def clone(self, **kwargs):
-        return type(self)()
-
-    def filter(self, x, strict=False, allow_downcast=None):
-        if isinstance(x, str):
-            return x
-        else:
-            raise TypeError("Expected a string!")
-
-    def __str__(self):
-        return "string"
-
-    @staticmethod
-    def may_share_memory(a, b):
-        return isinstance(a, str) and a is b
-
-
-stringtype = StringType()
-
-
-class StringConstant(Constant):
-    pass
-
-
-@pytensor.basic._as_symbolic.register(str)
-def as_symbolic_string(x, **kwargs):
-    return StringConstant(stringtype, x)
 
 
 def toposort_replace(

--- a/pymc/testing.py
+++ b/pymc/testing.py
@@ -47,6 +47,8 @@ from pymc.logprob.utils import (
     ParameterValueError,
     local_check_parameter_to_ninf_switch,
 )
+from pymc.model.core import Model
+from pymc.model.fgraph import ModelVar, fgraph_from_model
 from pymc.pytensorf import compile, floatX, inputvars, rvs_in_graph
 
 # This mode can be used for tests where model compilations takes the bulk of the runtime
@@ -1354,7 +1356,10 @@ def mock_sample_setup_and_teardown():
 
 
 def equal_computations_up_to_root(
-    xs: Sequence[Variable], ys: Sequence[Variable], ignore_rng_values=True
+    xs: Sequence[Variable],
+    ys: Sequence[Variable],
+    ignore_rng_values=True,
+    strict_dtype=True,
 ) -> bool:
     # Check if graphs are equivalent even if root variables have distinct identities
 
@@ -1375,4 +1380,55 @@ def equal_computations_up_to_root(
             if not x.type.values_eq(x.get_value(), y.get_value()):
                 return False
 
-    return equal_computations(xs, ys, in_xs=x_graph_inputs, in_ys=y_graph_inputs)  # type: ignore[arg-type]
+    return equal_computations(
+        xs,  # type: ignore[arg-type]
+        ys,  # type: ignore[arg-type]
+        in_xs=x_graph_inputs,
+        in_ys=y_graph_inputs,
+        strict_dtype=strict_dtype,
+    )
+
+
+def assert_equivalent_model(model_1: Model, model_2: Model, *, strict_dtype: bool = True) -> None:
+    """Assert that two PyMC models are equivalent.
+
+    Model variable order is incidental (it follows graph construction history); model
+    variables are uniquely named, so they are compared by name, ignoring order.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import pymc as pm
+        from pymc.testing import assert_equivalent_model
+
+        with pm.Model() as m1:
+            x = pm.Normal("x")
+            y = pm.Normal("y", x)
+
+        with pm.Model() as m2:
+            x = pm.Normal("x")
+            y = pm.Normal("y", x)
+
+        assert_equivalent_model(m1, m2)
+
+    """
+    fgraph_1, _ = fgraph_from_model(model_1)
+    fgraph_2, _ = fgraph_from_model(model_2)
+
+    def output_name(var: Variable) -> str:
+        # fgraph outputs are ModelVar nodes that carry the variable name on the Op
+        match var.owner_op:
+            case ModelVar(name=name):
+                return name
+            case _:
+                return ""
+
+    outputs_1 = sorted(fgraph_1.outputs, key=output_name)
+    outputs_2 = sorted(fgraph_2.outputs, key=output_name)
+    names_1 = [var.name for var in outputs_1]
+    names_2 = [var.name for var in outputs_2]
+    assert names_1 == names_2, f"Model variables differ: {names_1} != {names_2}"
+    assert equal_computations_up_to_root(outputs_1, outputs_2, strict_dtype=strict_dtype), (
+        "Model computations differ"
+    )

--- a/tests/backends/test_arviz.py
+++ b/tests/backends/test_arviz.py
@@ -70,8 +70,9 @@ class TestDataPyMC:
             self.model = model
             self.obj = trace
 
+    @staticmethod
     @pytest.fixture(scope="class")
-    def data(self, eight_schools_params, draws, chains):
+    def data(eight_schools_params, draws, chains):
         with pm.Model() as model:
             mu = pm.Normal("mu", mu=0, sigma=5)
             tau = pm.HalfCauchy("tau", beta=5)
@@ -90,7 +91,7 @@ class TestDataPyMC:
                     return_inferencedata=False,
                 )
 
-        return self.Data(model, trace)
+        return TestDataPyMC.Data(model, trace)
 
     def get_inference_data(self, data, eight_schools_params):
         with data.model:

--- a/tests/model/test_fgraph.py
+++ b/tests/model/test_fgraph.py
@@ -301,7 +301,8 @@ def non_centered_rewrite():
     def non_centered_param(fgraph: FunctionGraph, node):
         """Rewrite that replaces centered normal by non-centered parametrization."""
 
-        rv, value, *dims = node.inputs
+        rv, value = node.inputs
+        name, dims = node.op.name, node.op.dims
         if not isinstance(rv.owner.op, pm.Normal):
             return
         rng, size, loc, scale = rv.owner.inputs
@@ -322,15 +323,15 @@ def non_centered_rewrite():
         if is_unit:
             return
 
+        raw_name = f"{name}_raw_"
         raw_norm = pm.Normal.dist(0, 1, size=size, rng=rng)
-        raw_norm.name = f"{rv.name}_raw_"
         raw_norm_value = raw_norm.clone()
+        raw_norm_value.name = raw_name
         fgraph.add_input(raw_norm_value)
-        raw_norm = model_free_rv(raw_norm, raw_norm_value, node.op.transform, *dims)
+        raw_norm = model_free_rv(raw_norm, raw_norm_value, node.op.transform, raw_name, *dims)
 
         new_norm = loc + raw_norm * scale
-        new_norm.name = rv.name
-        new_norm_det = model_deterministic(new_norm, *dims)
+        new_norm_det = model_deterministic(new_norm, name, *dims)
         fgraph.add_output(new_norm_det)
 
         return [new_norm]

--- a/tests/model/transform/test_deterministic.py
+++ b/tests/model/transform/test_deterministic.py
@@ -1,0 +1,102 @@
+#   Copyright 2024 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import numpy as np
+import pytensor
+import pytest
+
+import pymc as pm
+
+from pymc.model.transform.deterministic import (
+    extract_deterministics,
+    insert_deterministics,
+)
+from pymc.testing import assert_equivalent_model
+
+
+@pytest.mark.parametrize(
+    "var_names, remaining",
+    [
+        (None, set()),
+        ("mu", {"sigma", "mu2"}),  # mu2 depends on extracted mu and stays
+        (["mu", "mu2"], {"sigma"}),
+        (["sigma"], {"mu", "mu2"}),
+    ],
+)
+def test_extract_insert_roundtrip(var_names, remaining):
+    # `sigma` is independent; `mu` and `mu2` are chained (mu2 depends on mu)
+    with pm.Model(coords={"obs": range(5), "feat": range(3)}) as m:
+        x = pm.Data("x", np.ones((5, 3)), dims=("obs", "feat"))
+        beta = pm.Normal("beta", dims="feat")
+        pm.Deterministic("sigma", pm.math.exp(pm.Normal("log_sigma")))
+        mu = pm.Deterministic("mu", x @ beta, dims="obs")
+        pm.Deterministic("mu2", mu * 3, dims="obs")
+        pm.Normal("y", m["mu2"], m["sigma"], observed=np.ones(5), dims="obs")
+
+    m_extracted, deterministics = extract_deterministics(m, var_names)
+    assert {d.name for d in m_extracted.deterministics} == remaining
+
+    m_inserted = insert_deterministics(m_extracted, deterministics)
+    assert_equivalent_model(m, m_inserted)
+
+    # And the inserted Deterministics are wired correctly: with x=ones and beta=pi,
+    # mu = 3 * pi, mu2 = 3 * mu = 9 * pi, sigma = exp(log_sigma)
+    fn = pytensor.function(
+        [m_inserted["beta"], m_inserted["log_sigma"]],
+        [m_inserted["mu"], m_inserted["mu2"], m_inserted["sigma"]],
+    )
+    mu, mu2, sigma = fn(np.full(3, np.pi), np.log(2.0))
+    np.testing.assert_allclose(mu, 3 * np.pi)
+    np.testing.assert_allclose(mu2, 9 * np.pi)
+    np.testing.assert_allclose(sigma, 2.0)
+
+
+def test_no_deterministics():
+    with pm.Model() as m:
+        pm.Normal("a")
+
+    m_extracted, deterministics = extract_deterministics(m)
+    assert deterministics == []
+    assert_equivalent_model(m, m_extracted)
+
+
+def test_insert_into_recovered_latent_model():
+    """Detach a deterministic before marginalizing a latent, then reinsert it onto the model
+    where that latent has been recovered as its conditional (the marginalize/conditional
+    workflow, with the recovered model built by hand).
+    """
+    # Measurement-error model: a latent log-rate (to marginalize) reported on the natural scale
+    with pm.Model() as m:
+        mu = pm.Normal("mu", 0, 1)
+        log_rate = pm.Normal("log_rate", mu, 1)
+        rate = pm.Deterministic("rate", pm.math.exp(log_rate))
+        pm.Normal("measured", log_rate, 0.5, observed=0.8)
+
+    _, deterministics = extract_deterministics(m, ["rate"])
+
+    # The conjugate conditional `conditional` produces: `mu` at its posterior and `log_rate`
+    # recovered as the posterior depending on `mu` and the measurement.
+    with pm.Model() as recovered_m:
+        mu = pm.Normal("mu", 0.356, 0.745)
+        measured = pm.Data("measured", 0.8)
+        log_rate = pm.Normal("log_rate", (mu + 4 * measured) / 5, 0.447)
+
+    recovered_m = insert_deterministics(recovered_m, deterministics)
+    assert "rate" in recovered_m.named_vars
+
+    # `rate` is wired to the recovered `log_rate`, with the correct conditional mean
+    log_rate_draws, rate_draws = pm.draw(
+        [recovered_m["log_rate"], recovered_m["rate"]], draws=4000, random_seed=1
+    )
+    np.testing.assert_allclose(rate_draws, np.exp(log_rate_draws))
+    np.testing.assert_allclose(log_rate_draws.mean(), 0.711, atol=0.05)


### PR DESCRIPTION
Also did the long-waited cleanup of making dims and variable name a __prop__ of ModelVar. This is a breaking change, at least pymc-extras will need tweaks.

This was one of my mistakes in the first iteration of the fgraph IR of model. We always need the RV name to rebuild a model, and attaching it to var.name is not reliable as PyTensor has no obligation to preserve it. Also dims as inputs make the graph larger/slower/harder to read, with no benefit since we never act symbolically on dims.

This is very useful for working with `marginal` from pymc-extras, which doesn't support when deterministics depend on the marginalized variable. This way we can extract them. And put them back on the `conditional` model afterwards (re-insertion is name-based).

Once pymc-extras is made compatible:

```python
import pymc as pm

from pymc.model.transform.deterministic import extract_deterministics, insert_deterministics
from pymc_extras.model.marginal import marginalize, conditional

with pm.Model() as model:
    mu = pm.Normal("mu", 0, 1)                          # population mean of the log-rate
    log_rate = pm.Normal("log_rate", mu, 1)             # latent log-rate, to be marginalized
    rate = pm.Deterministic("rate", pm.math.exp(log_rate))   # natural-scale rate, the reported quantity
    pm.Normal("measured", log_rate, 0.5, observed=0.8)  # noisy measurement on the log scale

# A Deterministic on the marginalized variable can't survive marginalization, so detach it first.
no_det_model, deterministics = extract_deterministics(model, ["rate"])

# Marginalize the latent and sample the marginal model.
marginal_model = marginalize(no_det_model, ["log_rate"])
idata = pm.sample(model=marginal_model)

# Recover log_rate's conditional posterior (same name) and re-attach the deterministic to it.
conditional_model = conditional(marginal_model)
conditional_model = insert_deterministics(conditional_model, deterministics)

# Posterior predictive now includes log_rate and its natural-scale deterministic `rate`.
pp = pm.sample_posterior_predictive(
    idata, model=conditional_model, var_names=["log_rate", "rate"]
)
```