### PR TITLE
Fix incorrect docstring parameter names

### DIFF
--- a/pymc/step_methods/hmc/quadpotential.py
+++ b/pymc/step_methods/hmc/quadpotential.py
@@ -685,7 +685,7 @@ class QuadPotentialFull(QuadPotential):
 
         Parameters
         ----------
-        A: matrix, ndim = 2
+        cov: matrix, ndim = 2
             scaling matrix for the potential vector
         dtype :
             The dtype to assign to the resulting momentum

--- a/pymc/tuning/scaling.py
+++ b/pymc/tuning/scaling.py
@@ -32,8 +32,6 @@ def fixed_hessian(point, model=None):
     ----------
     model: Model (optional if in `with` context)
     point: dict
-    vars: list
-        Variables for which Hessian is to be calculated.
     """
     model = modelcontext(model)
     point = Point(point, model=model)


### PR DESCRIPTION
## Description

Two docstrings document parameters that do not match their signatures:

- `pymc.tuning.scaling.fixed_hessian(point, model=None)` documents a `vars` parameter that it does not take (it appears to have been copied from `find_hessian`). The stale entry is removed.
- A `QuadPotential.__init__(self, cov, ...)` in `step_methods/hmc/quadpotential.py` documents its first parameter as `A`, but the parameter is named `cov` (the body uses `cov`).

Documentation-only change; no behaviour is affected.
