### PR TITLE
Fix find_constants excluding discrete observed data from constant_data

### DIFF
--- a/pymc/backends/arviz.py
+++ b/pymc/backends/arviz.py
@@ -153,15 +153,21 @@ def find_observations(model: Model) -> dict[str, Var]:
 
 def find_constants(model: Model) -> dict[str, Var]:
     """If there are constants available, return them as a dictionary."""
-    model_vars = model.basic_RVs + model.deterministics + model.potentials
-    value_vars = set(model.rvs_to_values.values())
+    # Collect data_vars that feed into observed value variables.
+    # This handles both the direct case (value_var IS the data var, e.g. continuous
+    # distributions) and the indirect case (value_var wraps the data var through a
+    # Cast op, e.g. discrete distributions like Categorical or Poisson).
+    observed_data_vars = set()
+    for rv in model.observed_RVs:
+        value_var = model.rvs_to_values[rv]
+        for anc in ancestors([value_var]):
+            if anc in model.data_vars:
+                observed_data_vars.add(anc)
 
     constant_data = {}
     for var in model.data_vars:
-        if var in value_vars:
-            # An observed value variable could also be part of the generative graph
-            if var not in ancestors(model_vars):
-                continue
+        if var in observed_data_vars:
+            continue
 
         if isinstance(var, SharedVariable):
             var_value = var.get_value()

--- a/tests/backends/test_arviz.py
+++ b/tests/backends/test_arviz.py
@@ -480,7 +480,7 @@ class TestDataPyMC:
 
     @pytest.mark.parametrize("constant_in_generative_graph", [True, False])
     def test_observed_data_also_constant(self, constant_in_generative_graph):
-        """Test that wen the same variable is used as constant data and observed data, it shows up in both groups."""
+        """Test that observed data never leaks into constant_data, even when also used in the generative graph."""
         with pm.Model(coords={"trial": [0, 1, 2]}) as model:
             x = pm.Data("x", [1.0, 2.0, 3.0], dims=["trial"])
             sigma = pm.HalfNormal("sigma", 1)
@@ -494,11 +494,28 @@ class TestDataPyMC:
         test_dict = {
             "prior": ["sigma"],
             "observed_data": ["y"],
+            "~constant_data": [],
         }
-        if constant_in_generative_graph:
-            test_dict["constant_data"] = ["x"]
-        else:
-            test_dict["~constant_data"] = []
+        fails = check_multiple_attrs(test_dict, inference_data)
+        assert not fails
+
+    def test_discrete_observed_not_in_constant_data(self):
+        """Regression test for #7851: discrete observed data should not leak into constant_data."""
+        with pm.Model() as model:
+            y_obs = pm.Data("y_obs", [0, 1, 2])
+            beta = pm.Normal("beta", shape=3)
+            p = pm.math.softmax(beta)
+            pm.Categorical("y", p=p, observed=y_obs)
+
+            trace = pm.sample_prior_predictive(100, return_inferencedata=False)
+
+        inference_data = to_inference_data(prior=trace, model=model, log_likelihood=False)
+
+        test_dict = {
+            "prior": ["beta"],
+            "observed_data": ["y"],
+            "~constant_data": [],
+        }
         fails = check_multiple_attrs(test_dict, inference_data)
         assert not fails
 


### PR DESCRIPTION
Closes #7851

## Problem

When using discrete distributions (Categorical, Poisson, Binomial) with `pm.Data` as observed, the data variable incorrectly ends up in the `constant_data` group of InferenceData. It should only appear in `observed_data`.

```python
with pm.Model() as model:
    y_obs = pm.Data("y_obs", [0, 1, 2])
    beta = pm.Normal("beta", shape=3)
    p = pm.math.softmax(beta)
    pm.Categorical("y", p=p, observed=y_obs)

idata = pm.sample_prior_predictive()
# y_obs incorrectly shows up in idata.constant_data
```

## Cause

For discrete distributions, the observed value variable gets wrapped in a `Cast` op (e.g. `Cast{int64}(y_obs)`). The old code in `find_constants` checked `var in value_vars`, but `value_vars` contains the Cast output, not the original `pm.Data` variable. So the identity check fails and the data var slips through into `constant_data`.

For continuous distributions this worked fine because the value variable IS the data var directly (no Cast in between).

## Fix

Instead of checking if a data var is directly in `value_vars`, walk the ancestors of each observed RV's value variable and collect any `data_vars` found there. This catches the data var regardless of whether a Cast (or any other transform) sits between it and the value var.

## Tests

- Added `test_discrete_observed_not_in_constant_data` as a regression test for the reported bug
- Updated `test_observed_data_also_constant` to reflect that observed data should not appear in `constant_data` even when also used in the generative graph (per discussion in #7851)
- All 50 tests in `tests/backends/test_arviz.py` pass
