### PR TITLE
Fix BaseHMC default mass matrix ignoring requested dtype (GH #8213)

### DIFF
--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -25,7 +25,6 @@ import numpy as np
 from pymc.blocking import DictToArrayBijection, PointType, RaveledVars, StatsType
 from pymc.exceptions import SamplingError
 from pymc.model import Point, modelcontext
-from pymc.pytensorf import floatX
 from pymc.stats.convergence import SamplerWarning, WarningType
 from pymc.step_methods.arraystep import GradientSharedStep
 from pymc.step_methods.compound import StepMethodState
@@ -164,9 +163,16 @@ class BaseHMC(GradientSharedStep):
         self.tune = True
 
         if scaling is None and potential is None:
-            mean = floatX(np.zeros(size))
-            var = floatX(np.ones(size))
-            potential = QuadPotentialDiagAdapt(size, mean, var, 10, rng=self.rng.spawn(1)[0])
+            # Use the same dtype as the logp/dlogp function (which honors the
+            # requested ``dtype``) rather than ``floatX`` unconditionally, so the
+            # default mass matrix always matches the integrator's expected dtype.
+            # See GH #8213.
+            dtype = self._logp_dlogp_func.dtype
+            mean = np.zeros(size, dtype=dtype)
+            var = np.ones(size, dtype=dtype)
+            potential = QuadPotentialDiagAdapt(
+                size, mean, var, 10, dtype=dtype, rng=self.rng.spawn(1)[0]
+            )
 
         if isinstance(scaling, dict):
             point = Point(scaling, model=self._model)

--- a/tests/step_methods/hmc/test_hmc.py
+++ b/tests/step_methods/hmc/test_hmc.py
@@ -16,6 +16,7 @@ import warnings
 
 import numpy as np
 import numpy.testing as npt
+import pytensor
 import pytest
 
 import pymc as pm
@@ -88,3 +89,35 @@ def test_nuts_tuning():
     ss_tuned = idata.warmup_sample_stats["step_size"][0, -1]
     ss_posterior = idata.sample_stats["step_size"][0, :]
     np.testing.assert_array_equal(ss_posterior, ss_tuned)
+
+
+def test_default_potential_honors_dtype():
+    """The default mass matrix must use the sampler's dtype, not ``floatX``.
+
+    ``BaseHMC`` forwards ``dtype`` to the logp/dlogp function but used to build
+    the default ``QuadPotentialDiagAdapt`` with ``floatX`` unconditionally. When
+    the requested ``dtype`` differed from ``pytensor.config.floatX`` the potential
+    and the logp function ended up with mismatched dtypes and
+    ``CpuLeapfrogIntegrator`` raised ``ValueError: dtypes of potential ... and
+    logp function ... don't match``. See GH #8213.
+    """
+
+    class HMC(BaseHMC):
+        def _hamiltonian_step(self, *args, **kwargs):
+            pass
+
+    # Build a float64 model, then construct the step method while the global
+    # floatX is float32. The requested dtype (float64) must win for the
+    # potential, matching the logp function, so no dtype mismatch is raised.
+    with pm.Model() as model:
+        pm.Normal("x", 0.0, 1.0)
+
+    assert all(v.dtype == "float64" for v in model.value_vars)
+
+    with pytensor.config.change_flags(floatX="float32"):
+        step = HMC(vars=model.value_vars, model=model, dtype="float64")
+
+    assert step.potential.dtype == np.dtype("float64")
+    assert step.potential._var.dtype == np.dtype("float64")
+    # The integrator's own check must agree (it raises on a mismatch on init).
+    assert step.integrator._potential.dtype == step.integrator._dtype


### PR DESCRIPTION
## Description

`BaseHMC.__init__` accepts a `dtype` argument and forwards it to the parent so the compiled logp/dlogp function is built with that dtype. However, when it constructs the *default* mass matrix it ignored that dtype and used `floatX` unconditionally:

```python
mean = floatX(np.zeros(size))
var = floatX(np.ones(size))
potential = QuadPotentialDiagAdapt(size, mean, var, 10, rng=...)
```

So whenever the requested `dtype` differs from `pytensor.config.floatX`, the potential and the logp function end up with different dtypes, and `CpuLeapfrogIntegrator.__init__` bails out:

```
ValueError: dtypes of potential (float32) and logp function (float64) don't match.
```

That traceback matches the one in #8213 exactly (the crash originates from the `QuadPotentialDiagAdapt(...)` line the reporter linked to).

The fix builds the default mass matrix using the dtype the logp/dlogp function actually resolved to (`self._logp_dlogp_func.dtype`) — which is the same value the integrator later compares against — instead of `floatX`. That keeps the two in sync in every case, including the common one where `dtype is None` (both fall back to `floatX`, so behavior is unchanged). The now-unused `floatX` import is dropped.

The `scaling`-based `quad_potential(...)` path already derives its dtype from the user-supplied array, so it isn't affected; this was the only default-construction site that hard-coded `floatX`.

## How was it tested

Added `test_default_potential_honors_dtype` in `tests/step_methods/hmc/test_hmc.py`. It builds a float64 model, then (inside `pytensor.config.change_flags(floatX="float32")`) constructs the step with `dtype="float64"` and asserts the default potential comes out `float64` and matches the integrator's expected dtype. On `main` this test fails with the `don't match` `ValueError`; with the fix it passes.

Local run:

- `pytest tests/step_methods/hmc/` → 67 passed, 6 skipped (matplotlib-optional tests run once installed).
- `ruff==0.11.13` `ruff check` and `ruff format --check` both clean on the changed files.

## Related Issue

- [x] Closes #8213

## Checklist

- [x] Checked that the pre-commit linting/style checks pass (ruff 0.11.13)
- [x] Included tests that prove the fix is effective
- [x] Added necessary documentation (inline comment explaining the dtype choice; no public API change)

## Type of change

- [x] Bug fix
