### PR TITLE
Deprecate DensityDist in favor of CustomDist

### DIFF
--- a/pymc/distributions/custom.py
+++ b/pymc/distributions/custom.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 import functools
 import re
+import warnings
 
 from collections.abc import Callable, Sequence
 
@@ -842,4 +843,27 @@ class CustomDist:
         return isinstance(out, Variable)
 
 
-DensityDist = CustomDist
+class DensityDist(CustomDist):
+    """Alias for :class:`~pymc.CustomDist`.
+
+    .. deprecated::
+        ``DensityDist`` is deprecated and will be removed in a future release.
+        Use :class:`~pymc.CustomDist` instead.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        warnings.warn(
+            "DensityDist has been deprecated, use CustomDist instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return super().__new__(cls, *args, **kwargs)
+
+    @classmethod
+    def dist(cls, *args, **kwargs):
+        warnings.warn(
+            "DensityDist has been deprecated, use CustomDist instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return super().dist(*args, **kwargs)

--- a/tests/distributions/test_custom.py
+++ b/tests/distributions/test_custom.py
@@ -169,7 +169,9 @@ class TestCustomDist:
         with Model():
             mu = Normal("mu", 0, 1)
             with pytest.warns(FutureWarning, match="DensityDist has been deprecated"):
-                DensityDist("y", mu, logp=lambda value, mu: -0.5 * (value - mu) ** 2, observed=[0.0])
+                DensityDist(
+                    "y", mu, logp=lambda value, mu: -0.5 * (value - mu) ** 2, observed=[0.0]
+                )
             with pytest.warns(FutureWarning, match="DensityDist has been deprecated"):
                 DensityDist.dist(mu, logp=lambda value, mu: -0.5 * (value - mu) ** 2)
 

--- a/tests/distributions/test_custom.py
+++ b/tests/distributions/test_custom.py
@@ -42,7 +42,7 @@ from pymc.distributions import (
     Truncated,
     Uniform,
 )
-from pymc.distributions.custom import CustomDist, CustomDistRV, CustomSymbolicDistRV
+from pymc.distributions.custom import CustomDist, CustomDistRV, CustomSymbolicDistRV, DensityDist
 from pymc.distributions.distribution import inline_symbolic_random_variable, support_point
 from pymc.distributions.shape_utils import change_dist_size, rv_size_is_none, to_tuple
 from pymc.distributions.transforms import log
@@ -164,6 +164,14 @@ class TestCustomDist:
                 TypeError, match="The DensityDist API has changed, you are using the old API"
             ):
                 CustomDist("a", lambda x: x)
+
+    def test_density_dist_deprecated(self):
+        with Model():
+            mu = Normal("mu", 0, 1)
+            with pytest.warns(FutureWarning, match="DensityDist has been deprecated"):
+                DensityDist("y", mu, logp=lambda value, mu: -0.5 * (value - mu) ** 2, observed=[0.0])
+            with pytest.warns(FutureWarning, match="DensityDist has been deprecated"):
+                DensityDist.dist(mu, logp=lambda value, mu: -0.5 * (value - mu) ** 2)
 
     @pytest.mark.parametrize("size", [None, (), (2,)], ids=str)
     def test_custom_dist_multivariate_logp(self, size):


### PR DESCRIPTION
Closes #8307

## What this PR does

`DensityDist` is currently a plain alias (`DensityDist = CustomDist`) with no
indication to users that it's deprecated in favor of `CustomDist`.

This PR turns `DensityDist` into a thin subclass of `CustomDist` that emits a
`FutureWarning` on use — both via `DensityDist(...)` and `DensityDist.dist(...)`
— while behaving identically to `CustomDist` otherwise.

Per @ricardoV94's comment on the issue:
> Yes let's start emitting now and remove in a couple months. It's just a one
> line alias

## Changes

- `pymc/distributions/custom.py`: `DensityDist` now subclasses `CustomDist`
  and warns with `FutureWarning` on both `__new__` and `.dist()`.
- `tests/distributions/test_custom.py`: added `test_density_dist_deprecated`,
  verifying the warning fires on both entry points and that `CustomDist`
  itself remains unaffected.

## Testing

Ran the full `test_custom.py` suite locally — all passing (2 pre-existing
failures in `test_serialize_custom_dist` and
`test_custom_dist_default_support_point_scan` reproduce identically on `main`
without this change, so they're unrelated environment issues, not caused by
this PR).
