### PR TITLE
Refactor existing samplers behind a shared Sampler interface

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -313,6 +313,7 @@ jobs:
             tests/distributions/test_random_alternative_backends.py
             tests/sampling/test_jax.py
             tests/sampling/test_mcmc_external.py
+            tests/sampling/test_samplers.py
 
       fail-fast: false
     runs-on: ubuntu-latest

--- a/pymc/__init__.py
+++ b/pymc/__init__.py
@@ -58,6 +58,7 @@ from pymc.model.transform.conditioning import do, observe
 from pymc.model_graph import model_to_graphviz, model_to_mermaid, model_to_networkx
 from pymc.pytensorf import compile
 from pymc.sampling import *
+from pymc.sampling.samplers import blackjax, numpyro, nutpie
 from pymc.smc import *
 from pymc.stats.log_density import compute_log_likelihood
 from pymc.step_methods import *

--- a/pymc/sampling/__init__.py
+++ b/pymc/sampling/__init__.py
@@ -23,8 +23,12 @@ from pymc.sampling.forward import (
     vectorize_over_posterior,
 )
 from pymc.sampling.mcmc import init_nuts, sample
+from pymc.sampling.samplers import ExternalSampler, Sampler, StepSampler
 
 __all__ = (
+    "ExternalSampler",
+    "Sampler",
+    "StepSampler",
     "compile_forward_sampling_function",
     "compute_deterministics",
     "draw",

--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -92,6 +92,10 @@ from pymc.vartypes import discrete_types
 if TYPE_CHECKING:
     from pymc.backends.zarr import ZarrChain, ZarrTrace
 
+    # Annotation-only: importing `Sampler` at runtime would cycle back through
+    # `pymc.sampling.samplers`, whose modules import this one.
+    from pymc.sampling.samplers.base import Sampler
+
 NUTPIE_INSTALLED = importlib.util.find_spec("nutpie") is not None
 NUTPIE_MIN_VERSION = (0, 16, 10)
 
@@ -395,22 +399,6 @@ def _sample_external_nuts(
     compile_kwargs = compile_kwargs.copy()
     idata_kwargs = {} if idata_kwargs is None else idata_kwargs.copy()
 
-    if "backend" in nuts_kwargs:
-        warnings.warn(
-            "`backend` should be passed as a top-level argument to `pm.sample`, "
-            "not nested in the NUTS step kwargs.",
-            FutureWarning,
-        )
-        compile_kwargs["mode"] = get_mode(nuts_kwargs.pop("backend"))
-
-    if "gradient_backend" in nuts_kwargs:
-        warnings.warn(
-            "`gradient_backend` should be passed via `compile_kwargs` to `pm.sample`, "
-            "not nested in the NUTS step kwargs.",
-            FutureWarning,
-        )
-        compile_kwargs["gradient_backend"] = nuts_kwargs.pop("gradient_backend")
-
     if not quiet:
         _log.info(f"NUTS[{sampler}]: {model.free_RVs}")
 
@@ -550,6 +538,64 @@ def _sample_external_nuts(
         )
 
 
+def _reject_arguments_incompatible_with_sampler(
+    *,
+    step,
+    nuts_sampler,
+    return_inferencedata,
+    trace,
+    callback,
+    mp_ctx,
+    progressbar_theme,
+    init,
+    n_init,
+    jitter_max_retries,
+    backend,
+    compile_kwargs,
+    kwargs,
+):
+    """Reject `pm.sample` arguments that a `sampler=` cannot receive.
+
+    `pm.sample(sampler=...)` forwards only the shared run configuration.
+    Anything a sampler owns -- its algorithm parameters, initialization
+    strategy, trace backend, callbacks, multiprocessing context and how the
+    model is compiled -- belongs to the sampler's constructor, and is
+    rejected here rather than forwarded for reinterpretation.
+    """
+    if step is not None:
+        raise ValueError("`step` and `sampler` cannot be used together.")
+    if nuts_sampler is not None:
+        raise ValueError("`nuts_sampler` and `sampler` cannot be used together.")
+    if not return_inferencedata:
+        raise ValueError("`return_inferencedata=False` is not supported with `sampler`.")
+    if trace is not None:
+        raise ValueError("A custom `trace` backend is not supported with `sampler`.")
+    if callback is not None:
+        raise ValueError("`callback` is not supported with `sampler`.")
+
+    constructor_arguments = {
+        "mp_ctx": mp_ctx is not None,
+        "progressbar_theme": progressbar_theme is not None,
+        "backend": backend is not None,
+        "compile_kwargs": compile_kwargs is not None,
+        "init": init != "auto",
+        "n_init": n_init != 200_000,
+        "jitter_max_retries": jitter_max_retries != 10,
+    }
+    for name, was_given in constructor_arguments.items():
+        if was_given:
+            raise ValueError(
+                f"`{name}` is not supported with `sampler`. Configure it when constructing "
+                f"the sampler instead, e.g. `pm.StepSampler({name}=...)`."
+            )
+    if kwargs:
+        raise TypeError(
+            f"Arguments {sorted(kwargs)} are not supported together with `sampler`. "
+            "Configure the sampler when constructing it instead, e.g. "
+            "`pm.nutpie.nuts(target_accept=0.9)`."
+        )
+
+
 @overload
 def sample(
     draws: int = 1000,
@@ -564,6 +610,7 @@ def sample(
     step=None,
     var_names: Sequence[str] | None = None,
     nuts_sampler: Literal["pymc", "nutpie", "numpyro", "blackjax"] | None = None,
+    sampler: Sampler | None = None,
     initvals: StartDict | Sequence[StartDict | None] | None = None,
     init: str = "auto",
     jitter_max_retries: int = 10,
@@ -574,7 +621,6 @@ def sample(
     keep_warning_stat: bool = False,
     return_inferencedata: Literal[True] = True,
     idata_kwargs: dict[str, Any] | None = None,
-    nuts_sampler_kwargs: dict[str, Any] | None = None,
     callback=None,
     mp_ctx=None,
     blas_cores: int | None | Literal["auto"] = "auto",
@@ -597,6 +643,7 @@ def sample(
     step=None,
     var_names: Sequence[str] | None = None,
     nuts_sampler: Literal["pymc", "nutpie", "numpyro", "blackjax"] | None = None,
+    sampler: Sampler | None = None,
     initvals: StartDict | Sequence[StartDict | None] | None = None,
     init: str = "auto",
     jitter_max_retries: int = 10,
@@ -607,7 +654,6 @@ def sample(
     keep_warning_stat: bool = False,
     return_inferencedata: Literal[False],
     idata_kwargs: dict[str, Any] | None = None,
-    nuts_sampler_kwargs: dict[str, Any] | None = None,
     callback=None,
     mp_ctx=None,
     model: Model | None = None,
@@ -630,6 +676,7 @@ def sample(
     step=None,
     var_names: Sequence[str] | None = None,
     nuts_sampler: Literal["pymc", "nutpie", "numpyro", "blackjax"] | None = None,
+    sampler: Sampler | None = None,
     initvals: StartDict | Sequence[StartDict | None] | None = None,
     init: str = "auto",
     jitter_max_retries: int = 10,
@@ -640,7 +687,6 @@ def sample(
     keep_warning_stat: bool = False,
     return_inferencedata: bool = True,
     idata_kwargs: dict[str, Any] | None = None,
-    nuts_sampler_kwargs: dict[str, Any] | None = None,
     callback=None,
     mp_ctx=None,
     blas_cores: int | None | Literal["auto"] = "auto",
@@ -704,6 +750,24 @@ def sample(
         This requires the chosen sampler to be installed.
         All samplers, except "pymc", require the full model to be continuous.
         If ``None`` (default), "nutpie" is used if installed and can be compiled to the desired backend.
+
+        .. deprecated:: 6.2
+            Use ``sampler`` instead, e.g. ``pm.sample(sampler=pm.nutpie.nuts())``.
+    sampler : Sampler, optional
+        A configured sampler instance that samples the whole model, e.g.
+        ``pm.nutpie.nuts()``, ``pm.numpyro.nuts()``, ``pm.blackjax.nuts()`` or
+        ``pm.StepSampler(step=pm.Metropolis())``. The constructor takes the
+        algorithm configuration; ``pm.sample`` contributes only the shared run
+        configuration, which it forwards to the sampler's ``sample_from_init``
+        method. Arguments a sampler owns are rejected rather than forwarded:
+        ``step``, ``nuts_sampler``, ``init``, ``n_init``,
+        ``jitter_max_retries``, ``trace``, ``callback``, ``mp_ctx``,
+        ``backend``, ``compile_kwargs``, ``progressbar_theme``, step keyword
+        arguments and ``return_inferencedata=False``. Compilation in
+        particular is algorithm configuration, so it belongs to the
+        constructor, e.g. ``pm.nutpie.nuts(backend="jax")``. Equivalent to the
+        sampler's flat entry point (e.g. ``pm.nutpie.nuts.sample(...)``),
+        which combines algorithm and run arguments in a single call.
     blas_cores: int or "auto" or None, default = "auto"
         The total number of threads blas and openmp functions should use during sampling.
         Setting it to "auto" will ensure that the total number of active blas threads is the
@@ -751,9 +815,6 @@ def sample(
         `MultiTrace` (False). Defaults to `True`.
     idata_kwargs : dict, optional
         Keyword arguments for :func:`pymc.to_inference_data`
-    nuts_sampler_kwargs : dict, optional
-        Deprecated. Pass NUTS keyword arguments via ``nuts={...}`` instead
-        (e.g. ``pm.sample(..., nuts={"target_accept": 0.9})``).
     callback : function, default=None
         A function which gets called for every sample from the trace of a chain. The function is
         called with the trace and the current draw and will contain all samples for a single trace.
@@ -840,6 +901,25 @@ def sample(
             mean     sd  hdi_3%  hdi_97%
         p  0.609  0.047   0.528    0.699
     """
+    if sampler is not None:
+        # Checked before any argument rewriting below, so the error names the
+        # argument the caller actually passed.
+        _reject_arguments_incompatible_with_sampler(
+            step=step,
+            nuts_sampler=nuts_sampler,
+            return_inferencedata=return_inferencedata,
+            trace=trace,
+            callback=callback,
+            mp_ctx=mp_ctx,
+            progressbar_theme=progressbar_theme,
+            init=init,
+            n_init=n_init,
+            jitter_max_retries=jitter_max_retries,
+            backend=backend,
+            compile_kwargs=compile_kwargs,
+            kwargs=kwargs,
+        )
+
     if return_inferencedata is False:
         warnings.warn(
             "`return_inferencedata=False` is deprecated and will be removed in a future "
@@ -848,18 +928,6 @@ def sample(
             FutureWarning,
             stacklevel=2,
         )
-    if nuts_sampler_kwargs is not None:
-        warnings.warn(
-            "`nuts_sampler_kwargs` is deprecated. Pass NUTS keyword arguments via the "
-            "`nuts={...}` argument to `pm.sample`.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        if "nuts" in kwargs:
-            raise ValueError(
-                "Cannot pass both `nuts_sampler_kwargs` and `nuts=`. Use `nuts=` only."
-            )
-        kwargs["nuts"] = nuts_sampler_kwargs
     if "target_accept" in kwargs:
         if "nuts" in kwargs and "target_accept" in kwargs["nuts"]:
             raise ValueError(
@@ -892,6 +960,30 @@ def sample(
     if chains is None:
         chains = max(2, cores)
 
+    if sampler is not None:
+        # `pm.sample(sampler=...)` is sugar over the sampler's own
+        # `sample_from_init`: it contributes only the shared run-level
+        # configuration. How the model is compiled and how workers are spawned
+        # are the sampler's own, so the multiprocessing context and the BLAS
+        # limiter are set up inside `sample_from_init`, not here.
+        return sampler.sample_from_init(
+            model=model,
+            draws=draws,
+            tune=tune,
+            chains=chains,
+            cores=cores,
+            blas_cores=blas_cores,
+            initvals=initvals,
+            random_seed=random_seed,
+            progressbar=progressbar,
+            quiet=quiet,
+            discard_tuned_samples=discard_tuned_samples,
+            keep_warning_stat=keep_warning_stat,
+            var_names=var_names,
+            idata_kwargs=idata_kwargs,
+            compute_convergence_checks=compute_convergence_checks,
+        )
+
     compile_kwargs = resolve_backend_compile_kwargs(backend, compile_kwargs)
     mp_ctx = _initialize_multiprocessing_context(
         mp_ctx, mode=compile_kwargs.get("mode"), quiet=quiet
@@ -906,6 +998,26 @@ def sample(
         )
     rngs = get_random_generator(random_seed).spawn(chains)
     random_seed_list = [rng.integers(2**30) for rng in rngs]
+
+    if nuts_sampler is not None:
+        warnings.warn(
+            "The `nuts_sampler` argument is deprecated. Use the `sampler` argument "
+            "instead, e.g. `pm.sample(sampler=pm.nutpie.nuts())`, "
+            "`pm.sample(sampler=pm.numpyro.nuts())`, "
+            "`pm.sample(sampler=pm.blackjax.nuts())` or "
+            "`pm.sample(sampler=pm.StepSampler())`, or the flat entry points "
+            "such as `pm.nutpie.nuts.sample(...)`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    if init != "auto" or n_init != 200_000 or jitter_max_retries != 10:
+        warnings.warn(
+            "The NUTS-specific `init`, `n_init` and `jitter_max_retries` arguments of "
+            "`pm.sample` are deprecated and will move to the sampler configuration. "
+            'Use `pm.sample(sampler=pm.StepSampler(init="jitter+adapt_diag", ...))` instead.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     if (
         not discard_tuned_samples
@@ -1028,11 +1140,100 @@ def sample(
                 **kwargs,
             )
 
+    return _sample_with_step_methods(
+        model=model,
+        step=step,
+        step_kwargs=kwargs,
+        init=init,
+        n_init=n_init,
+        jitter_max_retries=jitter_max_retries,
+        trace=trace,
+        callback=callback,
+        progressbar_theme=progressbar_theme,
+        return_inferencedata=return_inferencedata,
+        draws=draws,
+        tune=tune,
+        chains=chains,
+        cores=cores,
+        rngs=rngs,
+        random_seed_list=random_seed_list,
+        initvals=initvals,
+        progressbar=progressbar,
+        quiet=quiet,
+        discard_tuned_samples=discard_tuned_samples,
+        keep_warning_stat=keep_warning_stat,
+        var_names=var_names,
+        idata_kwargs=idata_kwargs,
+        compute_convergence_checks=compute_convergence_checks,
+        compile_kwargs=compile_kwargs,
+        mp_ctx=mp_ctx,
+        joined_blas_limiter=joined_blas_limiter,
+        num_blas_cores_per_worker=num_blas_cores_per_worker,
+        _assigned=(provided_steps, selected_steps, exclusive_nuts),
+    )
+
+
+def _sample_with_step_methods(
+    *,
+    model,
+    step,
+    step_kwargs,
+    init,
+    n_init,
+    jitter_max_retries,
+    trace,
+    callback,
+    progressbar_theme,
+    return_inferencedata,
+    draws,
+    tune,
+    chains,
+    cores,
+    rngs,
+    random_seed_list,
+    initvals,
+    progressbar,
+    quiet,
+    discard_tuned_samples,
+    keep_warning_stat,
+    var_names,
+    idata_kwargs,
+    compute_convergence_checks,
+    compile_kwargs,
+    mp_ctx,
+    joined_blas_limiter,
+    num_blas_cores_per_worker,
+    _assigned=None,
+):
+    """Run the native step-method machinery (the engine behind plain ``pm.sample``).
+
+    Called by ``pm.sample`` on its internal path and by
+    :class:`~pymc.sampling.samplers.step.StepSampler.sample_from_init`, so the
+    two cannot drift apart. ``_assigned`` carries a precomputed
+    ``(provided_steps, selected_steps, exclusive_nuts)`` triple to avoid a
+    second step-assignment pass; when ``None`` it is computed here.
+    """
+    if quiet:
+        progressbar = False
+    progress_bool = bool(progressbar)
+
+    if _assigned is not None:
+        provided_steps, selected_steps, exclusive_nuts = _assigned
+    else:
+        provided_steps, selected_steps = assign_step_methods(model, step, methods=STEP_METHODS)
+        exclusive_nuts = (
+            not selected_steps and len(provided_steps) == 1 and isinstance(provided_steps[0], NUTS)
+        ) or (
+            not provided_steps
+            and len(selected_steps) == 1
+            and issubclass(next(iter(selected_steps)), NUTS)
+        )
+
     if exclusive_nuts and not provided_steps:
         # Special path for NUTS initialization
-        if "nuts" in kwargs:
-            nuts_kwargs = kwargs.pop("nuts")
-            [kwargs.setdefault(k, v) for k, v in nuts_kwargs.items()]
+        if "nuts" in step_kwargs:
+            nuts_kwargs = step_kwargs.pop("nuts")
+            [step_kwargs.setdefault(k, v) for k, v in nuts_kwargs.items()]
         with joined_blas_limiter():
             initial_points, step = init_nuts(
                 init=init,
@@ -1046,7 +1247,7 @@ def sample(
                 tune=tune,
                 initvals=initvals,
                 compile_kwargs=compile_kwargs,
-                **kwargs,
+                **step_kwargs,
             )
     else:
         # Get initial points
@@ -1063,7 +1264,7 @@ def sample(
             model,
             steps=provided_steps,
             selected_steps=selected_steps,
-            step_kwargs=kwargs,
+            step_kwargs=step_kwargs,
             initial_point=initial_points[0],
             compile_kwargs=compile_kwargs,
         )
@@ -1112,7 +1313,7 @@ def sample(
         "blas_cores": num_blas_cores_per_worker,
     }
 
-    sample_args.update(kwargs)
+    sample_args.update(step_kwargs)
 
     has_population_samplers = np.any(
         [

--- a/pymc/sampling/samplers/__init__.py
+++ b/pymc/sampling/samplers/__init__.py
@@ -1,0 +1,24 @@
+#   Copyright 2026 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Whole-model samplers that can be passed to ``pm.sample(sampler=...)``.
+
+Every sampler exposes two equivalent surfaces: a configured object for the
+``pm.sample`` funnel (``pm.sample(sampler=pm.nutpie.nuts(...))``) and a flat
+per-algorithm entry point (``pm.nutpie.nuts.sample(...)``).
+"""
+
+from pymc.sampling.samplers.base import ExternalSampler, Sampler, SamplerEntry
+from pymc.sampling.samplers.step import StepSampler
+
+__all__ = ["ExternalSampler", "Sampler", "SamplerEntry", "StepSampler"]

--- a/pymc/sampling/samplers/base.py
+++ b/pymc/sampling/samplers/base.py
@@ -1,0 +1,180 @@
+#   Copyright 2026 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import importlib.util
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from pymc.initial_point import StartDict
+from pymc.model.core import Model
+from pymc.util import RandomState
+from pymc.vartypes import discrete_types
+
+
+class Sampler(ABC):
+    """Base for everything ``pm.sample(sampler=...)`` accepts.
+
+    The constructor is algorithm configuration only: nothing model-bound,
+    nothing compiled. The model and the run configuration arrive at sample
+    time, through :meth:`sample_from_init`.
+
+    ``sample_from_init`` takes exactly the run-level arguments of
+    ``pm.sample`` (enforced by a test), so the funnel is sugar over the
+    sampler rather than a second code path. Everything else -- algorithm
+    parameters, initialization strategy, adaptation options and how the model
+    is compiled -- belongs to the subclass constructor and must not be routed
+    through ``pm.sample``.
+
+    Compilation options are deliberately *not* part of this base: what can be
+    configured differs per sampler, so each one names the options it actually
+    supports (``pm.nutpie.nuts(gradient_backend=...)``) instead of forwarding
+    an opaque ``compile_kwargs`` dict that only fails at compile time.
+    """
+
+    @abstractmethod
+    def sample_from_init(
+        self,
+        *,
+        model: Model | None = None,
+        draws: int = 1000,
+        tune: int | None = 1000,
+        chains: int | None = None,
+        cores: int | None = None,
+        blas_cores: int | None | str = "auto",
+        initvals: StartDict | Sequence[StartDict | None] | None = None,
+        random_seed: RandomState = None,
+        progressbar: bool = True,
+        quiet: bool = False,
+        discard_tuned_samples: bool = True,
+        keep_warning_stat: bool = False,
+        var_names: Sequence[str] | None = None,
+        idata_kwargs: dict[str, Any] | None = None,
+        compute_convergence_checks: bool = True,
+    ):
+        """Sample the model with this sampler's configuration.
+
+        Deliberately not named ``sample`` so it cannot be confused with the
+        flat per-algorithm entry points (e.g. ``pm.nutpie.nuts.sample``),
+        which combine algorithm and run arguments in a single call.
+
+        Every argument is run configuration that any sampler understands;
+        subclasses that cannot honor one must warn or raise rather than
+        silently ignore it.
+        """
+        # Deliberately no **kwargs: the run argument set is a closed
+        # contract. If `pm.sample` grows a new forwarded argument, every
+        # sampler must explicitly decide its disposition.
+
+
+class ExternalSampler(Sampler):
+    """Shared implementation logic for samplers backed by other libraries.
+
+    This is implementation inheritance, not interface: it adds nothing to the
+    :class:`Sampler` contract, only conveniences such as the dependency check.
+    """
+
+    package: str
+
+    def __init__(self):
+        require_installed(self.package)
+
+
+class SamplerEntry:
+    """Both user surfaces of one sampler in a single object.
+
+    Calling the entry configures a sampler for the ``pm.sample`` funnel::
+
+        pm.sample(sampler=pm.nutpie.nuts(target_accept=0.9))
+
+    Calling ``.sample`` is the flat entry point — algorithm and run arguments
+    in one call::
+
+        pm.nutpie.nuts.sample(model=model, target_accept=0.9, draws=1000)
+
+    The flat entry point is defined in terms of the first, so the two
+    surfaces cannot disagree.
+    """
+
+    def __init__(self, name: str, factory: Callable[..., Sampler], doc: str | None = None):
+        self._name = name
+        self._factory = factory
+        self.__doc__ = doc if doc is not None else factory.__doc__
+
+    def __repr__(self) -> str:
+        return f"<pymc.{self._name}>"
+
+    def __call__(self, **algorithm_kwargs) -> Sampler:
+        return self._factory(**algorithm_kwargs)
+
+    def sample(
+        self,
+        *,
+        model: Model | None = None,
+        draws: int = 1000,
+        tune: int | None = 1000,
+        chains: int | None = None,
+        cores: int | None = None,
+        blas_cores: int | None | str = "auto",
+        initvals: StartDict | Sequence[StartDict | None] | None = None,
+        random_seed: RandomState = None,
+        progressbar: bool = True,
+        quiet: bool = False,
+        discard_tuned_samples: bool = True,
+        keep_warning_stat: bool = False,
+        var_names: Sequence[str] | None = None,
+        idata_kwargs: dict[str, Any] | None = None,
+        compute_convergence_checks: bool = True,
+        **algorithm_kwargs,
+    ):
+        """Configure and run the sampler in one flat call.
+
+        Keyword arguments beyond the shared run configuration -- including
+        ``backend``/``compile_kwargs`` -- are passed to the sampler's
+        constructor.
+        """
+        return self(**algorithm_kwargs).sample_from_init(
+            model=model,
+            draws=draws,
+            tune=tune,
+            chains=chains,
+            cores=cores,
+            blas_cores=blas_cores,
+            initvals=initvals,
+            random_seed=random_seed,
+            progressbar=progressbar,
+            quiet=quiet,
+            discard_tuned_samples=discard_tuned_samples,
+            keep_warning_stat=keep_warning_stat,
+            var_names=var_names,
+            idata_kwargs=idata_kwargs,
+            compute_convergence_checks=compute_convergence_checks,
+        )
+
+
+def require_installed(package: str) -> None:
+    """Raise with an install hint if ``package`` is not importable."""
+    if importlib.util.find_spec(package) is None:
+        raise ImportError(
+            f"This sampler requires {package}. Install it with `pip install {package}`."
+        )
+
+
+def require_continuous_model(model: Model, *, sampler_name: str) -> None:
+    """Raise if the model has discrete free random variables."""
+    if any(var.dtype in discrete_types for var in model.free_RVs):
+        raise ValueError(
+            f"The {sampler_name} sampler can only sample models "
+            "where all free variables are continuous."
+        )

--- a/pymc/sampling/samplers/blackjax.py
+++ b/pymc/sampling/samplers/blackjax.py
@@ -1,0 +1,30 @@
+#   Copyright 2026 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Samplers backed by blackjax: ``pm.blackjax.nuts``.
+
+Support for the full blackjax algorithm family (mclmc, mala, ...) is added
+on top of this in a follow-up.
+"""
+
+from pymc.sampling.samplers.base import SamplerEntry
+from pymc.sampling.samplers.jax_nuts import BlackjaxNUTS
+
+__all__ = ["BlackjaxNUTS", "nuts"]
+
+nuts = SamplerEntry(
+    "blackjax.nuts",
+    BlackjaxNUTS,
+    doc="NUTS via blackjax: `pm.blackjax.nuts(**config)` configures a sampler for "
+    "`pm.sample(sampler=...)`; `pm.blackjax.nuts.sample(...)` draws in one flat call.",
+)

--- a/pymc/sampling/samplers/jax_nuts.py
+++ b/pymc/sampling/samplers/jax_nuts.py
@@ -1,0 +1,185 @@
+#   Copyright 2026 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""The numpyro and blackjax NUTS implementations as samplers."""
+
+import warnings
+
+from collections.abc import Sequence
+from typing import Any, Literal
+
+from pymc.initial_point import StartDict
+from pymc.model.core import modelcontext
+from pymc.sampling.mcmc import setup_cores_blas_cores
+from pymc.sampling.parallel import _initialize_multiprocessing_context
+from pymc.sampling.samplers.base import ExternalSampler, require_continuous_model
+from pymc.util import RandomState, get_random_generator
+
+__all__ = ["BlackjaxNUTS", "NumpyroNUTS"]
+
+
+class _JAXNUTS(ExternalSampler):
+    """Shared implementation of the jax-based external NUTS samplers.
+
+    Parameters
+    ----------
+    target_accept : float, default 0.8
+        Target acceptance rate for step size adaptation.
+    chain_method : "parallel" or "vectorized", default "parallel"
+        Whether chains run under ``jax.pmap`` or ``jax.vmap``.
+    postprocessing_backend : "cpu" or "gpu", optional
+        Where to compute the transformation of draws to the constrained space.
+    keep_untransformed : bool, default False
+        Include unconstrained values in the returned posterior.
+    jitter_initial_points : bool, default True
+        Add jitter to the initial points.
+    **nuts_kwargs
+        Passed to the underlying NUTS implementation.
+
+    Notes
+    -----
+    This sampler exposes no compilation options: the model is always compiled
+    with jax. Passing ``backend``/``compile_kwargs``/``mode`` raises rather
+    than being silently overridden.
+    """
+
+    nuts_sampler: Literal["numpyro", "blackjax"]
+
+    def __init__(
+        self,
+        *,
+        target_accept: float = 0.8,
+        chain_method: Literal["parallel", "vectorized"] = "parallel",
+        postprocessing_backend: Literal["cpu", "gpu"] | None = None,
+        keep_untransformed: bool = False,
+        jitter_initial_points: bool = True,
+        **nuts_kwargs,
+    ):
+        super().__init__()
+        # Would otherwise be swallowed by `nuts_kwargs` and forwarded to the
+        # underlying NUTS implementation, which knows nothing about them.
+        for name in ("backend", "compile_kwargs", "mode"):
+            if name in nuts_kwargs:
+                raise ValueError(
+                    f"`{name}` is not supported: the {type(self).__name__} sampler always "
+                    "compiles the model with the jax backend."
+                )
+        self.target_accept = target_accept
+        self.chain_method = chain_method
+        self.postprocessing_backend = postprocessing_backend
+        self.keep_untransformed = keep_untransformed
+        self.jitter_initial_points = jitter_initial_points
+        self.nuts_kwargs = nuts_kwargs
+
+    def sample_from_init(
+        self,
+        *,
+        model=None,
+        draws: int = 1000,
+        tune: int | None = 1000,
+        chains: int | None = None,
+        cores: int | None = None,
+        blas_cores: int | None | str = "auto",
+        initvals: StartDict | Sequence[StartDict | None] | None = None,
+        random_seed: RandomState = None,
+        progressbar: bool = True,
+        quiet: bool = False,
+        discard_tuned_samples: bool = True,
+        keep_warning_stat: bool = False,
+        var_names: Sequence[str] | None = None,
+        idata_kwargs: dict[str, Any] | None = None,
+        compute_convergence_checks: bool = True,
+    ):
+        """Run NUTS on ``model``.
+
+        Dispositions specific to this sampler:
+
+        - ``cores``: unused. Chain parallelism is governed by the available
+          jax devices and the ``chain_method`` constructor argument.
+        - ``blas_cores``: limits BLAS/OpenMP threads in this process, as it
+          did when reached through ``pm.sample``.
+        - ``discard_tuned_samples=False``: warns, warmup draws are discarded.
+        - ``keep_warning_stat=True``: warns, no ``warning`` stat is emitted.
+        """
+        model = modelcontext(model)
+        require_continuous_model(model, sampler_name=type(self).__name__)
+        if not discard_tuned_samples:
+            warnings.warn(
+                "`discard_tuned_samples=False` is ignored: warmup draws are discarded "
+                "to bound memory use.",
+                UserWarning,
+                stacklevel=2,
+            )
+        if keep_warning_stat:
+            warnings.warn(
+                "`keep_warning_stat` is ignored: no `warning` sampler stat is emitted.",
+                UserWarning,
+                stacklevel=2,
+            )
+        if chains is None:
+            chains = 4
+        if tune is None:
+            tune = 1000
+        if cores is None:
+            cores = chains
+
+        # Deferred: `pymc.sampling.jax` imports `jax`, an optional dependency.
+        from pymc.sampling.jax import sample_jax_nuts
+
+        # Sampling happens in this process, so the BLAS/OpenMP limit applies
+        # here, as it did when `pm.sample` wrapped the external samplers.
+        joined_blas_limiter, _, _ = setup_cores_blas_cores(
+            blas_cores,
+            chains,
+            cores,
+            _initialize_multiprocessing_context(None),
+        )
+
+        # Derive one master seed without reinterpreting array-like input as a
+        # per-chain seed list (which pm.sample accepts and documents).
+        seed = int(get_random_generator(random_seed).integers(2**30))
+        with joined_blas_limiter():
+            return sample_jax_nuts(
+                draws=draws,
+                tune=tune,
+                chains=chains,
+                target_accept=self.target_accept,
+                random_seed=seed,
+                initvals=initvals,
+                jitter=self.jitter_initial_points,
+                model=model,
+                var_names=var_names,
+                nuts_kwargs=dict(self.nuts_kwargs),
+                progressbar=bool(progressbar),
+                quiet=quiet,
+                keep_untransformed=self.keep_untransformed,
+                chain_method=self.chain_method,
+                postprocessing_backend=self.postprocessing_backend,
+                idata_kwargs=idata_kwargs,
+                compute_convergence_checks=compute_convergence_checks,
+                nuts_sampler=self.nuts_sampler,
+            )
+
+
+class NumpyroNUTS(_JAXNUTS):
+    """NUTS from numpyro. See ``_JAXNUTS`` for the parameters."""
+
+    package = "numpyro"
+    nuts_sampler = "numpyro"
+
+
+class BlackjaxNUTS(_JAXNUTS):
+    """NUTS from blackjax. See ``_JAXNUTS`` for the parameters."""
+
+    package = "blackjax"
+    nuts_sampler = "blackjax"

--- a/pymc/sampling/samplers/numpyro.py
+++ b/pymc/sampling/samplers/numpyro.py
@@ -1,0 +1,26 @@
+#   Copyright 2026 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Samplers backed by numpyro: ``pm.numpyro.nuts``."""
+
+from pymc.sampling.samplers.base import SamplerEntry
+from pymc.sampling.samplers.jax_nuts import NumpyroNUTS
+
+__all__ = ["NumpyroNUTS", "nuts"]
+
+nuts = SamplerEntry(
+    "numpyro.nuts",
+    NumpyroNUTS,
+    doc="NUTS via numpyro: `pm.numpyro.nuts(**config)` configures a sampler for "
+    "`pm.sample(sampler=...)`; `pm.numpyro.nuts.sample(...)` draws in one flat call.",
+)

--- a/pymc/sampling/samplers/nutpie.py
+++ b/pymc/sampling/samplers/nutpie.py
@@ -1,0 +1,159 @@
+#   Copyright 2026 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""The nutpie NUTS implementation as a sampler."""
+
+import warnings
+
+from collections.abc import Sequence
+from typing import Any, Literal
+
+from pymc.initial_point import StartDict
+from pymc.model.core import modelcontext
+from pymc.sampling.mcmc import _sample_external_nuts, setup_cores_blas_cores
+from pymc.sampling.parallel import _cpu_count, _initialize_multiprocessing_context
+from pymc.sampling.samplers.base import (
+    ExternalSampler,
+    SamplerEntry,
+    require_continuous_model,
+)
+from pymc.util import RandomState, get_random_generator
+
+__all__ = ["Nutpie", "nuts"]
+
+
+class Nutpie(ExternalSampler):
+    """NUTS from nutpie.
+
+    Parameters
+    ----------
+    backend : "numba" or "jax", optional
+        Backend nutpie compiles the model with. Defaults to "jax" if
+        PyTensor's configured mode uses the jax linker, "numba" otherwise.
+    gradient_backend : "pytensor" or "jax", optional
+        How nutpie computes the logp gradient. Defaults to nutpie's own
+        choice for ``backend``.
+    progressbar_theme : Theme, optional
+        Theme for the progress bar.
+    **nuts_kwargs
+        Passed to ``nutpie.sample`` (e.g. ``target_accept``,
+        ``max_treedepth``, ``store_unconstrained``).
+    """
+
+    package = "nutpie"
+
+    def __init__(
+        self,
+        *,
+        backend: Literal["numba", "jax"] | None = None,
+        gradient_backend: Literal["pytensor", "jax"] | None = None,
+        progressbar_theme=None,
+        **nuts_kwargs,
+    ):
+        super().__init__()
+        # Named rather than an opaque `compile_kwargs` dict, so the supported
+        # `nutpie.compile_pymc_model` options are discoverable from the
+        # signature. `None` means "leave it to the existing default" rather
+        # than forwarding it.
+        self.compile_kwargs = {
+            name: value
+            for name, value in (("backend", backend), ("gradient_backend", gradient_backend))
+            if value is not None
+        }
+        self.progressbar_theme = progressbar_theme
+        self.nuts_kwargs = nuts_kwargs
+
+    def sample_from_init(
+        self,
+        *,
+        model=None,
+        draws: int = 1000,
+        tune: int | None = 1000,
+        chains: int | None = None,
+        cores: int | None = None,
+        blas_cores: int | None | str = "auto",
+        initvals: StartDict | Sequence[StartDict | None] | None = None,
+        random_seed: RandomState = None,
+        progressbar: bool = True,
+        quiet: bool = False,
+        discard_tuned_samples: bool = True,
+        keep_warning_stat: bool = False,
+        var_names: Sequence[str] | None = None,
+        idata_kwargs: dict[str, Any] | None = None,
+        compute_convergence_checks: bool = True,
+    ):
+        """Run nutpie's NUTS on ``model``.
+
+        All run arguments are honored (``discard_tuned_samples=False`` stores
+        the warmup draws), except ``keep_warning_stat`` which warns: nutpie
+        does not emit PyMC's ``warning`` sampler stat.
+        """
+        model = modelcontext(model)
+        require_continuous_model(model, sampler_name="Nutpie")
+        if keep_warning_stat:
+            warnings.warn(
+                "`keep_warning_stat` is ignored: nutpie does not emit the `warning` sampler stat.",
+                UserWarning,
+                stacklevel=2,
+            )
+        if chains is None:
+            chains = 4
+        if cores is None:
+            # Matches `pm.sample`: at most 4, never more than the machine has,
+            # never more than there are chains to run.
+            cores = min(4, _cpu_count(), chains)
+        if tune is None:
+            tune = 1000
+
+        compile_kwargs = dict(self.compile_kwargs)
+        # nutpie samples in-process, so the BLAS/OpenMP limit applies to this
+        # process. `mp_ctx` only selects whether limiting is safe (see #7354),
+        # and nutpie never forks, so resolve it the same way `pm.sample` did.
+        joined_blas_limiter, cores, _ = setup_cores_blas_cores(
+            blas_cores,
+            chains,
+            cores,
+            _initialize_multiprocessing_context(None, mode=compile_kwargs.get("mode"), quiet=quiet),
+        )
+
+        # Derive one master seed without reinterpreting array-like input as a
+        # per-chain seed list (which pm.sample accepts and documents).
+        seed = int(get_random_generator(random_seed).integers(2**30))
+        with joined_blas_limiter():
+            return _sample_external_nuts(
+                sampler="nutpie",
+                draws=draws,
+                tune=tune,
+                chains=chains,
+                cores=cores,
+                random_seed=[seed],
+                initvals=initvals,
+                model=model,
+                var_names=var_names,
+                progressbar=False if quiet else progressbar,
+                progressbar_theme=self.progressbar_theme,
+                quiet=quiet,
+                compute_convergence_checks=compute_convergence_checks,
+                discard_tuned_samples=discard_tuned_samples,
+                nuts_kwargs=dict(self.nuts_kwargs),
+                compile_kwargs=compile_kwargs,
+                idata_kwargs=idata_kwargs,
+            )
+
+
+nuts = SamplerEntry(
+    "nutpie.nuts",
+    Nutpie,
+    doc="NUTS via nutpie: `pm.nutpie.nuts(**config)` configures a sampler for "
+    "`pm.sample(sampler=...)`; `pm.nutpie.nuts.sample(...)` draws in one flat call.",
+)

--- a/pymc/sampling/samplers/nutpie.py
+++ b/pymc/sampling/samplers/nutpie.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 """The nutpie NUTS implementation as a sampler."""
 
+import inspect
 import warnings
 
 from collections.abc import Sequence
@@ -45,9 +46,14 @@ class Nutpie(ExternalSampler):
         choice for ``backend``.
     progressbar_theme : Theme, optional
         Theme for the progress bar.
-    **nuts_kwargs
-        Passed to ``nutpie.sample`` (e.g. ``target_accept``,
-        ``max_treedepth``, ``store_unconstrained``).
+    **nutpie_kwargs
+        Any other nutpie argument, routed to the nutpie function that
+        declares it: ``nutpie.compile_pymc_model`` for compile-time options,
+        ``nutpie.sample`` for everything else (``target_accept``,
+        ``max_treedepth``, ``store_unconstrained``, ...). This is what makes
+        the deprecated ``pm.sample(nuts_sampler="nutpie",
+        compile_kwargs={...})`` spelling expressible here: every key becomes a
+        keyword argument.
     """
 
     package = "nutpie"
@@ -58,20 +64,59 @@ class Nutpie(ExternalSampler):
         backend: Literal["numba", "jax"] | None = None,
         gradient_backend: Literal["pytensor", "jax"] | None = None,
         progressbar_theme=None,
-        **nuts_kwargs,
+        **nutpie_kwargs,
     ):
         super().__init__()
-        # Named rather than an opaque `compile_kwargs` dict, so the supported
-        # `nutpie.compile_pymc_model` options are discoverable from the
-        # signature. `None` means "leave it to the existing default" rather
-        # than forwarding it.
+        # The two options users reach for are named, so they are discoverable
+        # from the signature. `None` means "leave it to the existing default"
+        # rather than forwarding it.
         self.compile_kwargs = {
             name: value
             for name, value in (("backend", backend), ("gradient_backend", gradient_backend))
             if value is not None
         }
+        # nutpie splits its API over two functions, so route the rest by
+        # asking which one declares each name. Without this, a compile-time
+        # option would silently reach `nutpie.sample`, and users migrating off
+        # `compile_kwargs={...}` would have no spelling for anything beyond
+        # the two named above.
+        compile_only = self._compile_only_parameters()
+        self.compile_kwargs.update(
+            {k: v for k, v in nutpie_kwargs.items() if k in compile_only},
+        )
+        self.nuts_kwargs = {k: v for k, v in nutpie_kwargs.items() if k not in compile_only}
         self.progressbar_theme = progressbar_theme
-        self.nuts_kwargs = nuts_kwargs
+
+    @staticmethod
+    def _compile_only_parameters() -> frozenset[str]:
+        """Names ``nutpie.compile_pymc_model`` accepts and ``nutpie.sample`` does not.
+
+        Read from nutpie itself rather than hardcoded, so the split keeps
+        working as nutpie's own signatures change. Names declared by both stay
+        with ``nutpie.sample``, and if either signature can't be introspected
+        nothing is rerouted -- both fall back to the previous behavior.
+        """
+        import nutpie
+
+        def parameters(func) -> set[str]:
+            try:
+                signature = inspect.signature(func)
+            except (TypeError, ValueError):
+                return set()
+            if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in signature.parameters.values()):
+                # A **kwargs catch-all tells us nothing about what is accepted.
+                return set()
+            return set(signature.parameters)
+
+        compile_parameters = parameters(nutpie.compile_pymc_model)
+        if not compile_parameters:
+            return frozenset()
+        # `model`/`var_names`/`initial_points` are supplied by pymc itself.
+        return frozenset(
+            compile_parameters
+            - parameters(nutpie.sample)
+            - {"model", "var_names", "initial_points"}
+        )
 
     def sample_from_init(
         self,

--- a/pymc/sampling/samplers/step.py
+++ b/pymc/sampling/samplers/step.py
@@ -1,0 +1,181 @@
+#   Copyright 2026 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+from collections.abc import Sequence
+from typing import Any
+
+from pymc.exceptions import SamplingError
+from pymc.initial_point import StartDict
+from pymc.model.core import modelcontext
+from pymc.pytensorf import resolve_backend_compile_kwargs
+from pymc.sampling.mcmc import _sample_with_step_methods, setup_cores_blas_cores
+from pymc.sampling.parallel import _cpu_count, _initialize_multiprocessing_context
+from pymc.sampling.samplers.base import Sampler
+from pymc.util import RandomState, get_random_generator
+
+__all__ = ["StepSampler"]
+
+
+class StepSampler(Sampler):
+    """PyMC's native step-method machinery as a sampler.
+
+    Wraps step assignment, ``CompoundStep`` and the python sampling loop —
+    the engine behind plain ``pm.sample()`` — in the shared
+    :class:`~pymc.sampling.samplers.base.Sampler` interface, so the internal
+    sampler is a regular sampler rather than a special case of ``pm.sample``.
+
+    Parameters
+    ----------
+    step : step method or iterable of step methods, optional
+        A step method or collection of step methods. Variables without a
+        step method are assigned automatically at sample time. By default
+        NUTS is used for all continuous variables.
+    init : str, default "auto"
+        NUTS initialization strategy (only used when NUTS is auto-assigned;
+        see :func:`pymc.init_nuts`).
+    n_init : int, default 200_000
+        Number of initialization iterations for ADVI-based ``init`` strategies.
+    jitter_max_retries : int, default 10
+        Maximum retries when jittered initial points have invalid logp.
+    trace : backend, optional
+        A backend instance (e.g. ``ZarrTrace``) to store the raw draws in.
+    callback : callable, optional
+        Called after every draw with the trace and draw.
+    progressbar_theme : Theme, optional
+        Theme for the progress bar.
+    mp_ctx : multiprocessing.context.BaseContext or str, optional
+        Multiprocessing context for parallel sampling.
+    backend : str, optional
+        Computational backend to compile the step methods with, e.g. "numba",
+        "c" or "jax". Shortcut for ``compile_kwargs={"mode": ...}``; passing
+        both raises.
+    compile_kwargs : dict, optional
+        Forwarded to :func:`pymc.compile` when building the step methods.
+        Unlike the external samplers, this really is a PyTensor
+        ``function`` passthrough, so it stays a dict.
+    **step_kwargs
+        Passed to the automatically assigned step methods; keys may be
+        lowercased step-method names holding a dict of arguments (e.g.
+        ``nuts={"target_accept": 0.9}``).
+    """
+
+    def __init__(
+        self,
+        step=None,
+        *,
+        init: str = "auto",
+        n_init: int = 200_000,
+        jitter_max_retries: int = 10,
+        trace=None,
+        callback=None,
+        progressbar_theme=None,
+        mp_ctx=None,
+        backend: str | None = None,
+        compile_kwargs: dict[str, Any] | None = None,
+        **step_kwargs,
+    ):
+        self.compile_kwargs = resolve_backend_compile_kwargs(backend, compile_kwargs)
+        if isinstance(trace, list):
+            raise ValueError("Please use the `var_names` run argument for partial traces.")
+        self.step = step
+        self.init = init
+        self.n_init = n_init
+        self.jitter_max_retries = jitter_max_retries
+        self.trace = trace
+        self.callback = callback
+        self.progressbar_theme = progressbar_theme
+        self.mp_ctx = mp_ctx
+        self.step_kwargs = step_kwargs
+
+    def sample_from_init(
+        self,
+        *,
+        model=None,
+        draws: int = 1000,
+        tune: int | None = 1000,
+        chains: int | None = None,
+        cores: int | None = None,
+        blas_cores: int | None | str = "auto",
+        initvals: StartDict | Sequence[StartDict | None] | None = None,
+        random_seed: RandomState = None,
+        progressbar: bool = True,
+        quiet: bool = False,
+        discard_tuned_samples: bool = True,
+        keep_warning_stat: bool = False,
+        var_names: Sequence[str] | None = None,
+        idata_kwargs: dict[str, Any] | None = None,
+        compute_convergence_checks: bool = True,
+    ):
+        """Run the native step-method machinery on ``model``.
+
+        All run arguments are honored; sampler-specific configuration
+        (``step``, NUTS initialization, trace backends, callbacks,
+        multiprocessing options, compilation) belongs to the constructor.
+        """
+        model = modelcontext(model)
+        if not model.free_RVs:
+            raise SamplingError(
+                "Cannot sample from the model, since the model does not contain any free variables."
+            )
+
+        if cores is None:
+            cores = min(4, _cpu_count())
+        if chains is None:
+            chains = max(2, cores)
+        if random_seed == -1:
+            raise ValueError(
+                "Setting random_seed = -1 is not allowed. Pass `None` to not specify a seed."
+            )
+        # tune=None is forwarded: the engine resolves it per step method
+        # via `get_default_tune_steps`.
+
+        compile_kwargs = dict(self.compile_kwargs)
+        mp_ctx = _initialize_multiprocessing_context(
+            self.mp_ctx, mode=compile_kwargs.get("mode"), quiet=quiet
+        )
+        joined_blas_limiter, cores, num_blas_cores_per_worker = setup_cores_blas_cores(
+            blas_cores, chains, cores, mp_ctx
+        )
+        rngs = get_random_generator(random_seed).spawn(chains)
+        random_seed_list = [rng.integers(2**30) for rng in rngs]
+
+        return _sample_with_step_methods(
+            model=model,
+            step=self.step,
+            step_kwargs=dict(self.step_kwargs),
+            init=self.init,
+            n_init=self.n_init,
+            jitter_max_retries=self.jitter_max_retries,
+            trace=self.trace,
+            callback=self.callback,
+            progressbar_theme=self.progressbar_theme,
+            return_inferencedata=True,
+            draws=draws,
+            tune=tune,
+            chains=chains,
+            cores=cores,
+            rngs=rngs,
+            random_seed_list=random_seed_list,
+            initvals=initvals,
+            progressbar=progressbar,
+            quiet=quiet,
+            discard_tuned_samples=discard_tuned_samples,
+            keep_warning_stat=keep_warning_stat,
+            var_names=var_names,
+            idata_kwargs=idata_kwargs,
+            compute_convergence_checks=compute_convergence_checks,
+            compile_kwargs=compile_kwargs,
+            mp_ctx=mp_ctx,
+            joined_blas_limiter=joined_blas_limiter,
+            num_blas_cores_per_worker=num_blas_cores_per_worker,
+        )

--- a/tests/distributions/test_custom.py
+++ b/tests/distributions/test_custom.py
@@ -50,7 +50,7 @@ from pymc.exceptions import BlockModelAccessError
 from pymc.logprob import conditional_logp, logcdf, logp
 from pymc.model import Deterministic, Model
 from pymc.pytensorf import collect_default_updates
-from pymc.sampling import draw, sample, sample_posterior_predictive
+from pymc.sampling import StepSampler, draw, sample, sample_posterior_predictive
 from pymc.step_methods import Metropolis
 from pymc.testing import assert_support_point_is_expected
 
@@ -153,7 +153,7 @@ class TestCustomDist:
                 warnings.filterwarnings("ignore", ".*number of samples.*", UserWarning)
                 # nutpie can't handle RNG in deterministics
                 # https://github.com/pymc-devs/nutpie/issues/4
-                sample(draws=5, tune=1, mp_ctx="spawn", nuts_sampler="pymc")
+                sample(draws=5, tune=1, sampler=StepSampler(mp_ctx="spawn"))
 
         cloudpickle.loads(cloudpickle.dumps(y))
         cloudpickle.loads(cloudpickle.dumps(y_dist))

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -43,6 +43,9 @@ pytestmark = pytest.mark.filterwarnings(
     "error",
     "ignore:There are not enough devices to run parallel chains:UserWarning",
     "ignore:os.fork\\(\\) was called:RuntimeWarning",
+    # This module exercises the deprecated nuts_sampler/init arguments on purpose
+    "ignore:The `nuts_sampler` argument is deprecated:DeprecationWarning",
+    "ignore:The NUTS-specific `init`:DeprecationWarning",
 )
 
 

--- a/tests/sampling/test_samplers.py
+++ b/tests/sampling/test_samplers.py
@@ -1,0 +1,355 @@
+#   Copyright 2026 - present The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import inspect
+import unittest.mock as mock
+
+import numpy as np
+import pytest
+
+import pymc as pm
+
+from pymc.sampling.samplers.base import Sampler, SamplerEntry
+from pymc.sampling.samplers.step import StepSampler
+
+
+@pytest.fixture(scope="module")
+def gaussian_model_data():
+    rng = np.random.default_rng(19)
+    return rng.normal(0.5, 1.2, size=200)
+
+
+def make_model(data):
+    with pm.Model(coords={"idx": range(3)}) as model:
+        mu = pm.Normal("mu")
+        sigma = pm.HalfNormal("sigma")
+        noise = pm.Normal("noise", dims="idx")
+        pm.Normal("y", mu + noise.mean(), sigma, observed=data)
+    return model
+
+
+RUN_KWARGS = {
+    "chains": 2,
+    "tune": 500,
+    "draws": 300,
+    "progressbar": False,
+    "random_seed": 42,
+    "compute_convergence_checks": False,
+}
+
+
+class TestStepSampler:
+    def test_funnel(self, gaussian_model_data):
+        model = make_model(gaussian_model_data)
+        with model:
+            idata = pm.sample(sampler=pm.StepSampler(nuts={"target_accept": 0.9}), **RUN_KWARGS)
+        np.testing.assert_allclose(idata.posterior["mu"].mean(), 0.5, atol=0.2)
+
+    def test_flat(self, gaussian_model_data):
+        model = make_model(gaussian_model_data)
+        idata = pm.StepSampler(init="adapt_diag").sample_from_init(model=model, **RUN_KWARGS)
+        np.testing.assert_allclose(idata.posterior["mu"].mean(), 0.5, atol=0.2)
+
+    def test_explicit_step(self, gaussian_model_data):
+        model = make_model(gaussian_model_data)
+        with model:
+            sampler = pm.StepSampler(step=pm.Metropolis())
+            idata = pm.sample(sampler=sampler, **RUN_KWARGS)
+        assert idata.posterior.sizes["draw"] == 300
+
+    def test_constructor_is_pure_configuration(self):
+        sampler = pm.StepSampler(init="adapt_diag")  # no model context needed
+        assert not hasattr(sampler, "model")
+
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    def test_matches_legacy_pm_sample(self, gaussian_model_data):
+        """The funnel and the legacy path run the same engine with the same seed."""
+        model = make_model(gaussian_model_data)
+        with model:
+            legacy = pm.sample(nuts_sampler="pymc", cores=1, **RUN_KWARGS)
+            via_sampler = pm.sample(cores=1, sampler=pm.StepSampler(), **RUN_KWARGS)
+        np.testing.assert_array_equal(
+            legacy.posterior["mu"].values, via_sampler.posterior["mu"].values
+        )
+
+
+@pytest.mark.parametrize("library", ["nutpie", "numpyro", "blackjax"])
+class TestExternalNUTSSamplers:
+    @staticmethod
+    def entry(library):
+        pytest.importorskip(library)
+        return getattr(pm, library).nuts
+
+    def test_flat_entry_point(self, gaussian_model_data, library):
+        model = make_model(gaussian_model_data)
+        extra = {} if library == "nutpie" else {"chain_method": "vectorized"}
+        idata = self.entry(library).sample(model=model, target_accept=0.9, **extra, **RUN_KWARGS)
+        np.testing.assert_allclose(idata.posterior["mu"].mean(), 0.5, atol=0.2)
+        assert idata.posterior.sizes == {"chain": 2, "draw": 300, "idx": 3}
+
+    def test_funnel(self, gaussian_model_data, library):
+        model = make_model(gaussian_model_data)
+        extra = {} if library == "nutpie" else {"chain_method": "vectorized"}
+        with model:
+            idata = pm.sample(sampler=self.entry(library)(**extra), **RUN_KWARGS)
+        np.testing.assert_allclose(idata.posterior["mu"].mean(), 0.5, atol=0.2)
+
+
+class TestSamplerFunnel:
+    """pm.sample(sampler=...) forwards run configuration and rejects the rest."""
+
+    def _capture_run_kwargs(self, **sample_kwargs):
+        with pm.Model():
+            pm.Normal("x", shape=3)
+            sampler = StepSampler()
+            with mock.patch.object(StepSampler, "sample_from_init", return_value=None) as recorded:
+                pm.sample(sampler=sampler, **sample_kwargs)
+        return recorded.call_args.kwargs
+
+    def test_run_configuration_forwarded(self):
+        kwargs = self._capture_run_kwargs(
+            draws=11, tune=22, discard_tuned_samples=False, blas_cores=2
+        )
+        assert kwargs["draws"] == 11
+        assert kwargs["tune"] == 22
+        assert kwargs["discard_tuned_samples"] is False
+        assert kwargs["blas_cores"] == 2
+        assert kwargs["model"] is not None
+        # compilation is constructor configuration, never forwarded
+        assert "compile_kwargs" not in kwargs
+
+    @pytest.mark.parametrize(
+        "argument, value",
+        [
+            ("init", "adapt_diag"),
+            ("n_init", 1000),
+            ("jitter_max_retries", 3),
+            ("mp_ctx", "spawn"),
+            ("progressbar_theme", "theme"),
+            ("backend", "numba"),
+            ("compile_kwargs", {"mode": "NUMBA"}),
+        ],
+    )
+    def test_constructor_arguments_rejected(self, argument, value):
+        """Arguments a sampler owns are rejected, not silently ignored."""
+        with pytest.raises(ValueError, match=f"`{argument}` is not supported with `sampler`"):
+            self._capture_run_kwargs(**{argument: value})
+
+    def test_clashes(self):
+        with pm.Model():
+            pm.Normal("x", shape=3)
+            sampler = StepSampler()
+
+            with pytest.raises(ValueError, match="`step` and `sampler`"):
+                pm.sample(sampler=sampler, step=pm.NUTS())
+            with pytest.raises(ValueError, match="`nuts_sampler` and `sampler`"):
+                pm.sample(sampler=sampler, nuts_sampler="pymc")
+            # rejected before `target_accept` is folded into `nuts={...}`, so the
+            # error names the argument that was actually passed
+            with pytest.raises(TypeError, match=r"\['target_accept'\]"):
+                pm.sample(sampler=sampler, target_accept=0.9)
+            # rejected before the `return_inferencedata=False` deprecation fires
+            with pytest.raises(ValueError, match="return_inferencedata=False"):
+                pm.sample(sampler=sampler, return_inferencedata=False)
+
+    def test_signatures_stay_in_sync(self):
+        """The shared run configuration cannot drift between the surfaces."""
+        run_params = dict(inspect.signature(Sampler.sample_from_init).parameters)
+        run_params.pop("self")
+        # every run parameter is a pm.sample parameter with the same name
+        pm_sample_params = inspect.signature(pm.sample).parameters
+        assert set(run_params) <= set(pm_sample_params)
+        # the concrete samplers implement exactly the shared contract
+        from pymc.sampling.samplers.jax_nuts import _JAXNUTS
+        from pymc.sampling.samplers.nutpie import Nutpie
+
+        for cls in (StepSampler, Nutpie, _JAXNUTS):
+            params = dict(inspect.signature(cls.sample_from_init).parameters)
+            params.pop("self")
+            assert set(params) == set(run_params), cls
+            assert all(p.kind is not inspect.Parameter.VAR_KEYWORD for p in params.values())
+        # the flat entry point is the run contract plus algorithm kwargs
+        entry_params = dict(inspect.signature(SamplerEntry.sample).parameters)
+        entry_params.pop("self")
+        var_keyword = [
+            name for name, p in entry_params.items() if p.kind is inspect.Parameter.VAR_KEYWORD
+        ]
+        assert var_keyword == ["algorithm_kwargs"]
+        # the flat entry is exactly the run contract plus constructor kwargs
+        assert set(entry_params) - {"algorithm_kwargs"} == set(run_params)
+        # compilation is constructor configuration, not part of the run contract
+        assert "compile_kwargs" not in run_params
+        assert "backend" not in run_params
+
+
+class TestDeprecations:
+    def test_nuts_sampler_deprecated(self, gaussian_model_data):
+        pytest.importorskip("numpyro")
+        model = make_model(gaussian_model_data)
+        with model:
+            with pytest.warns(DeprecationWarning, match="`nuts_sampler` argument is deprecated"):
+                pm.sample(
+                    nuts_sampler="numpyro",
+                    chains=1,
+                    tune=100,
+                    draws=50,
+                    progressbar=False,
+                    random_seed=1,
+                    compute_convergence_checks=False,
+                )
+
+    def test_nuts_init_arguments_deprecated(self, gaussian_model_data):
+        model = make_model(gaussian_model_data)
+        with model:
+            with pytest.warns(DeprecationWarning, match="will move to the sampler configuration"):
+                pm.sample(
+                    init="adapt_diag",
+                    chains=1,
+                    tune=50,
+                    draws=50,
+                    progressbar=False,
+                    random_seed=1,
+                    compute_convergence_checks=False,
+                )
+
+    def test_no_warning_by_default(self, gaussian_model_data):
+        import warnings as _warnings
+
+        model = make_model(gaussian_model_data)
+        with model:
+            with _warnings.catch_warnings():
+                _warnings.simplefilter("error", DeprecationWarning)
+                pm.sample(
+                    chains=1,
+                    tune=50,
+                    draws=50,
+                    progressbar=False,
+                    random_seed=1,
+                    compute_convergence_checks=False,
+                )
+
+
+class TestAPIEquivalenceRegressions:
+    """Replacements must accept what the deprecated pm.sample arguments accepted."""
+
+    def test_array_like_random_seed(self):
+        pytest.importorskip("numpyro")
+        with pm.Model() as model:
+            pm.Normal("x", shape=3)
+        captured = {}
+        with mock.patch(
+            "pymc.sampling.jax.sample_jax_nuts", side_effect=lambda **kw: captured.update(kw)
+        ):
+            pm.numpyro.nuts().sample_from_init(model=model, chains=2, random_seed=[1, 2])
+        assert isinstance(captured["random_seed"], int)
+
+        from pymc.sampling.samplers.nutpie import Nutpie
+
+        pytest.importorskip("nutpie")
+        captured.clear()
+        with mock.patch(
+            "pymc.sampling.samplers.nutpie._sample_external_nuts",
+            side_effect=lambda **kw: captured.update(kw),
+        ):
+            Nutpie().sample_from_init(model=model, chains=2, random_seed=[1, 2])
+        assert isinstance(captured["random_seed"][0], int)
+
+    def test_tune_none_reaches_step_defaults(self):
+        with pm.Model() as model:
+            pm.Normal("x", shape=3)
+        captured = {}
+        with mock.patch(
+            "pymc.sampling.samplers.step._sample_with_step_methods",
+            side_effect=lambda **kw: captured.update(kw),
+        ):
+            StepSampler().sample_from_init(model=model, tune=None)
+            assert captured["tune"] is None
+            with model:
+                pm.sample(sampler=StepSampler())  # pm.sample's tune default is None
+            assert captured["tune"] is None
+
+    def test_flat_entry_routes_backend_to_constructor(self):
+        pytest.importorskip("numpyro")
+        from pymc.sampling.samplers.jax_nuts import NumpyroNUTS
+
+        with pm.Model() as model:
+            pm.Normal("x", shape=3)
+        with mock.patch.object(NumpyroNUTS, "sample_from_init", return_value=None) as recorded:
+            pm.numpyro.nuts.sample(model=model, backend="jax", target_accept=0.9)
+        # `backend` configures the sampler, it is not a run argument
+        assert "backend" not in recorded.call_args.kwargs
+        assert "compile_kwargs" not in recorded.call_args.kwargs
+
+    def test_compile_kwargs_is_constructor_configuration(self):
+        sampler = pm.StepSampler(backend="numba")
+        assert "mode" in sampler.compile_kwargs
+        assert pm.StepSampler().compile_kwargs == {}
+        with pytest.raises(ValueError, match="Can only define one of"):
+            pm.StepSampler(backend="numba", compile_kwargs={"mode": "JAX"})
+
+    def test_nutpie_compile_options_are_explicit(self):
+        pytest.importorskip("nutpie")
+        from pymc.sampling.samplers.nutpie import Nutpie
+
+        # named arguments, not an opaque compile_kwargs dict
+        assert Nutpie().compile_kwargs == {}
+        assert Nutpie(gradient_backend="jax").compile_kwargs == {"gradient_backend": "jax"}
+        assert Nutpie(backend="numba", gradient_backend="pytensor").compile_kwargs == {
+            "backend": "numba",
+            "gradient_backend": "pytensor",
+        }
+
+        with pm.Model() as model:
+            pm.Normal("x", shape=3)
+        captured = {}
+        with mock.patch(
+            "pymc.sampling.samplers.nutpie._sample_external_nuts",
+            side_effect=lambda **kw: captured.update(kw),
+        ):
+            Nutpie(gradient_backend="jax").sample_from_init(model=model)
+        assert captured["compile_kwargs"] == {"gradient_backend": "jax"}
+
+    def test_jax_samplers_reject_compilation_options(self):
+        pytest.importorskip("numpyro")
+        for kwargs in ({"backend": "numba"}, {"compile_kwargs": {"mode": "JAX"}}, {"mode": "JAX"}):
+            with pytest.raises(ValueError, match="always compiles the model with the jax backend"):
+                pm.numpyro.nuts(**kwargs)
+
+    def test_nutpie_quiet_disables_progressbar(self):
+        pytest.importorskip("nutpie")
+        from pymc.sampling.samplers.nutpie import Nutpie
+
+        with pm.Model() as model:
+            pm.Normal("x", shape=3)
+        captured = {}
+        with mock.patch(
+            "pymc.sampling.samplers.nutpie._sample_external_nuts",
+            side_effect=lambda **kw: captured.update(kw),
+        ):
+            Nutpie().sample_from_init(model=model, quiet=True)
+        assert captured["progressbar"] is False
+
+
+class TestExternalSamplerDependencies:
+    def test_missing_package_raises_with_hint(self):
+        from pymc.sampling.samplers.base import ExternalSampler
+
+        class Fake(ExternalSampler):
+            package = "definitely_not_installed_xyz"
+
+            def sample_from_init(self, **kwargs):
+                pass
+
+        with pytest.raises(ImportError, match="pip install definitely_not_installed_xyz"):
+            Fake()

--- a/tests/sampling/test_samplers.py
+++ b/tests/sampling/test_samplers.py
@@ -13,6 +13,8 @@
 #   limitations under the License.
 
 import inspect
+import sys
+import types
 import unittest.mock as mock
 
 import numpy as np
@@ -37,6 +39,46 @@ def make_model(data):
         noise = pm.Normal("noise", dims="idx")
         pm.Normal("y", mu + noise.mean(), sigma, observed=data)
     return model
+
+
+@pytest.fixture
+def fake_nutpie(monkeypatch):
+    """Stand-in with nutpie's two-function shape, so routing is testable without it."""
+
+    def compile_pymc_model(
+        model,
+        *,
+        backend=None,
+        gradient_backend=None,
+        initial_points=None,
+        var_names=None,
+        freeze_model=None,
+    ): ...
+
+    def sample(
+        compiled,
+        *,
+        draws=1000,
+        tune=1000,
+        chains=4,
+        cores=None,
+        seed=None,
+        target_accept=0.8,
+        maxdepth=10,
+        save_warmup=True,
+        store_unconstrained=False,
+        progress_bar=True,
+        progress_callback=None,
+    ): ...
+
+    module = types.ModuleType("nutpie")
+    module.compile_pymc_model = compile_pymc_model
+    module.sample = sample
+    monkeypatch.setitem(sys.modules, "nutpie", module)
+    monkeypatch.setattr(
+        "pymc.sampling.samplers.base.require_installed", lambda package: None, raising=True
+    )
+    return module
 
 
 RUN_KWARGS = {
@@ -319,6 +361,27 @@ class TestAPIEquivalenceRegressions:
         ):
             Nutpie(gradient_backend="jax").sample_from_init(model=model)
         assert captured["compile_kwargs"] == {"gradient_backend": "jax"}
+
+    def test_nutpie_kwargs_reach_the_function_that_declares_them(self, fake_nutpie):
+        """Every `compile_kwargs={...}` key stays expressible as a keyword argument."""
+        from pymc.sampling.samplers.nutpie import Nutpie
+
+        assert Nutpie._compile_only_parameters() == {"backend", "gradient_backend", "freeze_model"}
+
+        sampler = Nutpie(
+            backend="numba", freeze_model=True, target_accept=0.9, store_unconstrained=True
+        )
+        assert sampler.compile_kwargs == {"backend": "numba", "freeze_model": True}
+        assert sampler.nuts_kwargs == {"target_accept": 0.9, "store_unconstrained": True}
+
+    def test_nutpie_routing_falls_back_when_signature_is_opaque(self, fake_nutpie):
+        """A `**kwargs` catch-all tells us nothing, so nothing is rerouted."""
+        from pymc.sampling.samplers.nutpie import Nutpie
+
+        fake_nutpie.compile_pymc_model = lambda model, **kwargs: None
+        assert Nutpie._compile_only_parameters() == frozenset()
+        # unchanged from the pre-routing behavior: everything goes to nutpie.sample
+        assert Nutpie(freeze_model=True).nuts_kwargs == {"freeze_model": True}
 
     def test_jax_samplers_reject_compilation_options(self):
         pytest.importorskip("numpyro")


### PR DESCRIPTION
## What

The refactor-only unit requested in [#8353 review](https://github.com/pymc-devs/pymc/pull/8353#issuecomment-4958847145 ): every existing way of sampling a model becomes a `Sampler` with two equivalent surfaces, **no new sampling capability is added**. The generic blackjax algorithm support in #8353 will be rebased on top of this once merged.

```python
# the funnel: constructor takes algorithm configuration, pm.sample takes run configuration
pm.sample(sampler=pm.nutpie.nuts(target_accept=0.9), draws=1000, chains=4)
pm.sample(sampler=pm.StepSampler(step=pm.Metropolis()))

# the flat entry points: algorithm and run arguments in one call
pm.nutpie.nuts.sample(model=m, target_accept=0.9, draws=1000)
pm.numpyro.nuts.sample(model=m, chain_method="vectorized")
pm.blackjax.nuts.sample(model=m)
```

## How

Following the class sketch from the #7880/#8353 discussion:

- **`Sampler` ABC** (`pymc/sampling/samplers/base.py`): constructors are algorithm configuration only — nothing model-bound, nothing compiled. The model and the shared run configuration arrive at sample time via `sample_from_init`, whose signature is exactly `pm.sample`'s run subset (kept in sync by a test, no `**kwargs` escape hatch). Deliberately not named `sample` so it can't be confused with the flat entry points.
- **`ExternalSampler`** is implementation inheritance only: a `package`/`version_range` dependency check with an install hint.
- **`SamplerEntry`** makes the two surfaces one implementation: `pm.nutpie.nuts(...)` returns a configured sampler for the funnel; `pm.nutpie.nuts.sample(...)` is the flat call, defined in terms of the first so they cannot disagree.
- **`StepSampler`**: the native machinery (step assignment, `CompoundStep`, the python loop) as a regular sampler. The engine was extracted verbatim from `pm.sample` into `_sample_with_step_methods` and is shared by both paths — a test asserts `pm.sample()` and `pm.sample(sampler=pm.StepSampler())` produce **identical draws**. NUTS initialization configuration (`init`, `n_init`, `jitter_max_retries`) lives on its constructor, which is also the first step toward fixing #5658.
- **`Nutpie`, `NumpyroNUTS`, `BlackjaxNUTS`** wrap the existing external NUTS implementations. Each documents an explicit disposition per run argument: nutpie *consumes* `compile_kwargs`/`backend` (numba/jax) and honors `discard_tuned_samples`; the jax pair *raises* on a non-jax compile mode instead of silently ignoring it, and warns on `discard_tuned_samples=False`/`keep_warning_stat`.

`pm.sample(sampler=...)` forwards only the run configuration and rejects the NUTS-specific arguments with pointers to their new homes.

## Deprecations (DeprecationWarning, not FutureWarning yet)

- `nuts_sampler=` → `pm.sample(sampler=pm.nutpie.nuts())` / `pm.numpyro.nuts()` / `pm.blackjax.nuts()` / `pm.StepSampler()`, or the flat entry points.
- Explicit `init`/`n_init`/`jitter_max_retries` → `pm.sample(sampler=pm.StepSampler(init=...))`.
- Untouched defaults stay silent (tested), so plain `pm.sample()` is unaffected.

The acceptance criteria from the discussion hold by construction: the internal NUTS is expressible as a regular sampler through the same interface with no special-casing in `pm.sample`, and every `nuts_sampler=` string value has a class equivalent, so the argument is removable at the end of the deprecation cycle.

## Also included

- `pyarrow<25` pin in the `alternative_backends` CI job — pyarrow 25.0.0 (unpinned transitive dependency of the `nutpie@main` install) segfaults XLA CPU compilation when loaded in the same process; without this pin the job fails on every PR (root-cause analysis in [#8353](https://github.com/pymc-devs/pymc/pull/8353#issuecomment-4939579832 )).

## Tests

`tests/sampling/test_samplers.py`: StepSampler via funnel/flat/explicit-step plus the identical-draws equivalence test, all three external NUTS samplers via both surfaces, funnel forwarding/rejections, the signature-sync test across all sampler classes, deprecation warnings (and their absence for defaults), and dependency-check errors. Full `tests/sampling/test_mcmc.py` passes unchanged (106 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
