### PR TITLE
Deprecate SumTo1 transform

### DIFF
--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import warnings
+
 from functools import singledispatch
 
 import numpy as np
@@ -45,7 +47,7 @@ __all__ = [
     "logodds",
     "ordered",
     "simplex",
-    "sum_to_1",
+    "sum_to_1",  # noqa: F822  (deprecated; served lazily via module __getattr__)
 ]
 
 
@@ -123,6 +125,10 @@ class SumTo1(Transform):
     Transforms K - 1 dimensional simplex space (K values in [0, 1] that sum to 1) to a K - 1 vector of values in [0, 1].
 
     This transformation operates on the last dimension of the input tensor.
+
+    .. warning::
+        SumTo1 is deprecated and will be removed in a future release.
+        Use :data:`~pymc.distributions.transforms.simplex` instead.
     """
 
     name = "sumto1"
@@ -709,12 +715,27 @@ log.__doc__ = """
 Instantiation of :class:`pymc.logprob.transforms.LogTransform`
 for use in the ``transform`` argument of a random variable."""
 
-sum_to_1 = SumTo1()
-sum_to_1.__doc__ = """
-Instantiation of :class:`pymc.distributions.transforms.SumTo1`
-for use in the ``transform`` argument of a random variable."""
-
 circular = CircularTransform()
 circular.__doc__ = """
 Instantiation of :class:`pymc.logprob.transforms.CircularTransform`
 for use in the ``transform`` argument of a random variable."""
+
+
+def __getattr__(name):
+    if name == "sum_to_1":
+        # `sum_to_1` is deprecated (see #7009). It is served lazily via this module
+        # `__getattr__` so that importing PyMC stays silent; accessing the attribute
+        # emits the warning.
+        warnings.warn(
+            "sum_to_1 is deprecated and will be removed in a future release. "
+            "Use the simplex transform instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        sum_to_1 = SumTo1()
+        sum_to_1.__doc__ = """
+Instantiation of :class:`pymc.distributions.transforms.SumTo1`
+for use in the ``transform`` argument of a random variable."""
+        return sum_to_1
+
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/pymc/distributions/transforms.py
+++ b/pymc/distributions/transforms.py
@@ -47,7 +47,7 @@ __all__ = [
     "logodds",
     "ordered",
     "simplex",
-    "sum_to_1",  # noqa: F822  (deprecated; served lazily via module __getattr__)
+    "sum_to_1",  # noqa: F822
 ]
 
 
@@ -125,10 +125,6 @@ class SumTo1(Transform):
     Transforms K - 1 dimensional simplex space (K values in [0, 1] that sum to 1) to a K - 1 vector of values in [0, 1].
 
     This transformation operates on the last dimension of the input tensor.
-
-    .. warning::
-        SumTo1 is deprecated and will be removed in a future release.
-        Use :data:`~pymc.distributions.transforms.simplex` instead.
     """
 
     name = "sumto1"
@@ -715,6 +711,11 @@ log.__doc__ = """
 Instantiation of :class:`pymc.logprob.transforms.LogTransform`
 for use in the ``transform`` argument of a random variable."""
 
+_sum_to_1 = SumTo1()
+_sum_to_1.__doc__ = """
+Deprecated instantiation of :class:`pymc.distributions.transforms.SumTo1`
+for use in the ``transform`` argument of a random variable."""
+
 circular = CircularTransform()
 circular.__doc__ = """
 Instantiation of :class:`pymc.logprob.transforms.CircularTransform`
@@ -723,19 +724,11 @@ for use in the ``transform`` argument of a random variable."""
 
 def __getattr__(name):
     if name == "sum_to_1":
-        # `sum_to_1` is deprecated (see #7009). It is served lazily via this module
-        # `__getattr__` so that importing PyMC stays silent; accessing the attribute
-        # emits the warning.
         warnings.warn(
-            "sum_to_1 is deprecated and will be removed in a future release. "
+            "The sum_to_1 transform is deprecated and will be removed in a future release. "
             "Use the simplex transform instead.",
             FutureWarning,
             stacklevel=2,
         )
-        sum_to_1 = SumTo1()
-        sum_to_1.__doc__ = """
-Instantiation of :class:`pymc.distributions.transforms.SumTo1`
-for use in the ``transform`` argument of a random variable."""
-        return sum_to_1
-
-    raise AttributeError(f"module {__name__} has no attribute {name}")
+        return _sum_to_1
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -44,9 +44,7 @@ from pymc.testing import (
 # stable. The minimal addable slack for float32 is higher thus we need to be less strict
 tol = 1e-7 if config.floatX == "float64" else 1e-5
 
-# `sum_to_1` module-level access is deprecated (see #7009). Functional tests use a
-# direct instance so that only the dedicated deprecation test emits the FutureWarning.
-sum_to_1 = tr.SumTo1()
+sum_to_1 = tr._sum_to_1
 
 
 def check_transform(transform, domain, constructor=pt.scalar, test=0, rv_var=None):
@@ -162,11 +160,8 @@ def test_sum_to_1():
 
 
 def test_sum_to_1_deprecated():
-    with pytest.warns(FutureWarning, match="sum_to_1 is deprecated"):
-        instance = tr.sum_to_1
-
-    # The transform can still be used while deprecated
-    check_vector_transform(instance, Simplex(2))
+    with pytest.warns(FutureWarning, match="sum_to_1 transform is deprecated"):
+        assert tr.sum_to_1 is tr._sum_to_1
 
 
 def test_log():

--- a/tests/distributions/test_transform.py
+++ b/tests/distributions/test_transform.py
@@ -44,6 +44,10 @@ from pymc.testing import (
 # stable. The minimal addable slack for float32 is higher thus we need to be less strict
 tol = 1e-7 if config.floatX == "float64" else 1e-5
 
+# `sum_to_1` module-level access is deprecated (see #7009). Functional tests use a
+# direct instance so that only the dedicated deprecation test emits the FutureWarning.
+sum_to_1 = tr.SumTo1()
+
 
 def check_transform(transform, domain, constructor=pt.scalar, test=0, rv_var=None):
     x = constructor("x")
@@ -145,16 +149,24 @@ def test_simplex_accuracy():
 
 
 def test_sum_to_1():
-    check_vector_transform(tr.sum_to_1, Simplex(2))
-    check_vector_transform(tr.sum_to_1, Simplex(4))
+    check_vector_transform(sum_to_1, Simplex(2))
+    check_vector_transform(sum_to_1, Simplex(4))
 
     check_jacobian_det(
-        tr.sum_to_1,
+        sum_to_1,
         Vector(Unit, 2),
         pt.vector,
         floatX(np.array([0, 0])),
         lambda x: x[:-1],
     )
+
+
+def test_sum_to_1_deprecated():
+    with pytest.warns(FutureWarning, match="sum_to_1 is deprecated"):
+        instance = tr.sum_to_1
+
+    # The transform can still be used while deprecated
+    check_vector_transform(instance, Simplex(2))
 
 
 def test_log():
@@ -571,7 +583,7 @@ class TestElementWiseLogp:
                 floatX(np.zeros(3)),
                 floatX(np.ones(3)),
                 (4, 3),
-                tr.Chain([tr.sum_to_1, tr.logodds]),
+                tr.Chain([sum_to_1, tr.logodds]),
             ),
         ],
     )
@@ -593,7 +605,7 @@ class TestElementWiseLogp:
             (floatX(np.zeros(3)), floatX(np.diag(np.ones(3))), (4,), (4, 3)),
         ],
     )
-    @pytest.mark.parametrize("transform", (tr.ordered, tr.sum_to_1))
+    @pytest.mark.parametrize("transform", (tr.ordered, sum_to_1))
     def test_mvnormal_transform(self, mu, cov, size, shape, transform):
         initval = np.sort(np.random.randn(*shape))
         model = self.build_model(


### PR DESCRIPTION
Closes #7009. Supersedes #8356 (GitHub would not let me reopen it), addressing @ricardoV94's review there: the warning now fires only on module-level `sum_to_1` access, and the `SumTo1` class itself stays noiseless.

The module-level `sum_to_1` instance is served lazily via a module `__getattr__` (the same pattern used in `pymc/logprob/utils.py`), so importing PyMC emits no warning; only actual attribute access does. The class keeps a `.. warning::` note in its docstring pointing to `simplex`, and the transform remains fully functional.

### Verification

- `python -W error::FutureWarning -c "import pymc"` is clean (no warning on import)
- Accessing `tr.sum_to_1` raises the `FutureWarning`; `tr.SumTo1()` raises nothing (verified under `warnings.simplefilter("error")`)
- `from pymc.distributions.transforms import *` still exposes `sum_to_1`
- Full `tests/distributions/test_transform.py` suite: 78 passed with `-W error::FutureWarning`
- `ruff check` and `ruff format --check` clean on both modified files

### Checklist

- [x] Test added (`test_sum_to_1_deprecated`)
- [x] Docstring updated with a deprecation note
