### PR TITLE
`compute_deterministics` accepts datatree and allows extending inplace

### DIFF
--- a/pymc/sampling/deterministic.py
+++ b/pymc/sampling/deterministic.py
@@ -11,6 +11,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import warnings
+
 from collections.abc import Sequence
 
 from xarray import Dataset, DataTree, merge
@@ -20,23 +22,59 @@ from pymc.model.core import BaseModel, modelcontext
 from pymc.pytensorf import resolve_backend_compile_kwargs
 
 
+def _select_group(dataset: Dataset | DataTree, group: str | None) -> Dataset | DataTree:
+    """Select the relevant group when a whole InferenceData object is passed."""
+    if not (isinstance(dataset, DataTree) and dataset.children):
+        if group is not None:
+            raise ValueError(
+                "The `group` argument can only be used when passing a whole InferenceData object, "
+                "not a single group."
+            )
+        return dataset
+
+    if group is None:
+        for default_group in ("posterior", "prior"):
+            if default_group in dataset.children:
+                group = default_group
+                break
+        else:
+            raise ValueError(
+                "InferenceData has neither a `posterior` nor a `prior` group. "
+                f"Pass `group` explicitly, one of: {sorted(dataset.children)}"
+            )
+    elif group not in dataset.children:
+        raise ValueError(
+            f"InferenceData has no group {group!r}. Available groups: {sorted(dataset.children)}"
+        )
+
+    return dataset.children[group]
+
+
 def compute_deterministics(
-    dataset: Dataset,
+    dataset: Dataset | DataTree,
     *,
+    group: str | None = None,
     var_names: Sequence[str] | None = None,
     model: BaseModel | None = None,
     sample_dims: Sequence[str] = ("chain", "draw"),
     merge_dataset: bool = False,
+    extend_dataset: bool = False,
     progressbar: bool = True,
     backend: str | None = None,
     compile_kwargs: dict | None = None,
-) -> Dataset:
+) -> Dataset | DataTree:
     """Compute model deterministics given a dataset with values for model variables.
 
     Parameters
     ----------
-    dataset : Dataset
-        Dataset with values for model variables. Commonly DataTree["posterior"].
+    dataset : Dataset or DataTree
+        Dataset with values for model variables, such as ``idata.posterior``.
+        A whole InferenceData object can also be passed, in which case the group
+        given by ``group`` is used.
+    group : str, optional
+        Which group to use when ``dataset`` is a whole InferenceData object.
+        If None, "posterior" is used, falling back to "prior" when there is no
+        posterior group. Cannot be used when a single group is passed directly.
     var_names : sequence of str, optional
         List of names of deterministic variable to compute.
         If None, compute all deterministics in the model.
@@ -45,7 +83,16 @@ def compute_deterministics(
     sample_dims : sequence of str, default ("chain", "draw")
         Sample (batch) dimensions of the dataset over which to compute the deterministics.
     merge_dataset : bool, default False
-        Whether to extend the original dataset or return a new one.
+        Whether to include the values of the original dataset in the returned one.
+
+        .. deprecated::
+            ``merge_dataset`` is deprecated and will be removed in a future release.
+            Use ``extend_dataset`` instead.
+    extend_dataset : bool, default False
+        Whether to add the deterministics to the original dataset in place, instead of
+        returning a new one. The mutated input object is returned, so for an InferenceData
+        the deterministics end up in the selected group.
+        Cannot be combined with ``merge_dataset``.
     progressbar : bool, default True
         Whether to display a progress bar in the command line.
     progressbar_theme : Theme, optional
@@ -58,8 +105,11 @@ def compute_deterministics(
 
     Returns
     -------
-    Dataset
-        Dataset with values for the deterministics.
+    Dataset or DataTree
+        Dataset with values for the deterministics. When ``merge_dataset`` is True,
+        the values of the input dataset (or of the selected group) are included as well.
+        When ``extend_dataset`` is True, the input object is returned instead, with the
+        deterministics added to it.
 
 
     Examples
@@ -72,17 +122,34 @@ def compute_deterministics(
             mu_raw = pm.Normal("mu_raw", 0, 1, dims="group")
             mu = pm.Deterministic("mu", mu_raw.cumsum(), dims="group")
 
-            trace = pm.sample(var_names=["mu_raw"], chains=2, tune=5 draws=5)
+            trace = pm.sample(var_names=["mu_raw"], chains=2, tune=5, draws=5)
 
         assert "mu" not in trace.posterior
 
         with m:
-            trace.posterior = pm.compute_deterministics(trace.posterior, merge_dataset=True)
+            pm.compute_deterministics(trace, extend_dataset=True)
 
         assert "mu" in trace.posterior
 
 
     """
+    if merge_dataset and extend_dataset:
+        raise ValueError(
+            "`merge_dataset` and `extend_dataset` cannot be combined. "
+            "`extend_dataset` already keeps the values of the original dataset."
+        )
+
+    if merge_dataset:
+        warnings.warn(
+            "`merge_dataset` is deprecated and will be removed in a future release. "
+            "Use `extend_dataset=True` to add the deterministics to the original dataset, "
+            "passing a `.copy()` of it if it should not be mutated.",
+            FutureWarning,
+        )
+
+    original_object = dataset
+    dataset = _select_group(dataset, group)
+
     model = modelcontext(model)
 
     if var_names is None:
@@ -102,13 +169,11 @@ def compute_deterministics(
 
     coords, dims = coords_and_dims_for_inferencedata(model)
 
-    is_datatree = isinstance(dataset, DataTree)
-    input_dataset = dataset.dataset if is_datatree else dataset
-    input_dataset = input_dataset[[rv.name for rv in model.free_RVs]]
+    group_dataset: Dataset = dataset.dataset if isinstance(dataset, DataTree) else dataset
 
     new_dataset = apply_function_over_dataset(
         fn,
-        input_dataset,
+        group_dataset[[rv.name for rv in model.free_RVs]],
         output_var_names=var_names,
         dims=dims,
         coords=coords,
@@ -116,8 +181,11 @@ def compute_deterministics(
         progressbar=progressbar,
     )
 
+    if extend_dataset:
+        dataset.update(new_dataset)
+        return original_object
+
     if merge_dataset:
-        original_dataset = dataset.to_dataset() if is_datatree else dataset
-        new_dataset = merge([original_dataset, new_dataset], compat="override")
+        new_dataset = merge([group_dataset, new_dataset], compat="override")
 
     return new_dataset

--- a/tests/sampling/test_deterministic.py
+++ b/tests/sampling/test_deterministic.py
@@ -15,6 +15,7 @@ import numpy as np
 import pytest
 
 from numpy.testing import assert_allclose
+from xarray import DataTree
 
 from pymc.distributions import Normal
 from pymc.model.core import Deterministic, Model
@@ -53,14 +54,15 @@ def test_compute_deterministics(via):
         if via == "compile_kwargs"
         else {"backend": "FAST_COMPILE"}
     )
-    extended_with_mu = compute_deterministics(
-        dataset,
-        var_names=["mu"],
-        merge_dataset=True,
-        model=m,
-        progressbar=False,
-        **mode_kwargs,
-    )
+    with pytest.warns(FutureWarning, match="`merge_dataset` is deprecated"):
+        extended_with_mu = compute_deterministics(
+            dataset,
+            var_names=["mu"],
+            merge_dataset=True,
+            model=m,
+            progressbar=False,
+            **mode_kwargs,
+        )
     assert set(extended_with_mu.data_vars.variables) == {"mu_raw", "sigma_raw", "mu"}
     assert extended_with_mu["mu"].dims == ("chain", "draw", "group")
     assert_allclose(extended_with_mu["mu"], dataset["mu_raw"].cumsum("group"))
@@ -69,6 +71,68 @@ def test_compute_deterministics(via):
     assert set(only_sigma.data_vars.variables) == {"sigma"}
     assert only_sigma["sigma"].dims == ("chain", "draw")
     assert_allclose(only_sigma["sigma"], np.exp(dataset["sigma_raw"]))
+
+
+def test_compute_deterministics_extend_dataset():
+    with Model() as m:
+        mu_raw = Normal("mu_raw")
+        mu = Deterministic("mu", mu_raw.exp())
+
+    idata = sample_prior_predictive(draws=5, model=m, var_names=["mu_raw"], random_seed=22)
+
+    dataset = idata.prior.to_dataset()
+    extended = compute_deterministics(dataset, extend_dataset=True, model=m, progressbar=False)
+    assert extended is dataset
+    assert set(dataset.data_vars) == {"mu_raw", "mu"}
+    assert_allclose(dataset["mu"], np.exp(dataset["mu_raw"]))
+
+    # Extending an InferenceData mutates the selected group in place
+    extended = compute_deterministics(idata, extend_dataset=True, model=m, progressbar=False)
+    assert extended is idata
+    assert set(idata.prior.data_vars) == {"mu_raw", "mu"}
+    assert_allclose(idata.prior["mu"], np.exp(idata.prior["mu_raw"]))
+
+    with pytest.raises(ValueError, match="cannot be combined"):
+        compute_deterministics(
+            idata, merge_dataset=True, extend_dataset=True, model=m, progressbar=False
+        )
+
+
+def test_compute_deterministics_from_inferencedata():
+    with Model() as m:
+        mu_raw = Normal("mu_raw")
+        mu = Deterministic("mu", mu_raw.exp())
+
+    idata = sample_prior_predictive(draws=5, model=m, var_names=["mu_raw"], random_seed=22)
+    assert "prior" in idata.children and "posterior" not in idata.children
+
+    # No posterior group, so the prior is used by default
+    with m:
+        from_prior = compute_deterministics(idata, progressbar=False)
+    assert_allclose(from_prior["mu"], np.exp(idata.prior["mu_raw"]))
+
+    # Explicit group
+    with m:
+        assert_allclose(
+            compute_deterministics(idata, group="prior", progressbar=False)["mu"],
+            from_prior["mu"],
+        )
+
+    # Posterior takes precedence over prior
+    idata["posterior"] = idata.prior.dataset * 2
+    with m:
+        from_posterior = compute_deterministics(idata, progressbar=False)
+    assert_allclose(from_posterior["mu"], np.exp(idata.posterior["mu_raw"]))
+
+    with m, pytest.raises(ValueError, match="InferenceData has no group 'predictions'"):
+        compute_deterministics(idata, group="predictions", progressbar=False)
+
+    groupless = DataTree.from_dict({"predictions": idata.prior.dataset})
+    with m, pytest.raises(ValueError, match="neither a `posterior` nor a `prior` group"):
+        compute_deterministics(groupless, progressbar=False)
+
+    with m, pytest.raises(ValueError, match="`group` argument can only be used"):
+        compute_deterministics(idata.prior, group="prior", progressbar=False)
 
 
 def test_docstring_example():
@@ -83,6 +147,6 @@ def test_docstring_example():
     assert "mu" not in trace.posterior
 
     with m:
-        trace.posterior = pm.compute_deterministics(trace.posterior, merge_dataset=True)
+        pm.compute_deterministics(trace, extend_dataset=True)
 
     assert "mu" in trace.posterior


### PR DESCRIPTION
Slightly better UX? Deprecates merge_dataset kwarg