### PR TITLE
Fix bare except: replace with except Exception: in test fixtures

### DIFF
--- a/tests/backends/fixtures.py
+++ b/tests/backends/fixtures.py
@@ -450,7 +450,7 @@ class DumpLoadTestCase(ModelBackendSampledTestCase):
         try:
             with cls.model:
                 cls.dumped = cls.load_func(cls.name)
-        except:
+        except Exception:
             remove_file_or_directory(cls.name)
             raise
 


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in `tests/backends/fixtures.py`.

The bare `except:` clause guards `cls.load_func(cls.name)` during test setup. Using `except Exception:` is more precise — it still catches all normal errors while allowing `SystemExit` and `KeyboardInterrupt` to propagate as intended.