### PR TITLE
Introduce `step-setup` in samplers

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1072,9 +1072,7 @@ def sample(
 
     tune = get_default_tune_steps(step, tune)
 
-    for method in flatten_steps(step):
-        if hasattr(method, "setup"):
-            method.setup(tune, draws)
+    step.setup(tune, draws)
 
     if var_names is not None:
         trace_vars = [v for v in model.unobserved_RVs if v.name in var_names]

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1542,6 +1542,7 @@ def _iter_sample(
     if draws < 1:
         raise ValueError("Argument `draws` must be greater than 0.")
 
+    # `draws` includes tuning here, but `setup_chain` expects the two separately
     step.setup_chain(rng, tune, draws - tune)
 
     point = start

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1075,7 +1075,7 @@ def sample(
     for method in flatten_steps(step):
         if hasattr(method, "setup"):
             method.setup(tune, draws)
-                
+
     if var_names is not None:
         trace_vars = [v for v in model.unobserved_RVs if v.name in var_names]
         trace_vars = model.replace_rvs_by_values(trace_vars)

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1072,6 +1072,10 @@ def sample(
 
     tune = get_default_tune_steps(step, tune)
 
+    for method in flatten_steps(step):
+        if hasattr(method, "setup"):
+            method.setup(tune, draws)
+                
     if var_names is not None:
         trace_vars = [v for v in model.unobserved_RVs if v.name in var_names]
         trace_vars = model.replace_rvs_by_values(trace_vars)

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -1072,8 +1072,6 @@ def sample(
 
     tune = get_default_tune_steps(step, tune)
 
-    step.setup(tune, draws)
-
     if var_names is not None:
         trace_vars = [v for v in model.unobserved_RVs if v.name in var_names]
         trace_vars = model.replace_rvs_by_values(trace_vars)
@@ -1544,7 +1542,7 @@ def _iter_sample(
     if draws < 1:
         raise ValueError("Argument `draws` must be greater than 0.")
 
-    step.set_rng(rng)
+    step.setup_chain(rng, tune, draws - tune)
 
     point = start
     if isinstance(trace, _ZarrChainBase):

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -248,7 +248,7 @@ class _Process:
 
     def _start_loop(self):
         zarr_recording = self._zarr_recording
-        self._step_method.set_rng(self._rng)
+        self._step_method.setup_chain(self._rng, self._tune, self._draws - self._tune)
 
         draw = 0
         tuning = True

--- a/pymc/sampling/parallel.py
+++ b/pymc/sampling/parallel.py
@@ -248,7 +248,8 @@ class _Process:
 
     def _start_loop(self):
         zarr_recording = self._zarr_recording
-        self._step_method.setup_chain(self._rng, self._tune, self._draws - self._tune)
+        # `_draws` already excludes tuning (see `draws -= tune` in `_mp_sample`)
+        self._step_method.setup_chain(self._rng, self._tune, self._draws)
 
         draw = 0
         tuning = True

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -396,7 +396,7 @@ def _prepare_iter_population(
             chainstep = CompoundStep([copy(m) for m in step.methods])
         else:
             chainstep = copy(step)
-        chainstep.set_rng(rng)
+        chainstep.setup_chain(rng, tune, draws - tune)
         # link population samplers to the shared population state
         for sm in chainstep.methods if isinstance(step, CompoundStep) else [chainstep]:
             if isinstance(sm, PopulationArrayStepShared):

--- a/pymc/sampling/population.py
+++ b/pymc/sampling/population.py
@@ -396,6 +396,7 @@ def _prepare_iter_population(
             chainstep = CompoundStep([copy(m) for m in step.methods])
         else:
             chainstep = copy(step)
+        # `draws` includes tuning here, but `setup_chain` expects the two separately
         chainstep.setup_chain(rng, tune, draws - tune)
         # link population samplers to the shared population state
         for sm in chainstep.methods if isinstance(step, CompoundStep) else [chainstep]:

--- a/pymc/step_methods/compound.py
+++ b/pymc/step_methods/compound.py
@@ -236,6 +236,7 @@ class BlockedStep(ABC, WithSamplingState):
     def setup(self, tune: int, draws: int) -> None:
         pass
 
+
 def flat_statname(sampler_idx: int, sname: str) -> str:
     """Get the flat-stats name for a samplers stat."""
     return f"sampler_{sampler_idx}__{sname}"
@@ -302,7 +303,7 @@ class CompoundStep(WithSamplingState):
     def setup(self, tune: int, draws: int) -> None:
         for method in self.methods:
             method.setup(tune, draws)
-    
+
     @property
     def sampling_state(self) -> DataClassState:
         return CompoundStepState(methods=[method.sampling_state for method in self.methods])

--- a/pymc/step_methods/compound.py
+++ b/pymc/step_methods/compound.py
@@ -230,11 +230,12 @@ class BlockedStep(ABC, WithSamplingState):
         if hasattr(self, "tune"):
             self.tune = False
 
-    def set_rng(self, rng: RandomGenerator):
+    def setup_chain(self, rng: RandomGenerator, tune: int, draws: int) -> None:
+        """Prepare the step method for sampling one chain.
+        Called once per chain, right before that chain starts sampling.
+        Can be called multiple times, meaning downstream method 
+        should handle multiple, possibly repeated calls."""
         self.rng = get_random_generator(rng, copy=False)
-
-    def setup(self, tune: int, draws: int) -> None:
-        pass
 
 
 def flat_statname(sampler_idx: int, sname: str) -> str:
@@ -300,9 +301,10 @@ class CompoundStep(WithSamplingState):
             if hasattr(method, "reset_tuning"):
                 method.reset_tuning()
 
-    def setup(self, tune: int, draws: int) -> None:
-        for method in self.methods:
-            method.setup(tune, draws)
+    def setup_chain(self, rng: RandomGenerator, tune: int, draws: int) -> None:
+        _rngs = get_random_generator(rng, copy=False).spawn(len(self.methods))
+        for method, _rng in zip(self.methods, _rngs):
+            method.setup_chain(_rng, tune, draws)
 
     @property
     def sampling_state(self) -> DataClassState:
@@ -319,11 +321,6 @@ class CompoundStep(WithSamplingState):
     @property
     def vars(self) -> list[Variable]:
         return [var for method in self.methods for var in method.vars]
-
-    def set_rng(self, rng: RandomGenerator):
-        _rngs = get_random_generator(rng, copy=False).spawn(len(self.methods))
-        for method, _rng in zip(self.methods, _rngs):
-            method.set_rng(_rng)
 
     def _progressbar_config(self, n_chains=1):
         from functools import reduce

--- a/pymc/step_methods/compound.py
+++ b/pymc/step_methods/compound.py
@@ -232,9 +232,11 @@ class BlockedStep(ABC, WithSamplingState):
 
     def setup_chain(self, rng: RandomGenerator, tune: int, draws: int) -> None:
         """Prepare the step method for sampling one chain.
+
         Called once per chain, right before that chain starts sampling.
-        Can be called multiple times, meaning downstream method 
-        should handle multiple, possibly repeated calls."""
+        Can be called multiple times, meaning downstream method
+        should handle multiple, possibly repeated calls.
+        """
         self.rng = get_random_generator(rng, copy=False)
 
 

--- a/pymc/step_methods/compound.py
+++ b/pymc/step_methods/compound.py
@@ -233,6 +233,8 @@ class BlockedStep(ABC, WithSamplingState):
     def set_rng(self, rng: RandomGenerator):
         self.rng = get_random_generator(rng, copy=False)
 
+    def setup(self, tune: int, draws: int) -> None:
+        pass
 
 def flat_statname(sampler_idx: int, sname: str) -> str:
     """Get the flat-stats name for a samplers stat."""
@@ -297,6 +299,10 @@ class CompoundStep(WithSamplingState):
             if hasattr(method, "reset_tuning"):
                 method.reset_tuning()
 
+    def setup(self, tune: int, draws: int) -> None:
+        for method in self.methods:
+            method.setup(tune, draws)
+    
     @property
     def sampling_state(self) -> DataClassState:
         return CompoundStepState(methods=[method.sampling_state for method in self.methods])

--- a/pymc/step_methods/compound.py
+++ b/pymc/step_methods/compound.py
@@ -234,8 +234,18 @@ class BlockedStep(ABC, WithSamplingState):
         """Prepare the step method for sampling one chain.
 
         Called once per chain, right before that chain starts sampling.
-        Can be called multiple times, meaning downstream method
-        should handle multiple, possibly repeated calls.
+        The same instance may be reused across chains, so implementations
+        must reset any per-chain state instead of accumulating it.
+
+        Parameters
+        ----------
+        rng : RandomGenerator
+            Random generator for this chain.
+        tune : int
+            Number of tuning iterations. Zero if the chain does not tune.
+        draws : int
+            Number of iterations after tuning. The chain runs ``tune + draws``
+            iterations in total.
         """
         self.rng = get_random_generator(rng, copy=False)
 
@@ -304,9 +314,10 @@ class CompoundStep(WithSamplingState):
                 method.reset_tuning()
 
     def setup_chain(self, rng: RandomGenerator, tune: int, draws: int) -> None:
-        _rngs = get_random_generator(rng, copy=False).spawn(len(self.methods))
-        for method, _rng in zip(self.methods, _rngs):
-            method.setup_chain(_rng, tune, draws)
+        """Set up each wrapped step method with its own spawned random generator."""
+        rngs = get_random_generator(rng, copy=False).spawn(len(self.methods))
+        for method, method_rng in zip(self.methods, rngs):
+            method.setup_chain(method_rng, tune, draws)
 
     @property
     def sampling_state(self) -> DataClassState:

--- a/pymc/step_methods/hmc/base_hmc.py
+++ b/pymc/step_methods/hmc/base_hmc.py
@@ -39,7 +39,7 @@ from pymc.step_methods.hmc.quadpotential import (
 from pymc.step_methods.state import dataclass_state
 from pymc.step_methods.step_sizes import DualAverageAdaptation, StepSizeState
 from pymc.tuning import guess_scaling
-from pymc.util import RandomGenerator, get_random_generator, get_value_vars_from_user_vars
+from pymc.util import RandomGenerator, get_value_vars_from_user_vars
 
 logger = logging.getLogger(__name__)
 
@@ -297,6 +297,6 @@ class BaseHMC(GradientSharedStep):
         self.tune = True
         self.potential.reset()
 
-    def set_rng(self, rng: RandomGenerator):
-        self.rng = get_random_generator(rng, copy=False)
+    def setup_chain(self, rng: RandomGenerator, tune: int, draws: int) -> None:
+        super().setup_chain(rng, tune, draws)
         self.potential.set_rng(self.rng.spawn(1)[0])

--- a/tests/sampling/test_mcmc.py
+++ b/tests/sampling/test_mcmc.py
@@ -41,6 +41,7 @@ from pymc.step_methods import (
     BinaryGibbsMetropolis,
     CategoricalGibbsMetropolis,
     CompoundStep,
+    DEMetropolis,
     HamiltonianMC,
     Metropolis,
     Slice,
@@ -341,6 +342,66 @@ class ApocalypticMetropolis(pm.Metropolis):
             "warn",
         )
         return draw, stats
+
+
+_SETUP_CHAIN_STATS = {
+    "setup_tune": (np.int64, []),
+    "setup_draws": (np.int64, []),
+}
+
+
+class SetupChainReporter:
+    """Mixin reporting the ``tune`` and ``draws`` passed to `setup_chain` as sampler stats.
+
+    Stats are used because they are the only channel that survives the round-trip
+    back from the worker processes of the multiprocess sampler.
+    """
+
+    def setup_chain(self, rng, tune, draws):
+        super().setup_chain(rng, tune, draws)
+        self._setup_tune = tune
+        self._setup_draws = draws
+
+    def astep(self, q0):
+        draw, stats = super().astep(q0)
+        stats[0]["setup_tune"] = self._setup_tune
+        stats[0]["setup_draws"] = self._setup_draws
+        return draw, stats
+
+
+class SetupChainMetropolis(SetupChainReporter, Metropolis):
+    stats_dtypes_shapes = {**Metropolis.stats_dtypes_shapes, **_SETUP_CHAIN_STATS}
+
+
+class SetupChainDEMetropolis(SetupChainReporter, DEMetropolis):
+    stats_dtypes_shapes = {**DEMetropolis.stats_dtypes_shapes, **_SETUP_CHAIN_STATS}
+
+
+@pytest.mark.parametrize(
+    "step_cls, chains, cores",
+    [
+        (SetupChainMetropolis, 1, 1),
+        (SetupChainMetropolis, 2, 2),
+        (SetupChainDEMetropolis, 4, 1),
+    ],
+    ids=["sequential", "multiprocess", "population"],
+)
+def test_setup_chain_receives_draw_counts(step_cls, chains, cores):
+    """Each sampling path must report `tune` and `draws` separately, not double-subtract."""
+    with pm.Model():
+        pm.Normal("x")
+        idata = pm.sample(
+            draws=7,
+            tune=3,
+            chains=chains,
+            cores=cores,
+            step=step_cls(),
+            progressbar=False,
+            compute_convergence_checks=False,
+        )
+
+    assert (idata.sample_stats["setup_tune"] == 3).all()
+    assert (idata.sample_stats["setup_draws"] == 7).all()
 
 
 class TestSampleReturn:


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

I added a function to ```pm.sample(...)``` that passes the number of draws to the step methods if they have the ```setup``` attribute. With this setup method, we can pre-allocate a vector to store ```TreeBatch``` for each sampling draw in ```bartrs```. 

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
