### PR TITLE
Implement icdf for Bernoulli

### DIFF
--- a/pymc/distributions/discrete.py
+++ b/pymc/distributions/discrete.py
@@ -390,6 +390,20 @@ class Bernoulli(Discrete):
             msg="0 <= p <= 1",
         )
 
+    def icdf(value, p):
+        res = pt.switch(
+            pt.le(value, 1 - p),
+            0,
+            1,
+        ).astype("int64")
+        res = check_icdf_value(res, value)
+        return check_icdf_parameters(
+            res,
+            0 <= p,
+            p <= 1,
+            msg="0 <= p <= 1",
+        )
+
 
 class DiscreteWeibullRV(SymbolicRandomVariable):
     name = "discrete_weibull"

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -317,6 +317,11 @@ class TestMatchesScipy:
             Bool,
             {"p": Unit},
         )
+        check_icdf(
+            pm.Bernoulli,
+            {"p": Unit},
+            st.bernoulli.ppf,
+        )
 
     def test_bernoulli_wrong_arguments(self):
         m = pm.Model()


### PR DESCRIPTION
Adds a closed-form `icdf` for `Bernoulli`. Split out from #8339 since it needs no numerical search and is trivial to review on its own.