### PR TITLE
Thread sampler arguments through to numpyro/blackjax via `nuts` dict

### DIFF
--- a/pymc/sampling/mcmc.py
+++ b/pymc/sampling/mcmc.py
@@ -506,13 +506,27 @@ def _sample_external_nuts(
         import pymc.sampling.jax as pymc_jax
 
         jax_nuts_kwargs = dict(nuts_kwargs)
-        jax_target_accept = jax_nuts_kwargs.pop("target_accept", 0.8)
+        # `sample_jax_nuts` exposes several sampler-driver options as top-level
+        # arguments rather than NUTS-kernel kwargs. Lift any passed via `nuts`
+        # so they reach the sampler; the rest stay in `jax_nuts_kwargs` and are
+        # forwarded to the kernel. Unlifted options use `sample_jax_nuts`'s defaults.
+        jax_top_level_params = (
+            "target_accept",
+            "jitter",
+            "keep_untransformed",
+            "chain_method",
+            "postprocessing_backend",
+            "postprocessing_vectorize",
+            "postprocessing_chunks",
+        )
+        jax_top_level_kwargs = {
+            key: jax_nuts_kwargs.pop(key) for key in jax_top_level_params if key in jax_nuts_kwargs
+        }
         # Don't forward tune=None: let `sample_jax_nuts`'s own default kick in.
         tune_kwarg = {"tune": tune} if tune is not None else {}
         idata = pymc_jax.sample_jax_nuts(
             draws=draws,
             chains=chains,
-            target_accept=jax_target_accept,
             # jax samplers take a single master seed; `random_seed` here is the
             # per-chain list produced by `pm.sample`, so use the first entry.
             random_seed=int(random_seed[0]),
@@ -525,6 +539,7 @@ def _sample_external_nuts(
             nuts_kwargs=jax_nuts_kwargs,
             idata_kwargs=idata_kwargs,
             compute_convergence_checks=compute_convergence_checks,
+            **jax_top_level_kwargs,
             **tune_kwarg,
         )
         return idata

--- a/tests/sampling/test_mcmc_external.py
+++ b/tests/sampling/test_mcmc_external.py
@@ -101,6 +101,28 @@ def test_step_args():
     npt.assert_almost_equal(idata.sample_stats.acceptance_rate.mean(), 0.5, decimal=1)
 
 
+def test_jax_sampler_kwargs_routing():
+    pytest.importorskip("numpyro")
+
+    # `chain_method` and `max_tree_depth` share the single `nuts` dict but belong to
+    # different layers: the former is a `sample_jax_nuts` argument, the latter a
+    # NUTS-kernel one. Their effects are not observable in the returned trace, so the
+    # dispatch is checked at the call `_sample_external_nuts` makes to the sampler.
+    with mock.patch("pymc.sampling.jax.sample_jax_nuts") as mock_sampler:
+        with Model():
+            Normal("a")
+            sample(
+                nuts_sampler="numpyro",
+                nuts={"chain_method": "vectorized", "max_tree_depth": 7},
+                random_seed=1411,
+                progressbar=False,
+            )
+
+    call_kwargs = mock_sampler.call_args.kwargs
+    assert call_kwargs["chain_method"] == "vectorized"
+    assert call_kwargs["nuts_kwargs"] == {"max_tree_depth": 7}
+
+
 @pytest.mark.parametrize("nuts_sampler", ["pymc", "nutpie", "blackjax", "numpyro"])
 def test_sample_var_names(nuts_sampler):
     if nuts_sampler != "pymc":


### PR DESCRIPTION
When we cut the API over to `nuts` from `nuts_sampler_kwargs`, we stopped correctly threading sampler arguments like `chain_method` through. This patch enumerates such sampler arguments, splits them from the NUTS kernel arguments that we do correctly thread, and passes them to the correct place.