### PR TITLE
Implement icdf for TruncatedNormal distribution

### DIFF
--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -786,16 +786,19 @@ class TruncatedNormal(BoundedContinuous):
         # for numerical stability, along with its complement 1 - p
         log_p = pt.log(value) + log_norm
         log_1mp = pt.log1p(-value) + log_norm
+        # a + softplus(b - a) is logaddexp(a, b), written so that graph rewrites
+        # cannot fold exp(a) to zero when a is a very negative constant
         if is_lower_bounded:
-            log_p = pt.logaddexp(normal_lcdf(mu, sigma, lower), log_p)
+            lower_lcdf = normal_lcdf(mu, sigma, lower)
+            log_p = lower_lcdf + pt.softplus(log_p - lower_lcdf)
         if is_upper_bounded:
-            log_1mp = pt.logaddexp(normal_lccdf(mu, sigma, upper), log_1mp)
+            upper_lccdf = normal_lccdf(mu, sigma, upper)
+            log_1mp = upper_lccdf + pt.softplus(log_1mp - upper_lccdf)
 
-        # Use the more accurate erfcinv branch for each tail
         res = pt.switch(
             log_p <= np.log(0.5),
-            mu - sigma * np.sqrt(2.0) * pt.erfcinv(2 * pt.exp(log_p)),
-            mu + sigma * np.sqrt(2.0) * pt.erfcinv(2 * pt.exp(log_1mp)),
+            mu + sigma * pt.ndtri_exp(log_p),
+            mu - sigma * pt.ndtri_exp(log_1mp),
         )
         res = check_icdf_value(res, value)
 

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -767,6 +767,32 @@ class TruncatedNormal(BoundedContinuous):
 
         return logcdf
 
+    def icdf(value, mu, sigma, lower, upper):
+        is_lower_bounded = not (
+            isinstance(lower, TensorConstant) and np.all(np.isneginf(lower.value))
+        )
+        is_upper_bounded = not (isinstance(upper, TensorConstant) and np.all(np.isinf(upper.value)))
+
+        cdf_lower = pt.exp(normal_lcdf(mu, sigma, lower)) if is_lower_bounded else 0.0
+        cdf_upper = pt.exp(normal_lcdf(mu, sigma, upper)) if is_upper_bounded else 1.0
+
+        p = cdf_lower + value * (cdf_upper - cdf_lower)
+        res = mu - sigma * np.sqrt(2.0) * pt.erfcinv(2 * p)
+        res = check_icdf_value(res, value)
+
+        if is_lower_bounded and is_upper_bounded:
+            res = check_icdf_parameters(
+                res,
+                pt.le(lower, upper),
+                msg="lower_bound <= upper_bound",
+            )
+
+        return check_icdf_parameters(
+            res,
+            sigma > 0,
+            msg="sigma > 0",
+        )
+
 
 @_default_transform.register(TruncatedNormal)
 def truncated_normal_default_transform(op, rv):

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -586,6 +586,13 @@ class TruncatedNormalRV(RandomVariable):
 truncated_normal = TruncatedNormalRV()
 
 
+def _truncation_is_bounded(lower, upper):
+    """Whether each truncation bound is finite, when this can be known statically."""
+    is_lower_bounded = not (isinstance(lower, TensorConstant) and np.all(np.isneginf(lower.value)))
+    is_upper_bounded = not (isinstance(upper, TensorConstant) and np.all(np.isinf(upper.value)))
+    return is_lower_bounded, is_upper_bounded
+
+
 class TruncatedNormal(BoundedContinuous):
     r"""
     Univariate truncated normal distribution.
@@ -711,10 +718,7 @@ class TruncatedNormal(BoundedContinuous):
         return support_point
 
     def logp(value, mu, sigma, lower, upper):
-        is_lower_bounded = not (
-            isinstance(lower, TensorConstant) and np.all(np.isneginf(lower.value))
-        )
-        is_upper_bounded = not (isinstance(upper, TensorConstant) and np.all(np.isinf(upper.value)))
+        is_lower_bounded, is_upper_bounded = _truncation_is_bounded(lower, upper)
 
         if is_lower_bounded and is_upper_bounded:
             norm = log_diff_normal_cdf(mu, sigma, upper, lower)
@@ -747,10 +751,7 @@ class TruncatedNormal(BoundedContinuous):
             mu, sigma, upper, lower
         )
 
-        is_lower_bounded = not (
-            isinstance(lower, TensorConstant) and np.all(np.isneginf(lower.value))
-        )
-        is_upper_bounded = not (isinstance(upper, TensorConstant) and np.all(np.isinf(upper.value)))
+        is_lower_bounded, is_upper_bounded = _truncation_is_bounded(lower, upper)
 
         if is_lower_bounded:
             logcdf = pt.switch(value < lower, -np.inf, logcdf)
@@ -768,10 +769,7 @@ class TruncatedNormal(BoundedContinuous):
         return logcdf
 
     def icdf(value, mu, sigma, lower, upper):
-        is_lower_bounded = not (
-            isinstance(lower, TensorConstant) and np.all(np.isneginf(lower.value))
-        )
-        is_upper_bounded = not (isinstance(upper, TensorConstant) and np.all(np.isinf(upper.value)))
+        is_lower_bounded, is_upper_bounded = _truncation_is_bounded(lower, upper)
 
         if is_lower_bounded and is_upper_bounded:
             log_norm = log_diff_normal_cdf(mu, sigma, upper, lower)
@@ -786,8 +784,8 @@ class TruncatedNormal(BoundedContinuous):
         # for numerical stability, along with its complement 1 - p
         log_p = pt.log(value) + log_norm
         log_1mp = pt.log1p(-value) + log_norm
-        # a + softplus(b - a) is logaddexp(a, b), written so that graph rewrites
-        # cannot fold exp(a) to zero when a is a very negative constant
+        # Stable logaddexp(a, b). pt.logaddexp is not usable here: with constant
+        # bounds, exp(a) folds to zero before local_log_add_exp can stabilize it.
         if is_lower_bounded:
             lower_lcdf = normal_lcdf(mu, sigma, lower)
             log_p = lower_lcdf + pt.softplus(log_p - lower_lcdf)

--- a/pymc/distributions/continuous.py
+++ b/pymc/distributions/continuous.py
@@ -773,11 +773,30 @@ class TruncatedNormal(BoundedContinuous):
         )
         is_upper_bounded = not (isinstance(upper, TensorConstant) and np.all(np.isinf(upper.value)))
 
-        cdf_lower = pt.exp(normal_lcdf(mu, sigma, lower)) if is_lower_bounded else 0.0
-        cdf_upper = pt.exp(normal_lcdf(mu, sigma, upper)) if is_upper_bounded else 1.0
+        if is_lower_bounded and is_upper_bounded:
+            log_norm = log_diff_normal_cdf(mu, sigma, upper, lower)
+        elif is_lower_bounded:
+            log_norm = normal_lccdf(mu, sigma, lower)
+        elif is_upper_bounded:
+            log_norm = normal_lcdf(mu, sigma, upper)
+        else:
+            log_norm = 0.0
 
-        p = cdf_lower + value * (cdf_upper - cdf_lower)
-        res = mu - sigma * np.sqrt(2.0) * pt.erfcinv(2 * p)
+        # p = cdf(lower) + value * (cdf(upper) - cdf(lower)), computed in logspace
+        # for numerical stability, along with its complement 1 - p
+        log_p = pt.log(value) + log_norm
+        log_1mp = pt.log1p(-value) + log_norm
+        if is_lower_bounded:
+            log_p = pt.logaddexp(normal_lcdf(mu, sigma, lower), log_p)
+        if is_upper_bounded:
+            log_1mp = pt.logaddexp(normal_lccdf(mu, sigma, upper), log_1mp)
+
+        # Use the more accurate erfcinv branch for each tail
+        res = pt.switch(
+            log_p <= np.log(0.5),
+            mu - sigma * np.sqrt(2.0) * pt.erfcinv(2 * pt.exp(log_p)),
+            mu + sigma * np.sqrt(2.0) * pt.erfcinv(2 * pt.exp(log_1mp)),
+        )
         res = check_icdf_value(res, value)
 
         if is_lower_bounded and is_upper_bounded:

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -1067,6 +1067,35 @@ class TestMatchesScipy:
             skip_paramdomain_outside_edge_test=True,
         )
 
+        def scipy_icdf(q, mu, sigma, lower, upper):
+            return st.truncnorm.ppf(
+                q, (lower - mu) / sigma, (upper - mu) / sigma, loc=mu, scale=sigma
+            )
+
+        check_icdf(
+            pm.TruncatedNormal,
+            {"mu": R, "sigma": Rplusbig, "lower": -Rplusbig, "upper": Rplusbig},
+            scipy_icdf,
+            decimal=select_by_precision(float64=6, float32=1),
+            skip_paramdomain_outside_edge_test=True,
+        )
+
+        check_icdf(
+            pm.TruncatedNormal,
+            {"mu": R, "sigma": Rplusbig, "upper": Rplusbig},
+            ft.partial(scipy_icdf, lower=-np.inf),
+            decimal=select_by_precision(float64=6, float32=1),
+            skip_paramdomain_outside_edge_test=True,
+        )
+
+        check_icdf(
+            pm.TruncatedNormal,
+            {"mu": R, "sigma": Rplusbig, "lower": -Rplusbig},
+            ft.partial(scipy_icdf, upper=np.inf),
+            decimal=select_by_precision(float64=6, float32=1),
+            skip_paramdomain_outside_edge_test=True,
+        )
+
         # This is a regression test for #6128: Check that having one out-of-bound value
         # in an input array does not set all logp values to -inf
         dist = pm.TruncatedNormal.dist(mu=1, sigma=2, lower=0, upper=3)

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -1080,22 +1080,6 @@ class TestMatchesScipy:
             skip_paramdomain_outside_edge_test=True,
         )
 
-        check_icdf(
-            pm.TruncatedNormal,
-            {"mu": R, "sigma": Rplusbig, "upper": Rplusbig},
-            ft.partial(scipy_icdf, lower=-np.inf),
-            decimal=select_by_precision(float64=6, float32=1),
-            skip_paramdomain_outside_edge_test=True,
-        )
-
-        check_icdf(
-            pm.TruncatedNormal,
-            {"mu": R, "sigma": Rplusbig, "lower": -Rplusbig},
-            ft.partial(scipy_icdf, upper=np.inf),
-            decimal=select_by_precision(float64=6, float32=1),
-            skip_paramdomain_outside_edge_test=True,
-        )
-
         # This is a regression test for #6128: Check that having one out-of-bound value
         # in an input array does not set all logp values to -inf
         dist = pm.TruncatedNormal.dist(mu=1, sigma=2, lower=0, upper=3)

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -1080,6 +1080,17 @@ class TestMatchesScipy:
             skip_paramdomain_outside_edge_test=True,
         )
 
+        # Far-tail truncation, where exp(logcdf) underflows
+        if pytensor.config.floatX == "float64":
+            q = np.array([1e-12, 0.3, 0.9, 1 - 1e-12])
+            for lower, upper in [(39, np.inf), (39, 42), (100, np.inf)]:
+                dist = pm.TruncatedNormal.dist(mu=0, sigma=1, lower=lower, upper=upper)
+                npt.assert_allclose(
+                    icdf(dist, q).eval(),
+                    scipy_icdf(q, 0, 1, lower, upper),
+                    rtol=1e-6,
+                )
+
         # This is a regression test for #6128: Check that having one out-of-bound value
         # in an input array does not set all logp values to -inf
         dist = pm.TruncatedNormal.dist(mu=1, sigma=2, lower=0, upper=3)


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-devs/pymc/releases -->

## Description
<!--- Describe your changes in detail -->

Adds an `icdf` method to `TruncatedNormal`, which was missing one (only `logp`/`logcdf`/`logccdf` were implemented, so `pm.icdf` raised `NotImplementedError`)

The implementation uses the closed form inverse of the truncated normal CDF. The requested quantile q is rescaled from [0, 1] onto the portion of the normal CDF that lies between lower and upper, then applying the standard normal quantile function (same erfcinv formulation as Normal.icdf). Infinite bounds are handled the same way as in the existing logp/logcdf methods.

Tests use `check_icdf` against `scipy.stats.truncnorm.ppf` for the two-sided, lower-only, and upper-only bounded cases. 

I noticed this would let `pm.Truncated`wrapped normals to use inverse-CDF sampling instead of the rejection-sampling fallback.

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [x] Related to #6612 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [x] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->
